### PR TITLE
Bug Fix: Illegal values returned to client applications

### DIFF
--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolConfigurationImpl.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolConfigurationImpl.java
@@ -32,7 +32,7 @@ public class ConnectionPoolConfigurationImpl implements ConnectionPoolConfigurat
 	
 	// DEFAULTS 
 	private static final int DEFAULT_PORT = 8102; 
-	private static final int DEFAULT_MAX_CONNS_PER_HOST = 1; 
+	private static final int DEFAULT_MAX_CONNS_PER_HOST = 3;
 	private static final int DEFAULT_MAX_TIMEOUT_WHEN_EXHAUSTED = 2000; 
 	private static final int DEFAULT_MAX_FAILOVER_COUNT = 3; 
 	private static final int DEFAULT_CONNECT_TIMEOUT = 3000; 

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/HostConnectionPoolImpl.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/HostConnectionPoolImpl.java
@@ -313,15 +313,21 @@ public class HostConnectionPoolImpl<CL> implements HostConnectionPool<CL> {
 		public boolean returnConnection(Connection<CL> connection) {
 			try {
 				if (numActiveConnections.get() > cpConfig.getMaxConnsPerHost()) {
-					
-					// Just close the connection
-					return closeConnection(connection);
-					
-				} else {
-					// add connection back to the pool
-					availableConnections.add(connection);
-					return false;
+
+                    // Just close the connection
+                    return closeConnection(connection);
+
+                } else if (numActiveConnections.get() < cpConfig.getMaxConnsPerHost()) {
+
+                    // Create a connection and add it to the pool
+                    createConnectionWithRetries();
+
 				}
+
+				// Add the given connection back to the pool
+				availableConnections.add(connection);
+				return false;
+
 			} finally { 
 				monitor.incConnectionReturned(host);
 			}

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/MonitorConsole.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/MonitorConsole.java
@@ -76,6 +76,8 @@ public class MonitorConsole implements MonitorConsoleMBean {
              .append(",  createFailed: "  ).append(cpMonitor.getConnectionCreateFailedCount())
              .append(",  borrowed: ").append(cpMonitor.getConnectionBorrowedCount())
              .append(",  returned: ").append(cpMonitor.getConnectionReturnedCount())
+             .append(",  borrowedLatMean: ").append(cpMonitor.getConnectionBorrowedLatMean())
+             .append(",  borrowedLatP99: ").append(cpMonitor.getConnectionBorrowedLatP99())
              
          .append("]\nOperations[")
              .append("   success=" ).append(cpMonitor.getOperationSuccessCount())

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/lb/HostSelectionWithFallback.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/lb/HostSelectionWithFallback.java
@@ -135,7 +135,7 @@ public class HostSelectionWithFallback<CL> {
                     cpMonitor.incOperationFailure(null,lastEx);
 					throw lastEx; // give up
 				} else {
-                    PoolOfflineException poe = new PoolOfflineException(hostPool.getHost(), "host pool is offline and no DCs available for fallback");
+                    PoolOfflineException poe = new PoolOfflineException(hostPool.getHost(), "host pool is offline and no Racks available for fallback");
                     cpMonitor.incOperationFailure(null, poe);
 					throw poe;
 				}
@@ -148,7 +148,7 @@ public class HostSelectionWithFallback<CL> {
         }
 		
 		if (hostPool == null) {
-			throw new NoAvailableHostsException("Found no hosts when using fallback DC");
+			throw new NoAvailableHostsException("Found no hosts when using fallback Rack");
 		}
 		
 		return hostPool.borrowConnection(duration, unit);
@@ -158,7 +158,7 @@ public class HostSelectionWithFallback<CL> {
 		
 		int numRemotes = remoteDCNames.getEntireList().size();
 		if (numRemotes == 0) {
-			throw new NoAvailableHostsException("Could not find any remote DCs for fallback");
+			throw new NoAvailableHostsException("Could not find any remote Racks for fallback");
 		}
 
 		int numTries = Math.min(numRemotes, cpConfig.getMaxFailoverCount());
@@ -198,7 +198,7 @@ public class HostSelectionWithFallback<CL> {
 		final Collection<HostToken> localZoneTokens = CollectionUtils.filter(hostTokens.values(), new Predicate<HostToken>() {
 			@Override
 			public boolean apply(HostToken x) {
-				return localRack != null ? localRack.equalsIgnoreCase(x.getHost().getRack()) : true; 
+				return localRack == null || localRack.equalsIgnoreCase(x.getHost().getRack());
 			}
 		});
 		

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/SimpleAsyncConnectionPoolImplTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/SimpleAsyncConnectionPoolImplTest.java
@@ -37,12 +37,10 @@ public class SimpleAsyncConnectionPoolImplTest {
 	private static ExecutorService threadPool;
 
 	private static ConnectionFactory<TestClient> connFactory = new ConnectionFactory<TestClient>() {
-
-		@SuppressWarnings("unchecked")
-		Connection<TestClient> connection = mock(Connection.class);
-		@Override
+        @SuppressWarnings("unchecked")
+        @Override
 		public Connection<TestClient> createConnection(HostConnectionPool<TestClient> pool, ConnectionObservor cObservor) throws DynoConnectException, ThrottledException {
-			return connection;
+			return mock(Connection.class);
 		}
 	};
 

--- a/dyno-jedis/src/main/java/com/netflix/dyno/jedis/JedisConnectionFactory.java
+++ b/dyno-jedis/src/main/java/com/netflix/dyno/jedis/JedisConnectionFactory.java
@@ -89,6 +89,7 @@ public class JedisConnectionFactory implements ConnectionFactory<Jedis> {
                     opMonitor.recordSuccess(opName);
                 }
 				opResult = new OperationResultImpl<R>(opName, result, opMonitor);
+				opResult.addMetadata("connectionId", String.valueOf(this.hashCode()));
                 return opResult;
 				
 			} catch (JedisConnectionException ex) {


### PR DESCRIPTION
Clients were seeing illegal values for operations, such as "OK" as a return value on a GET operation. This occurred when a socket exception was thrown by jedis and the dyno client re-used the connection. I modified the code such that when this occurs, the connection is closed. Separately, a new connection is primed and added to the host pool as other connections are returned to the pool so as not to block the current request on which this happens.

I also modified the default maxConnsPerHost to be 3 now since, if it were left at 1 and this issue occurred the connection would be discarded and another one would not be primed until 10 more connection errors occurred and were reported by the health tracker since individual connections are primed only after a connection has been returned to the pool.