### PR TITLE
Bug Fix - dyno client can hang client application on startup

### DIFF
--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/lb/AbstractTokenMapSupplier.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/lb/AbstractTokenMapSupplier.java
@@ -79,7 +79,12 @@ public abstract class AbstractTokenMapSupplier implements TokenMapSupplier {
 	
 	@Override
 	public HostToken getTokenForHost(final Host host, final Set<Host> activeHosts) {
-		String jsonPayload = getTopologyJsonPayload(activeHosts);
+        String jsonPayload;
+        if (activeHosts.size() == 0) {
+            jsonPayload = getTopologyJsonPayload(host.getHostName());
+        } else {
+            jsonPayload = getTopologyJsonPayload(activeHosts);
+        }
 		List<HostToken> hostTokens = parseTokenListFromJson(jsonPayload);
 		
 		return CollectionUtils.find(hostTokens, new Predicate<HostToken>() {

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolImplTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolImplTest.java
@@ -251,20 +251,6 @@ public class ConnectionPoolImplTest {
 				return tokenMap.get(host);
 			}
 
-//			@Override
-//			public void initWithHosts(Collection<Host> hosts) {
-//
-//				tokenMap.clear();
-//				for (Host h : hosts) {
-//					if (h.getHostName().equals("host1")) {
-//						tokenMap.put(host1, new HostToken(309687905L, host1));
-//					} else if (h.getHostName().equals("host2")) {
-//						tokenMap.put(host2, new HostToken(1383429731L, host2));
-//					} else if (h.getHostName().equals("host3")) {
-//						tokenMap.put(host3, new HostToken(2457171554L, host3));
-//					}
-//				}
-//			}
 		};
 	}
 	


### PR DESCRIPTION
If the host supplier reports hosts are available but dyno cannot establish connections with them on startup exceptions are thrown for each failed connection. If each exception stack trace is being logged the java process spikes the cpu at 100%. Also the connection pool itself is left in an unrecoverable state