### PR TITLE
Bug Fixes related to resiliency

### DIFF
--- a/dyno-contrib/src/main/java/com/netflix/dyno/contrib/ArchaiusConnectionPoolConfiguration.java
+++ b/dyno-contrib/src/main/java/com/netflix/dyno/contrib/ArchaiusConnectionPoolConfiguration.java
@@ -28,6 +28,7 @@ public class ArchaiusConnectionPoolConfiguration extends ConnectionPoolConfigura
 	private final DynamicIntProperty socketTimeout;
 	private final DynamicIntProperty poolShutdownDelay;
 	private final DynamicBooleanProperty localDcAffinity;
+	private final DynamicIntProperty resetTimingsFrequency;
 	
 	private final LoadBalancingStrategy loadBalanceStrategy;
 	private final ErrorRateMonitorConfig errorRateConfig;
@@ -46,7 +47,7 @@ public class ArchaiusConnectionPoolConfiguration extends ConnectionPoolConfigura
 		socketTimeout = DynamicPropertyFactory.getInstance().getIntProperty(propertyPrefix + ".connection.socketTimeout", super.getSocketTimeout());
 		poolShutdownDelay = DynamicPropertyFactory.getInstance().getIntProperty(propertyPrefix + ".connection.poolShutdownDelay", super.getPoolShutdownDelay());
 		localDcAffinity = DynamicPropertyFactory.getInstance().getBooleanProperty(propertyPrefix + ".connection.localDcAffinity", super.localDcAffinity());
-
+		resetTimingsFrequency = DynamicPropertyFactory.getInstance().getIntProperty(propertyPrefix + ".connection.metrics.resetFrequencySeconds", super.getTimingCountersResetFrequencySeconds());
 		
 		loadBalanceStrategy = parseLBStrategy(propertyPrefix);
 		errorRateConfig = parseErrorRateMonitorConfig(propertyPrefix);
@@ -109,6 +110,12 @@ public class ArchaiusConnectionPoolConfiguration extends ConnectionPoolConfigura
 	public LoadBalancingStrategy getLoadBalancingStrategy() {
 		return loadBalanceStrategy;
 	}
