### PR TITLE
Modified startup behavior of the pool.

### DIFF
--- a/dyno-contrib/src/main/java/com/netflix/dyno/contrib/ArchaiusConnectionPoolConfiguration.java
+++ b/dyno-contrib/src/main/java/com/netflix/dyno/contrib/ArchaiusConnectionPoolConfiguration.java
@@ -35,6 +35,7 @@ public class ArchaiusConnectionPoolConfiguration extends ConnectionPoolConfigura
 	private final LoadBalancingStrategy loadBalanceStrategy;
 	private final ErrorRateMonitorConfig errorRateConfig;
 	private final RetryPolicyFactory retryPolicyFactory;
+    private final DynamicBooleanProperty failOnStartupIfNoHosts;
 
 	public ArchaiusConnectionPoolConfiguration(String name) {
 		super(name);
@@ -51,7 +52,8 @@ public class ArchaiusConnectionPoolConfiguration extends ConnectionPoolConfigura
 		localDcAffinity = DynamicPropertyFactory.getInstance().getBooleanProperty(propertyPrefix + ".connection.localDcAffinity", super.localDcAffinity());
 		resetTimingsFrequency = DynamicPropertyFactory.getInstance().getIntProperty(propertyPrefix + ".connection.metrics.resetFrequencySeconds", super.getTimingCountersResetFrequencySeconds());
         configPublisherConfig = DynamicPropertyFactory.getInstance().getStringProperty(propertyPrefix + ".config.publisher.address", super.getConfigurationPublisherConfig());
-		
+		failOnStartupIfNoHosts = DynamicPropertyFactory.getInstance().getBooleanProperty(propertyPrefix + ".config.startup.failIfNoHosts", super.getFailOnStartupIfNoHosts());
+
 		loadBalanceStrategy = parseLBStrategy(propertyPrefix);
 		errorRateConfig = parseErrorRateMonitorConfig(propertyPrefix);
 		retryPolicyFactory = parseRetryPolicyFactory(propertyPrefix);
@@ -124,8 +126,13 @@ public class ArchaiusConnectionPoolConfiguration extends ConnectionPoolConfigura
         return configPublisherConfig.get();
     }
 
+    @Override
+    public boolean getFailOnStartupIfNoHosts() {
+        return failOnStartupIfNoHosts.get();
+    }
 
