### PR TITLE
Fixing issue #52: connect timeout not used when constructing Jedis() connection

### DIFF
--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/HostConnectionPool.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/HostConnectionPool.java
@@ -129,4 +129,6 @@ public interface HostConnectionPool<CL> {
      * @return Collection<Connection<CL>>
      */
     Collection<Connection<CL>> getAllConnections();
+
+    int getConnectionTimeout();
 }

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/HostConnectionPoolImpl.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/HostConnectionPoolImpl.java
@@ -250,6 +250,11 @@ public class HostConnectionPoolImpl<CL> implements HostConnectionPool<CL> {
 		throw new RuntimeException("Not Implemented");
 	}
 
+	@Override
+	public int getConnectionTimeout() {
+		return cpConfig.getConnectTimeout();
+	}
+
 	private interface ConnectionPoolState<CL> { 
 		
 		

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/SimpleAsyncConnectionPoolImpl.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/SimpleAsyncConnectionPoolImpl.java
@@ -174,6 +174,11 @@ public class SimpleAsyncConnectionPoolImpl<CL> implements HostConnectionPool<CL>
 		return connMap.keySet();
 	}
 
+	@Override
+	public int getConnectionTimeout() {
+		return cpConfig.getConnectTimeout();
+	}
+
 	private Connection<CL> createConnection() throws DynoException {
 		
 		Connection<CL> connection = connFactory.createConnection((HostConnectionPool<CL>) this, null);

--- a/dyno-demo/src/main/java/com/netflix/dyno/demo/redis/DynoJedisDemo.java
+++ b/dyno-demo/src/main/java/com/netflix/dyno/demo/redis/DynoJedisDemo.java
@@ -307,18 +307,39 @@ public class DynoJedisDemo {
 		return hosts;
 	}
 	
-	public void runSinglePipeline() throws Exception {
+	public void runBinarySinglePipeline() throws Exception {
 
 		for (int i=0; i<10; i++) {
 			DynoJedisPipeline pipeline = client.pipelined();
 
-			Response<Long> resultA1 = pipeline.hset("Puneet_pipeline" + i, "a1", "v11");
-			Response<Long> resultA2 = pipeline.hset("Puneet_pipeline" + i, "a2", "v11");
+			Map<byte[], byte[]> bar = new HashMap<byte[], byte[]>();
+			bar.put("key__1".getBytes(), "value__1".getBytes());
+			bar.put("key__2".getBytes(), "value__2".getBytes());
+
+			Response<String> hmsetResult = pipeline.hmset(("hash__" + i).getBytes(), bar);
+
+//			Response<Long> resultA1 = pipeline.hset("Puneet_pipeline" + i, "a1", "v11");
+//			Response<Long> resultA2 = pipeline.hset("Puneet_pipeline" + i, "a2", "v11");
 
 			pipeline.sync();
 
-			System.out.println(resultA1.get() + " "  + resultA2.get());
+			System.out.println(hmsetResult.get());
 		}
+
+		System.out.println("Reading all keys");
+
+		DynoJedisPipeline readPipeline = client.pipelined();
+		Response<Map<byte[], byte[]>> resp = readPipeline.hgetAll("hash__1".getBytes());
+		readPipeline.sync();
+
+        StringBuilder sb = new StringBuilder();
+        for (byte[] bytes: resp.get().keySet()) {
+            if (sb.length() > 0) {
+                sb.append(",");
+            }
+            sb.append(new String(bytes));
+        }
+		System.out.println("Got hash :" + sb.toString());
 	}
 	
 	public void runPipeline() throws Exception {
@@ -519,14 +540,15 @@ public class DynoJedisDemo {
 
 		try {
 			
-			demo.initWithRemoteClusterFromEurekaUrl("dyno_json", 8102);
+			demo.initWithRemoteClusterFromEurekaUrl("dyno_jcacciatore_7", 8102);
 			System.out.println("Connected");
 
-			demo.runSimpleTest();
+			//demo.runSimpleTest();
 			//demo.runKeysTest();
 			//demo.runMultiThreaded();
 			//demo.runSinglePipeline();
 			//demo.runPipeline();
+			demo.runBinarySinglePipeline();
 			
 			//demo.runLongTest();
 			Thread.sleep(1000);

--- a/dyno-jedis/src/main/java/com/netflix/dyno/jedis/DynoJedisPipeline.java
+++ b/dyno-jedis/src/main/java/com/netflix/dyno/jedis/DynoJedisPipeline.java
@@ -363,8 +363,8 @@ public class DynoJedisPipeline implements RedisPipeline, AutoCloseable {
 
             @Override
             Response<byte[]> execute(Pipeline jedisPipeline) throws DynoException {
-                return jedisPipeline.hget(key, field);
-            }
+				return jedisPipeline.hget(key, field);
+			}
         }.execute(key, OpName.HGET);
 
     }

--- a/dyno-jedis/src/main/java/com/netflix/dyno/jedis/JedisConnectionFactory.java
+++ b/dyno-jedis/src/main/java/com/netflix/dyno/jedis/JedisConnectionFactory.java
@@ -38,7 +38,7 @@ public class JedisConnectionFactory implements ConnectionFactory<Jedis> {
 	}
 	
 	@Override
-	public Connection<Jedis> createConnection(HostConnectionPool<Jedis> pool, ConnectionObservor connectionObservor) 
+	public Connection<Jedis> createConnection(HostConnectionPool<Jedis> pool, ConnectionObservor connectionObservor)
 			throws DynoConnectException, ThrottledException {
 		
 		return new JedisConnection(pool);
@@ -55,7 +55,7 @@ public class JedisConnectionFactory implements ConnectionFactory<Jedis> {
 		public JedisConnection(HostConnectionPool<Jedis> hostPool) {
 			this.hostPool = hostPool;
 			Host host = hostPool.getHost();
-			jedisClient = new Jedis(host.getHostName(), host.getPort());
+			jedisClient = new Jedis(host.getHostName(), host.getPort(), hostPool.getConnectionTimeout());
 		}
 		
 		@Override


### PR DESCRIPTION
ConnectionPoolConfiguration.getConnectTimeout() not used when constructing Jedis() connection