### PR TITLE
Bug fix in host metrics count

### DIFF
--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/ConnectionPoolMonitor.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/ConnectionPoolMonitor.java
@@ -185,6 +185,14 @@ public interface ConnectionPoolMonitor {
     public void hostUp(Host host, HostConnectionPool<?> pool);
 
     /**
+     * Sets the current total number of hosts tracked by this monitor
+     *
+     * @param hostCount
+     */
+    public void setHostCount(long hostCount);
+
+
+    /**
      * @return Return a mapping of all hosts and their statistics
      */
     public Map<Host, HostConnectionStats> getHostStats();

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolImpl.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolImpl.java
@@ -459,6 +459,7 @@ public class ConnectionPoolImpl<CL> implements ConnectionPool<CL> {
 		}
 
 		HostStatusTracker hostStatus = hostsUpdater.refreshHosts();
+		cpMonitor.setHostCount(hostStatus.getHostCount());
 		Collection<Host> hostsUp = hostStatus.getActiveHosts();
 		
 		if (hostsUp == null || hostsUp.isEmpty()) {
@@ -506,6 +507,7 @@ public class ConnectionPoolImpl<CL> implements ConnectionPool<CL> {
 				public void run() {
 					try {
                         HostStatusTracker hostStatus = hostsUpdater.refreshHosts();
+						cpMonitor.setHostCount(hostStatus.getHostCount());
                         updateHosts(hostStatus.getActiveHosts(), hostStatus.getInactiveHosts());
                     } catch (Throwable throwable) {
                         Logger.error("Failed to update hosts cache", throwable);

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/HostStatusTracker.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/HostStatusTracker.java
@@ -177,6 +177,17 @@ public class HostStatusTracker {
 	public Collection<Host> getInactiveHosts() {
 		return inactiveHosts;
 	}
+
+	/**
+	 * Returns the total number of hosts being tracked by this instance. Note that this is calculated
+	 * on every invocation.
+	 *
+	 * @return Integer
+	 */
+	public int getHostCount() {
+		// The host collections are never null since they are initialized during construction of this instance.
+		return activeHosts.size() + inactiveHosts.size();
+	}
 	
 	public String toString() {
 		return "HostStatusTracker \nactiveSet: " + activeHosts.toString() + "\ninactiveSet: " + inactiveHosts.toString();  


### PR DESCRIPTION
The counter class relied on synchronizing it's collection with that of the host supplier via add/remove hosts however this can get out of sync, for example, if the client cluster starts while dynomite server(s) are down. In this case the host count is off as is the number of hosts down.