-	private LoadBalancingStrategy parseLBStrategy(String propertyPrefix) {
+
+    private LoadBalancingStrategy parseLBStrategy(String propertyPrefix) {
 		
 		LoadBalancingStrategy defaultConfig = super.getLoadBalancingStrategy();
 		

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/ConnectionPool.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/ConnectionPool.java
@@ -119,9 +119,22 @@ public interface ConnectionPool<CL> {
     void shutdown();
 
     /**
-     * Setup the connection pool and start any maintenance threads
+     * Setup the connection pool and start any maintenance threads. This includes priming connections
+     * to server hosts.
      */
-    Future<Boolean> start();
+    Future<Boolean> start() throws DynoException;
+
+    /**
+     * Construct the connection pool but do not start any threads. The pool will poll the {@link HostSupplier}
+     * once per minute and will start upon finding active hosts.
+     * <p>
+     * Note that an {@link IllegalStateException} will be thrown if the connection pool has been successfully
+     * started.
+     * </p>
+     * This api is utilized by DynoJedisClient and DynoRedissonClient when starting the connection pool unless
+     * {@link ConnectionPoolConfiguration#getFailOnStartupIfNoHosts()} is set to true.
+     */
+    void idle();
 
     /**
      * Retrieve the runtime configuration of the connection pool instance.

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/ConnectionPoolConfiguration.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/ConnectionPoolConfiguration.java
@@ -21,25 +21,25 @@ import com.netflix.dyno.connectionpool.impl.health.ErrorMonitor.ErrorMonitorFact
 
 public interface ConnectionPoolConfiguration {
 	
-	public static enum LoadBalancingStrategy {
+	enum LoadBalancingStrategy {
 		RoundRobin, TokenAware;
 	}
 
     /**
      * @return Unique name assigned to this connection pool
      */
-    public String getName();
+    String getName();
 
     /**
      * @return Data port to be used when no port is specified to a list of seeds or when
      * doing a ring describe since the ring describe does not include a host
      */
-    public int getPort();
+    int getPort();
 
     /**
      * @return Maximum number of connections to allocate for a single host's pool
      */
-    public int getMaxConnsPerHost();
+    int getMaxConnsPerHost();
 
     /**
      * @return Maximum amount of time to wait for a connection to free up when a
@@ -47,75 +47,75 @@ public interface ConnectionPoolConfiguration {
      * 
      * @return
      */
-    public int getMaxTimeoutWhenExhausted();
+    int getMaxTimeoutWhenExhausted();
 
     /**
      * @return Get the max number of failover attempts
      */
-    public int getMaxFailoverCount();
+    int getMaxFailoverCount();
 
     /**
      * @return Socket read/write timeout
      */
-    public int getSocketTimeout();
+    int getSocketTimeout();
 
     /**
      * @return LoadBalancingStrategy
      */
-    public LoadBalancingStrategy getLoadBalancingStrategy();
+    LoadBalancingStrategy getLoadBalancingStrategy();
     
     /**
      * @return Socket connect timeout
      */
-    public int getConnectTimeout();
+    int getConnectTimeout();
     
     /**
      * 
      * @return
      */
-    public int getPoolShutdownDelay();
+    int getPoolShutdownDelay();
     
     /**
      * 
      * @return
      */
-    public boolean localDcAffinity(); 
+    boolean localDcAffinity();
     
     /**
      * 
      * @return
      */
-    public ErrorMonitorFactory getErrorMonitorFactory();
+    ErrorMonitorFactory getErrorMonitorFactory();
     
     /**
      * 
      * @return
      */
-    public RetryPolicyFactory getRetryPolicyFactory();
+    RetryPolicyFactory getRetryPolicyFactory();
     
     /**
      * 
      * @return
      */
-    public HostSupplier getHostSupplier();
+    HostSupplier getHostSupplier();
     
     /**
      * 
      * @return
      */
-    public TokenMapSupplier getTokenSupplier();
+    TokenMapSupplier getTokenSupplier();
     
     /**
      * 
      * @return
      */
-    public int getPingFrequencySeconds();
+    int getPingFrequencySeconds();
     
     /**
      * 
      * @return
      */
-    public String getLocalDC();
+    String getLocalDC();
 
     /**
      * Returns the amount of time the histogram accumulates data before it is cleared, in seconds.
@@ -129,7 +129,7 @@ public interface ConnectionPoolConfiguration {
      *
      * @return a positive integer that specifies the duration of the frequency to accumulate timing data or 0
      */
-    public int getTimingCountersResetFrequencySeconds();
+    int getTimingCountersResetFrequencySeconds();
 
     /**
      * Returns info about a system that will consume configuration data from dyno. This is used to
@@ -137,6 +137,21 @@ public interface ConnectionPoolConfiguration {
      *
      * @return todo
      */
-     public String getConfigurationPublisherConfig();
+     String getConfigurationPublisherConfig();
+
+    /**
+     * If there are no hosts marked as 'Up' in the {@link HostSupplier} when starting the connection pool
+     * a {@link com.netflix.dyno.connectionpool.exception.NoAvailableHostsException} will be thrown
+     * if this is set to true. By default this is false.
+     * <p>
+     * When this does occur and this property is set to false, a warning will be logged and the connection pool
+     * will go into an idle state, polling once per minute in the background for available hosts to connect to.
+     * The connection pool can idle indefinitely. In the event that hosts do become available, the connection
+     * pool will start.
+     * </p>
+     *
+     * @return boolean to control the startup behavior specified in the description.
+     */
+    boolean getFailOnStartupIfNoHosts();
 
 }

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolConfigurationImpl.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolConfigurationImpl.java
@@ -43,6 +43,8 @@ public class ConnectionPoolConfigurationImpl implements ConnectionPoolConfigurat
 	private static final boolean DEFAULT_LOCAL_DC_AFFINITY = true; 
 	private static final LoadBalancingStrategy DEFAULT_LB_STRATEGY = LoadBalancingStrategy.TokenAware;
     private static final String DEFAULT_CONFIG_PUBLISHER_ADDRESS = null;
+    private static final boolean DEFAULT_FAIL_ON_STARTUP_IFNOHOSTS = false;
+    private static final int DEFAULT_FAIL_ON_STARTUP_IFNOHOSTS_SECONDS = 60;
 
 	private HostSupplier hostSupplier;
 	private TokenMapSupplier tokenSupplier;
@@ -61,6 +63,8 @@ public class ConnectionPoolConfigurationImpl implements ConnectionPoolConfigurat
 	private LoadBalancingStrategy lbStrategy = DEFAULT_LB_STRATEGY; 
 	private String localDC;
     private String configPublisherAddress = DEFAULT_CONFIG_PUBLISHER_ADDRESS;
+    private boolean failOnStartupIfNoHosts = DEFAULT_FAIL_ON_STARTUP_IFNOHOSTS;
+    private int failOnStarupIfNoHostsSeconds = DEFAULT_FAIL_ON_STARTUP_IFNOHOSTS_SECONDS;
 
 	private RetryPolicyFactory retryFactory = new RetryPolicyFactory() {
 
@@ -146,6 +150,30 @@ public class ConnectionPoolConfigurationImpl implements ConnectionPoolConfigurat
 	public int getPingFrequencySeconds() {
 		return pingFrequencySeconds;
 	}
+
+    @Override
+    public String getLocalDC() {
+        return localDC;
+    }
+
+    @Override
+    public int getTimingCountersResetFrequencySeconds() {
+        return flushTimingsFrequencySeconds;
+    }
+
+    @Override
+    public String getConfigurationPublisherConfig() {
+        return null;
+    }
+
+    @Override
+    public boolean getFailOnStartupIfNoHosts() {
+        return failOnStartupIfNoHosts;
+    }
+
+    public int getDefaultFailOnStartupIfNoHostsSeconds() {
+        return failOnStarupIfNoHostsSeconds;
+    }
 	
 	// ALL SETTERS
 	public ConnectionPoolConfigurationImpl setMaxConnsPerHost(int maxConnsPerHost) {
@@ -197,6 +225,16 @@ public class ConnectionPoolConfigurationImpl implements ConnectionPoolConfigurat
 		localDcAffinity = condition;
 		return this;
 	}
+
+    public ConnectionPoolConfigurationImpl setFailOnStartupIfNoHosts(boolean condition) {
+        this.failOnStartupIfNoHosts = condition;
+        return this;
+    }
+
+    public ConnectionPoolConfigurationImpl setFailOnStartupIfNoHostsSeconds(int seconds) {
+        this.failOnStarupIfNoHostsSeconds = seconds;
+        return null;
+    }
 
 	public HostSupplier getHostSupplier() {
 		return hostSupplier;
@@ -280,21 +318,6 @@ public class ConnectionPoolConfigurationImpl implements ConnectionPoolConfigurat
 			});
 		}
 	}
