### PR TITLE
Guard against NPE

### DIFF
--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolImpl.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolImpl.java
@@ -303,17 +303,20 @@ public class ConnectionPoolImpl<CL> implements ConnectionPool<CL> {
 				
 				retry.failure(e);
 				lastException = e;
-				
-				cpMonitor.incOperationFailure(connection != null ? connection.getHost() : null, e);
-				if (retry.allowRetry()) {
-					cpMonitor.incFailover(connection.getHost(), e);
-				}
-				
-				// Track the connection health so that the pool can be purged at a later point
-				if (connection != null) {
-					cpHealthTracker.trackConnectionError(connection.getParentConnectionPool(), lastException);
-				}
-				
+
+                if (connection != null) {
+                    cpMonitor.incOperationFailure(connection.getHost(), e);
+
+                    if (retry.allowRetry()) {
+                        cpMonitor.incFailover(connection.getHost(), e);
+                    }
+
+                    // Track the connection health so that the pool can be purged at a later point
+                    cpHealthTracker.trackConnectionError(connection.getParentConnectionPool(), lastException);
+                } else {
+                    cpMonitor.incOperationFailure(null, e);
+                }
+
 			} catch(Throwable t) {
 				throw new RuntimeException(t);
 			} finally {

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolImplTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolImplTest.java
@@ -128,17 +128,18 @@ public class ConnectionPoolImplTest {
 	private Host host1 = new Host("host1", 8080, Status.Up).setRack("localDC");
 	private Host host2 = new Host("host2", 8080, Status.Up).setRack("localDC");
 	private Host host3 = new Host("host3", 8080, Status.Up).setRack("localDC");
-	
-	private final List<Host> hostSupplierHosts = new ArrayList<Host>();
+
+    private final List<Host> hostSupplierHosts = new ArrayList<Host>();
 	
 	@Before
 	public void beforeTest() {
 
 		hostSupplierHosts.clear();
 		
-		host1 = new Host("host1", 8080, Status.Up).setRack("localDC");
-		host2 = new Host("host2", 8080, Status.Up).setRack("localDC");
-		host3 = new Host("host3", 8080, Status.Up).setRack("localDC");
+//		host1 = new Host("host1", 8080, Status.Up).setRack("localDC");
+//		host2 = new Host("host2", 8080, Status.Up).setRack("localDC");
+//		host3 = new Host("host3", 8080, Status.Up).setRack("localDC");
+
 
 		client = new TestClient();
 		cpConfig = new ConnectionPoolConfigurationImpl("TestClient").setLoadBalancingStrategy(LoadBalancingStrategy.RoundRobin);
@@ -523,6 +524,19 @@ public class ConnectionPoolImplTest {
 			pool.shutdown();
 		}
 	}
+
+    @Test(expected = NoAvailableHostsException.class)
+    public void testHostsDownDuringStartup() {
+
+        final ConnectionPoolImpl<TestClient> pool = new ConnectionPoolImpl<TestClient>(connFactory, cpConfig, cpMonitor);
+
+        hostSupplierHosts.add(new Host("host1_down", 8080, Status.Down).setRack("localDC"));
+        hostSupplierHosts.add(new Host("host2_down", 8080, Status.Down).setRack("localDC"));
+        hostSupplierHosts.add(new Host("host3_down", 8080, Status.Down).setRack("localDC"));
+
+        pool.start();
+
+    }
 
 	private void executeTestClientOperation(final ConnectionPoolImpl<TestClient> pool) {
 		executeTestClientOperation(pool, null);

--- a/dyno-jedis/src/main/java/com/netflix/dyno/jedis/DynoJedisClient.java
+++ b/dyno-jedis/src/main/java/com/netflix/dyno/jedis/DynoJedisClient.java
@@ -1947,8 +1947,17 @@ public class DynoJedisClient implements JedisCommands, MultiKeyCommands {
 		return allResults;
 	}
 
+    /**
+     * Use this with care, especially in the context of production databases.
+     *
+     * @param pattern Specifies the mach set for keys
+     * @return a collection of operation results
+     * @see <a href="http://redis.io/commands/KEYS">keys</a>
+     */
 	public Collection<OperationResult<Set<String>>> d_keys(final String pattern) {
-	
+
+        Logger.warn("Executing d_keys for pattern: " + pattern);
+
 		Collection<OperationResult<Set<String>>> results = connPool.executeWithRing(new BaseKeyOperation<Set<String>>(pattern, OpName.KEYS) {
 
 			@Override


### PR DESCRIPTION
Guard against NPE in executeWithFailover() exception handling block
Added unit test to ensure connection pool does not 'start' if there are no hosts available for it to connect to
Added a log warning to add visibility of d_keys() method invocation