+
+	@Override
+	public int getTimingCountersResetFrequencySeconds() {
+		return resetTimingsFrequency.get();
+	}
+
 
 	
 	private LoadBalancingStrategy parseLBStrategy(String propertyPrefix) {

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/ConnectionPool.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/ConnectionPool.java
@@ -119,4 +119,6 @@ public interface ConnectionPool<CL> {
      * Setup the connection pool and start any maintenance threads
      */
     public Future<Boolean> start();
+
+    public ConnectionPoolConfiguration getConfiguration();
 }

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/ConnectionPoolConfiguration.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/ConnectionPoolConfiguration.java
@@ -116,4 +116,19 @@ public interface ConnectionPoolConfiguration {
      * @return
      */
     public String getLocalDC();
+
+    /**
+     * Returns the amount of time the histogram accumulates data before it is cleared, in seconds.
+     * <p>
+     * A histogram is used to record timing metrics. This provides more accurate timings to telemetry systems that
+     * are polling at a fixed interval that spans hundreds or thousands of requests, i.e. 1 minute. Since the history
+     * off all requests are preserved this is not ideal for scenarios where we don't want the history, for example
+     * after a network latency spike the average latency will be affected for hours or days.
+     * <p>
+     * Note that 0 is the default and effectively disables this setting meaning all history is preserved.
+     *
+     * @return a positive integer that specifies the duration of the frequency to accumulate timing data or 0
+     */
+    public int getTimingCountersResetFrequencySeconds();
+
 }

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolConfigurationImpl.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolConfigurationImpl.java
@@ -38,7 +38,8 @@ public class ConnectionPoolConfigurationImpl implements ConnectionPoolConfigurat
 	private static final int DEFAULT_CONNECT_TIMEOUT = 3000; 
 	private static final int DEFAULT_SOCKET_TIMEOUT = 12000; 
 	private static final int DEFAULT_POOL_SHUTDOWN_DELAY = 60000; 
-	private static final int DEFAULT_PING_FREQ_SECONDS = 1; 
+	private static final int DEFAULT_PING_FREQ_SECONDS = 1;
+	private static final int DEFAULT_FLUSH_TIMINGS_FREQ_SECONDS = 0;
 	private static final boolean DEFAULT_LOCAL_DC_AFFINITY = true; 
 	private static final LoadBalancingStrategy DEFAULT_LB_STRATEGY = LoadBalancingStrategy.TokenAware; 
 
@@ -53,7 +54,8 @@ public class ConnectionPoolConfigurationImpl implements ConnectionPoolConfigurat
 	private int connectTimeout = DEFAULT_CONNECT_TIMEOUT; 
 	private int socketTimeout = DEFAULT_SOCKET_TIMEOUT; 
 	private int poolShutdownDelay = DEFAULT_POOL_SHUTDOWN_DELAY; 
-	private int pingFrequencySeconds = DEFAULT_PING_FREQ_SECONDS; 
+	private int pingFrequencySeconds = DEFAULT_PING_FREQ_SECONDS;
+	private int flushTimingsFrequencySeconds = DEFAULT_FLUSH_TIMINGS_FREQ_SECONDS;
 	private boolean localDcAffinity = DEFAULT_LOCAL_DC_AFFINITY; 
 	private LoadBalancingStrategy lbStrategy = DEFAULT_LB_STRATEGY; 
 	private String localDC;
@@ -281,7 +283,12 @@ public class ConnectionPoolConfigurationImpl implements ConnectionPoolConfigurat
 	public String getLocalDC() {
 		return localDC;
 	}
-	
+
+	@Override
+	public int getTimingCountersResetFrequencySeconds() {
+		return flushTimingsFrequencySeconds;
+	}
+
 	public ConnectionPoolConfigurationImpl setLocalDC(String dc) {
 		this.localDC = dc;
 		return this;

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolConfigurationImpl.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolConfigurationImpl.java
@@ -39,7 +39,7 @@ public class ConnectionPoolConfigurationImpl implements ConnectionPoolConfigurat
 	private static final int DEFAULT_SOCKET_TIMEOUT = 12000; 
 	private static final int DEFAULT_POOL_SHUTDOWN_DELAY = 60000; 
 	private static final int DEFAULT_PING_FREQ_SECONDS = 1;
-	private static final int DEFAULT_FLUSH_TIMINGS_FREQ_SECONDS = 0;
+	private static final int DEFAULT_FLUSH_TIMINGS_FREQ_SECONDS = 300;
 	private static final boolean DEFAULT_LOCAL_DC_AFFINITY = true; 
 	private static final LoadBalancingStrategy DEFAULT_LB_STRATEGY = LoadBalancingStrategy.TokenAware; 
 

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolImpl.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolImpl.java
@@ -508,6 +508,7 @@ public class ConnectionPoolImpl<CL> implements ConnectionPool<CL> {
 					try {
                         HostStatusTracker hostStatus = hostsUpdater.refreshHosts();
 						cpMonitor.setHostCount(hostStatus.getHostCount());
+						Logger.debug(hostStatus.toString());
                         updateHosts(hostStatus.getActiveHosts(), hostStatus.getInactiveHosts());
                     } catch (Throwable throwable) {
                         Logger.error("Failed to update hosts cache", throwable);
@@ -524,7 +525,12 @@ public class ConnectionPoolImpl<CL> implements ConnectionPool<CL> {
 		return getEmptyFutureTask(true);
 	}
 
-    private void registerMonitorConsoleMBean(MonitorConsoleMBean bean) {
+	@Override
+	public ConnectionPoolConfiguration getConfiguration() {
+		return cpConfiguration;
+	}
+
+	private void registerMonitorConsoleMBean(MonitorConsoleMBean bean) {
         final MBeanServer server = ManagementFactory.getPlatformMBeanServer();
         try {
             ObjectName objectName = new ObjectName(MonitorConsole.OBJECT_NAME);

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/CountingConnectionPoolMonitor.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/CountingConnectionPoolMonitor.java
@@ -25,11 +25,7 @@ import com.netflix.dyno.connectionpool.Host;
 import com.netflix.dyno.connectionpool.HostConnectionPool;
 import com.netflix.dyno.connectionpool.HostConnectionStats;
 import com.netflix.dyno.connectionpool.HostGroup;
-import com.netflix.dyno.connectionpool.exception.BadRequestException;
-import com.netflix.dyno.connectionpool.exception.NoAvailableHostsException;
-import com.netflix.dyno.connectionpool.exception.PoolExhaustedException;
-import com.netflix.dyno.connectionpool.exception.PoolTimeoutException;
-import com.netflix.dyno.connectionpool.exception.TimeoutException;
+import com.netflix.dyno.connectionpool.exception.*;
 
 /**
  * Impl of {@link ConnectionPoolMonitor} using thread safe AtomicLongs
@@ -77,7 +73,9 @@ public class CountingConnectionPoolMonitor implements ConnectionPoolMonitor {
     		} else if (reason instanceof PoolExhaustedException) {
         	        this.poolExhastedCount.incrementAndGet();
     		} else if (reason instanceof TimeoutException) {
-    			this.socketTimeoutCount.incrementAndGet();
+                this.socketTimeoutCount.incrementAndGet();
+            } else if (reason instanceof FatalConnectionException) {
+                this.socketTimeoutCount.incrementAndGet();
     		} else if (reason instanceof BadRequestException) {
     			this.badRequestCount.incrementAndGet();
     		} else if (reason instanceof NoAvailableHostsException ) {

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/CountingConnectionPoolMonitor.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/CountingConnectionPoolMonitor.java
@@ -235,7 +235,7 @@ public class CountingConnectionPoolMonitor implements ConnectionPoolMonitor {
                     .append(",busy="       ).append(getNumBusyConnections())
                     .append(",create="     ).append(connectionCreateCount.get())
                     .append(",close="      ).append(connectionClosedCount.get())
-                    .append(",failed="     ).append(connectionCreateFailureCount.get())
+                    .append(",createFailed="     ).append(connectionCreateFailureCount.get())
                     .append(",borrow="     ).append(connectionBorrowCount.get())
                     .append(",return="     ).append(connectionReturnCount.get())
                 .append("], Operations[")

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/MonitorConsole.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/MonitorConsole.java
@@ -75,7 +75,7 @@ public class MonitorConsole implements MonitorConsoleMBean {
          .append("\nConnections[" )
              .append("   created: " ).append(cpMonitor.getConnectionCreatedCount())
              .append(",  closed: "  ).append(cpMonitor.getConnectionClosedCount())
-             .append(",  failed: "  ).append(cpMonitor.getConnectionCreateFailedCount())
+             .append(",  createFailed: "  ).append(cpMonitor.getConnectionCreateFailedCount())
              .append(",  borrowed: ").append(cpMonitor.getConnectionBorrowedCount())
              .append(",  returned: ").append(cpMonitor.getConnectionReturnedCount())
              
@@ -101,7 +101,9 @@ public class MonitorConsole implements MonitorConsoleMBean {
 			 sb.append(" returned: " + hStats.getConnectionsReturned());
 			 sb.append(" created: " + hStats.getConnectionsCreated());
 			 sb.append(" closed: " + hStats.getConnectionsClosed());
-			 sb.append(" failed: " + hStats.getConnectionsCreateFailed());
+			 sb.append(" createFailed: " + hStats.getConnectionsCreateFailed());
+			 sb.append(" errors: " + hStats.getOperationErrorCount());
+			 sb.append(" success: " + hStats.getOperationSuccessCount());
 		 }
 		 sb.append("\n");
 		 

--- a/dyno-jedis/src/main/java/com/netflix/dyno/jedis/DynoJedisClient.java
+++ b/dyno-jedis/src/main/java/com/netflix/dyno/jedis/DynoJedisClient.java
@@ -2095,8 +2095,9 @@ public class DynoJedisClient implements JedisCommands, MultiKeyCommands {
 		if (pipelineMonitor.get() != null) {
 			return pipelineMonitor.get();
 		}
-		
-		DynoJedisPipelineMonitor plMonitor = new DynoJedisPipelineMonitor(appName);
+
+		int flushTimerFrequency = this.connPool.getConfiguration().getTimingCountersResetFrequencySeconds();
+		DynoJedisPipelineMonitor plMonitor = new DynoJedisPipelineMonitor(appName, flushTimerFrequency);
 		boolean success = pipelineMonitor.compareAndSet(null, plMonitor);
 		if (success) {
 			pipelineMonitor.get().init();

--- a/dyno-jedis/src/main/java/com/netflix/dyno/jedis/DynoJedisPipeline.java
+++ b/dyno-jedis/src/main/java/com/netflix/dyno/jedis/DynoJedisPipeline.java
@@ -1242,6 +1242,7 @@ public class DynoJedisPipeline implements RedisPipeline, AutoCloseable {
 		} catch (JedisConnectionException jce) {
 			String msg = "Failed sync() to host: " + getHostInfo();
 			pipelineEx.set(new FatalConnectionException(msg, jce));
+			cpMonitor.incOperationFailure(connection == null ? null : connection.getHost(), jce);
 			throw jce;
 		} finally {
             long duration = System.nanoTime()/1000 - startTime;
@@ -1260,6 +1261,7 @@ public class DynoJedisPipeline implements RedisPipeline, AutoCloseable {
 		} catch (JedisConnectionException jce) {
 			String msg = "Failed syncAndReturnAll() to host: " + getHostInfo();
 			pipelineEx.set(new FatalConnectionException(msg, jce));
+			cpMonitor.incOperationFailure(connection == null ? null : connection.getHost(), jce);
 			throw jce;
         } finally {
             long duration = System.nanoTime()/1000 - startTime;


### PR DESCRIPTION
1. For latent connections that timeout during a sync() or syncAndReturnAll() the client was not recording operation failures or utilizing the health tracker.
2. Periodically clear the internal histogram used for latency metrics reporting so that latency spikes do not  take an extremely long time to recover from