-
-	@Override
-	public String getLocalDC() {
-		return localDC;
-	}
-
-	@Override
-	public int getTimingCountersResetFrequencySeconds() {
-		return flushTimingsFrequencySeconds;
-	}
-
-    @Override
-    public String getConfigurationPublisherConfig() {
-        return null;
-    }
 
     public ConnectionPoolConfigurationImpl setLocalDC(String dc) {
 		this.localDC = dc;

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolImplTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolImplTest.java
@@ -199,7 +199,7 @@ public class ConnectionPoolImplTest {
 		
 		Assert.assertEquals(numHosts*cpConfig.getMaxConnsPerHost(), cpMonitor.getConnectionCreatedCount());
 		Assert.assertEquals(0, cpMonitor.getConnectionCreateFailedCount());
-		Assert.assertEquals(numHosts*cpConfig.getMaxConnsPerHost(), cpMonitor.getConnectionClosedCount());
+		Assert.assertEquals(numHosts * cpConfig.getMaxConnsPerHost(), cpMonitor.getConnectionClosedCount());
 		
 		Assert.assertEquals(client.ops.get(), cpMonitor.getConnectionBorrowedCount());
 		Assert.assertEquals(client.ops.get(), cpMonitor.getConnectionReturnedCount());
@@ -351,6 +351,24 @@ public class ConnectionPoolImplTest {
 			pool.shutdown();
 		}
 	}
+
+    @Test
+    public void testIdleWhenNoAvailableHosts() throws Exception {
+        final ConnectionPoolImpl<TestClient> pool = new ConnectionPoolImpl<TestClient>(connFactory, cpConfig, cpMonitor);
+
+        try {
+            pool.start();
+        } catch (NoAvailableHostsException nah) {
+            pool.idle();
+            Thread.sleep(1000);
+
+            // calling idle() again should have no effect and will throw an exception if the pool has already been
+            // started
+            pool.idle();
+        } finally {
+            pool.shutdown();
+        }
+    }
 	
 	@Test
 	public void testPoolExhausted() throws Exception {
@@ -359,8 +377,8 @@ public class ConnectionPoolImplTest {
 		hostSupplierHosts.add(host1);
 		hostSupplierHosts.add(host2);
 		hostSupplierHosts.add(host3);
-		
-		pool.start();
+
+        pool.start();
 		
 		// Now exhaust all 9 connections, so that the 10th one can fail with PoolExhaustedException
 		final ExecutorService threadPool = Executors.newFixedThreadPool(9);
@@ -390,8 +408,9 @@ public class ConnectionPoolImplTest {
 				}
 			});
 		}
