### PR TITLE
Fix bug in hosts down/up metric

### DIFF
--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/CountingConnectionPoolMonitor.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/CountingConnectionPoolMonitor.java
@@ -257,7 +257,7 @@ public class CountingConnectionPoolMonitor implements ConnectionPoolMonitor {
 
 	@Override
 	public void hostAdded(Host host, HostConnectionPool<?> pool) {
-		hostStats.putIfAbsent(host, new HostConnectionStatsImpl(host));
+        getOrCreateHostStats(host).hostUp.set(true);
 	}
 
 	@Override


### PR DESCRIPTION
Minor change to mark a host as 'up' during the addHost operation. By default this is the case, however, if the host being added is actually being re-activated it was never marked as 'up'.