-		
-		latch.await(); Thread.sleep(100); // wait patiently for all threads to have blocked the connections
+
+        latch.await();
+        Thread.sleep(100); // wait patiently for all threads to have blocked the connections
 		
 		try {
 			executeTestClientOperation(pool);
@@ -438,8 +457,8 @@ public class ConnectionPoolImplTest {
 		hostSupplierHosts.add(host1);
 		hostSupplierHosts.add(host2);
 		hostSupplierHosts.add(host3);
-		
-		pool.start();
+
+        pool.start();
 
 		final Callable<Void> testLogic = new Callable<Void>() {
 
@@ -451,15 +470,15 @@ public class ConnectionPoolImplTest {
 				return null;
 			}
 		};
-		
-		runTest(pool, testLogic);
+
+        runTest(pool, testLogic);
 		
 		Assert.assertTrue("Total ops: " + client.ops.get(), client.ops.get() > 0);
 		Assert.assertTrue("Total errors: " + cpMonitor.getOperationFailureCount(), cpMonitor.getOperationFailureCount() > 0);
 		
-		Assert.assertEquals(3*cpConfig.getMaxConnsPerHost(), cpMonitor.getConnectionCreatedCount());
+		Assert.assertEquals(3 * cpConfig.getMaxConnsPerHost(), cpMonitor.getConnectionCreatedCount());
 		Assert.assertEquals(0, cpMonitor.getConnectionCreateFailedCount());
-		Assert.assertEquals(3*cpConfig.getMaxConnsPerHost(), cpMonitor.getConnectionClosedCount());
+		Assert.assertEquals(3 * cpConfig.getMaxConnsPerHost(), cpMonitor.getConnectionClosedCount());
 		
 		Assert.assertEquals(client.ops.get() + cpMonitor.getOperationFailureCount(), cpMonitor.getConnectionBorrowedCount());
 		Assert.assertEquals(client.ops.get() + cpMonitor.getOperationFailureCount(), cpMonitor.getConnectionReturnedCount());
@@ -503,7 +522,7 @@ public class ConnectionPoolImplTest {
 		
 		try { 
 			executeTestClientOperation(pool, null);
-			Assert.fail("Test failed: expected PoolExhaustedException");
+            Assert.fail("Test failed: expected PoolExhaustedException");
 		} catch (DynoException e) {
 			Assert.assertEquals("Retry: " + retry.getAttemptCount(), 4, retry.getAttemptCount());
 		} finally {

--- a/dyno-redisson/src/main/java/com/netflix/dyno/redisson/DynoRedissonClient.java
+++ b/dyno-redisson/src/main/java/com/netflix/dyno/redisson/DynoRedissonClient.java
@@ -114,7 +114,11 @@ public class DynoRedissonClient {
 			try {
 				pool.start().get();
 			} catch (Exception e) {
-				throw new RuntimeException(e);
+                if (cpConfig.getFailOnStartupIfNoHosts()) {
+                    throw new RuntimeException(e);
+                }
+
+                pool.idle();
 			}
 			
 			final DynoRedissonClient client = new DynoRedissonClient(appName, pool);


### PR DESCRIPTION
If there are no hosts available to connect to at the time of startup the pool will now go into and idle state and poll for available hosts once per minute in a background thread. The behavior prior to this commit is that a NoHostsAvailableException would be thrown. To enable this same behavior, set *.config.startup.failIfNoHosts to true.