### PR TITLE
Bug Fix - host pool can run out of connections

### DIFF
--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/TokenPoolTopology.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/TokenPoolTopology.java
@@ -8,9 +8,10 @@ import java.util.concurrent.ConcurrentHashMap;
 public class TokenPoolTopology {
 
 	private final ConcurrentHashMap<String, List<TokenStatus>> map = new ConcurrentHashMap<String, List<TokenStatus>>();
+	private final int replicationFactor;
 	
-	public TokenPoolTopology () {
-		
+	public TokenPoolTopology (int replicationFactor) {
+		this.replicationFactor = replicationFactor;
 	}
 	
 	public void addToken(String rack, Long token, HostConnectionPool<?> hostPool) {
@@ -27,7 +28,11 @@ public class TokenPoolTopology {
 	public ConcurrentHashMap<String, List<TokenStatus>> getAllTokens() {
 		return map;
 	}
-	
+
+	public int getReplicationFactor() {
+		return replicationFactor;
+	}
+
 	public String toString() {
 		
 		ArrayList<String> keyList = new ArrayList<String>(map.keySet());

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/exception/PoolExhaustedException.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/exception/PoolExhaustedException.java
@@ -24,11 +24,11 @@ public class PoolExhaustedException extends DynoConnectException {
 
     public PoolExhaustedException(HostConnectionPool hostConnectionPool, Throwable t) {
         super(t);
-        hcp = hostConnectionPool;
+        this.hcp = hostConnectionPool;
     }
 
     public HostConnectionPool getHostConnectionPool() {
-        return hcp;
+        return this.hcp;
     }
 }
 

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/exception/PoolExhaustedException.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/exception/PoolExhaustedException.java
@@ -1,22 +1,34 @@
 package com.netflix.dyno.connectionpool.exception;
 
-public class PoolExhaustedException extends DynoConnectException { 
+import com.netflix.dyno.connectionpool.HostConnectionPool;
 
-	/**
-	 * 
-	 */
+/**
+ * Indicates there are no connections left in the host connection pool.
+ */
+public class PoolExhaustedException extends DynoConnectException {
+
+    private final HostConnectionPool hcp;
+
 	private static final long serialVersionUID = 9081993527008721028L;
 
-	public PoolExhaustedException(String message) {
+
+	public PoolExhaustedException(HostConnectionPool hostConnectionPool, String message) {
 		super(message);
+        this.hcp = hostConnectionPool;
 	}
 
-	public PoolExhaustedException(Throwable t) {
-		super(t);
-	}
+    public PoolExhaustedException(HostConnectionPool hostConnectionPool, String message, Throwable cause) {
+        super(message, cause);
+        this.hcp = hostConnectionPool;
+    }
 
-	public PoolExhaustedException(String message, Throwable cause) {
-		super(message, cause);
-	}
+    public PoolExhaustedException(HostConnectionPool hostConnectionPool, Throwable t) {
+        super(t);
+        hcp = hostConnectionPool;
+    }
+
+    public HostConnectionPool getHostConnectionPool() {
+        return hcp;
+    }
 }
 

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/exception/PoolOfflineException.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/exception/PoolOfflineException.java
@@ -2,6 +2,9 @@ package com.netflix.dyno.connectionpool.exception;
 
 import com.netflix.dyno.connectionpool.Host;
 
+/**
+ * Indicates the pool is likely not active when accessed
+ */
 public class PoolOfflineException extends DynoConnectException {
 
 	private static final long serialVersionUID = -345340994112630363L;

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/exception/PoolTimeoutException.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/exception/PoolTimeoutException.java
@@ -1,8 +1,10 @@
 package com.netflix.dyno.connectionpool.exception;
 
 
-
-
+/**
+ * Indicates that a thread waiting to obtain a connection from the pool has timed-out while waiting; it's likely
+ * that all connections are busy servicing requests.
+ */
 public class PoolTimeoutException extends DynoConnectException implements IsRetryableException {
 
 	private static final long serialVersionUID = -8579946319118318717L;

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolConfigurationImpl.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolConfigurationImpl.java
@@ -33,7 +33,7 @@ public class ConnectionPoolConfigurationImpl implements ConnectionPoolConfigurat
 	// DEFAULTS 
 	private static final int DEFAULT_PORT = 8102; 
 	private static final int DEFAULT_MAX_CONNS_PER_HOST = 3;
-	private static final int DEFAULT_MAX_TIMEOUT_WHEN_EXHAUSTED = 2000; 
+	private static final int DEFAULT_MAX_TIMEOUT_WHEN_EXHAUSTED = 800;
 	private static final int DEFAULT_MAX_FAILOVER_COUNT = 3; 
 	private static final int DEFAULT_CONNECT_TIMEOUT = 3000; 
 	private static final int DEFAULT_SOCKET_TIMEOUT = 12000; 

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolImpl.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolImpl.java
@@ -602,14 +602,10 @@ public class ConnectionPoolImpl<CL> implements ConnectionPool<CL>, TopologyView 
             } else {
                 Logger.info("mbean " + objectName + "has already been registered !");
             }
-        } catch (MalformedObjectNameException | InstanceAlreadyExistsException ex) {
-            Logger.error("Unable to register MonitorConsole mbean ", ex);
-        } catch (MBeanRegistrationException ex) {
-            Logger.error("Unable to register MonitorConsole mbean ", ex);
-        } catch (NotCompliantMBeanException ex) {
+        } catch (MalformedObjectNameException | InstanceAlreadyExistsException | MBeanRegistrationException | NotCompliantMBeanException ex) {
             Logger.error("Unable to register MonitorConsole mbean ", ex);
         }
-    }
+	}
 
     private void unregisterMonitorConsoleMBean() {
         final MBeanServer server = ManagementFactory.getPlatformMBeanServer();
@@ -619,15 +615,11 @@ public class ConnectionPoolImpl<CL> implements ConnectionPool<CL>, TopologyView 
                 server.unregisterMBean(objectName);
                 Logger.info("unregistered mbean " + objectName);
             }
-        } catch (MalformedObjectNameException ex) {
-            Logger.error("Unable to unregister MonitorConsole mbean ", ex);
-        } catch (MBeanRegistrationException ex) {
-            Logger.error("Unable to unregister MonitorConsole mbean ", ex);
-        } catch (InstanceNotFoundException ex) {
+        } catch (MalformedObjectNameException | MBeanRegistrationException | InstanceNotFoundException ex) {
             Logger.error("Unable to unregister MonitorConsole mbean ", ex);
         }
 
-    }
+	}
 	
 	private HostSelectionWithFallback<CL> initSelectionStrategy() {
 		

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/CountingConnectionPoolMonitor.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/CountingConnectionPoolMonitor.java
@@ -47,7 +47,7 @@ public class CountingConnectionPoolMonitor implements ConnectionPoolMonitor {
     private final AtomicLong connectionReturnCount  = new AtomicLong();
     private final AtomicLong operationFailoverCount = new AtomicLong();
 
-    //private final AtomicLong poolTimeoutCount      = new AtomicLong();
+    private final AtomicLong poolTimeoutCount       = new AtomicLong();
     private final AtomicLong poolExhastedCount      = new AtomicLong();
     private final AtomicLong operationTimeoutCount  = new AtomicLong();
     private final AtomicLong socketTimeoutCount     = new AtomicLong();
@@ -72,7 +72,7 @@ public class CountingConnectionPoolMonitor implements ConnectionPoolMonitor {
     private void trackError(Host host, Exception reason) {
     	if (reason != null) {
     		if (reason instanceof PoolTimeoutException) {
-    			this.poolExhastedCount.incrementAndGet();
+    			this.poolTimeoutCount.incrementAndGet();
     		} else if (reason instanceof PoolExhaustedException) {
         	        this.poolExhastedCount.incrementAndGet();
     		} else if (reason instanceof TimeoutException) {

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/HostConnectionPoolImpl.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/HostConnectionPoolImpl.java
@@ -23,6 +23,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
+import com.netflix.dyno.connectionpool.exception.PoolExhaustedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -108,6 +109,9 @@ public class HostConnectionPoolImpl<CL> implements HostConnectionPool<CL> {
 
 	@Override
 	public void markAsDown(DynoException reason) {
+        if (Logger.isDebugEnabled()) {
+            Logger.debug(String.format("Marking Host Connection Pool %s DOWN", getHost()));
+        }
 		
 		ConnectionPoolState<CL> currentState = cpState.get();
 		
@@ -304,7 +308,7 @@ public class HostConnectionPoolImpl<CL> implements HostConnectionPool<CL> {
                     }
 				}
 				monitor.incConnectionCreateFailed(host, e);
-				throw new DynoConnectException(e);
+				throw new DynoConnectException(e); // TODO - FatalConnectionException ?
 			}
 		}
 
@@ -350,7 +354,14 @@ public class HostConnectionPoolImpl<CL> implements HostConnectionPool<CL> {
 		@Override
 		public Connection<CL> borrowConnection(int duration, TimeUnit unit) {
 
-			// Start recording how long it takes to get the connection - for insight/metrics
+            if (numActiveConnections.get() < 1) {
+                // Need to throw something other than DynoConnectException in order to bubble past HostSelectionWithFallback
+                // Is that the right thing to do ???
+                throw new PoolExhaustedException(HostConnectionPoolImpl.this,
+                        "Fast fail - NO ACTIVE CONNECTIONS in pool").setHost(getHost());
+            }
+
+            // Start recording how long it takes to get the connection - for insight/metrics
 			long startTime = System.nanoTime()/1000;
 
 			Connection<CL> conn = null;
@@ -359,15 +370,15 @@ public class HostConnectionPoolImpl<CL> implements HostConnectionPool<CL> {
 				conn = availableConnections.poll(duration, unit);
 			} catch (InterruptedException e) {
 				Logger.info("Thread interrupted when waiting on connections");
-				throw new DynoConnectException(e);
+				throw new DynoConnectException(e); // TODO Change this to DynoBorrowedConnectionException(e)
 			}
 
 			long delay = System.nanoTime()/1000 - startTime;
 
 			if (conn == null) {
-				throw new PoolTimeoutException("Fast fail waiting for connection from pool")
-				.setHost(getHost())
-				.setLatency(delay);
+                throw new PoolTimeoutException("Fast fail waiting for connection from pool")
+                        .setHost(getHost())
+                        .setLatency(delay);
 			}
 
             monitor.incConnectionBorrowed(host, delay);
@@ -421,22 +432,22 @@ public class HostConnectionPoolImpl<CL> implements HostConnectionPool<CL> {
 
 		@Override
 		public Connection<CL> createConnection() {
-			throw new DynoConnectException("Pool must be inited first");
+			throw new DynoConnectException("Pool must be initialized first");
 		}
 
 		@Override
 		public Connection<CL> borrowConnection(int duration, TimeUnit unit) {
-			throw new DynoConnectException("Pool must be inited first");
+			throw new DynoConnectException("Pool must be initialized first");
 		}
 
 		@Override
 		public boolean returnConnection(Connection<CL> connection) {
-			throw new DynoConnectException("Pool must be inited first");
+			throw new DynoConnectException("Pool must be initialized first");
 		}
 
 		@Override
 		public boolean closeConnection(Connection<CL> connection) {
-			throw new DynoConnectException("Pool must be inited first");
+			throw new DynoConnectException("Pool must be initialized first");
 		}
 	}
 	

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/HostConnectionPoolImpl.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/HostConnectionPoolImpl.java
@@ -308,7 +308,7 @@ public class HostConnectionPoolImpl<CL> implements HostConnectionPool<CL> {
                     }
 				}
 				monitor.incConnectionCreateFailed(host, e);
-				throw new DynoConnectException(e); // TODO - FatalConnectionException ?
+				throw new DynoConnectException(e);
 			}
 		}
 
@@ -370,7 +370,7 @@ public class HostConnectionPoolImpl<CL> implements HostConnectionPool<CL> {
 				conn = availableConnections.poll(duration, unit);
 			} catch (InterruptedException e) {
 				Logger.info("Thread interrupted when waiting on connections");
-				throw new DynoConnectException(e); // TODO Change this to DynoBorrowedConnectionException(e)
+				throw new DynoConnectException(e);
 			}
 
 			long delay = System.nanoTime()/1000 - startTime;

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/HostSelectionStrategy.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/HostSelectionStrategy.java
@@ -42,7 +42,7 @@ public interface HostSelectionStrategy<CL> {
 	 * @return
 	 * @throws NoAvailableHostsException
 	 */
-	public HostConnectionPool<CL> getPoolForOperation(BaseOperation<CL, ?> op) throws NoAvailableHostsException;
+	HostConnectionPool<CL> getPoolForOperation(BaseOperation<CL, ?> op) throws NoAvailableHostsException;
 
 	/**
 	 * 
@@ -50,20 +50,20 @@ public interface HostSelectionStrategy<CL> {
 	 * @return
 	 * @throws NoAvailableHostsException
 	 */
-	public Map<HostConnectionPool<CL>,BaseOperation<CL,?>> getPoolsForOperationBatch(Collection<BaseOperation<CL, ?>> ops) throws NoAvailableHostsException;
+	Map<HostConnectionPool<CL>,BaseOperation<CL,?>> getPoolsForOperationBatch(Collection<BaseOperation<CL, ?>> ops) throws NoAvailableHostsException;
 	
 	/**
 	 * 
 	 * @return
 	 */
-	public List<HostConnectionPool<CL>> getOrderedHostPools();
+	List<HostConnectionPool<CL>> getOrderedHostPools();
 	
 	/**
 	 * 
 	 * @param token
 	 * @return
 	 */
-	public HostConnectionPool<CL> getPoolForToken(Long token);
+	HostConnectionPool<CL> getPoolForToken(Long token);
 	
 	/**
 	 * 
@@ -71,7 +71,7 @@ public interface HostSelectionStrategy<CL> {
 	 * @param end
 	 * @return
 	 */
-	public List<HostConnectionPool<CL>> getPoolsForTokens(Long start, Long end);
+	List<HostConnectionPool<CL>> getPoolsForTokens(Long start, Long end);
 
     /**
      * Finds the server Host that owns the specified key.
@@ -86,7 +86,7 @@ public interface HostSelectionStrategy<CL> {
 	 * Init the connection pool with the set of hosts provided
 	 * @param hostPools
 	 */
-	public void initWithHosts(Map<HostToken, HostConnectionPool<CL>> hostPools);
+	void initWithHosts(Map<HostToken, HostConnectionPool<CL>> hostPools);
 	
 	/**
 	 * Add a host to the selection strategy. This is useful when the underlying dynomite topology changes.
@@ -94,14 +94,16 @@ public interface HostSelectionStrategy<CL> {
 	 * @param hostPool
 	 * @return true/false indicating whether the pool was indeed added
 	 */
-	public boolean addHostPool(HostToken host, HostConnectionPool<CL> hostPool);
+	boolean addHostPool(HostToken host, HostConnectionPool<CL> hostPool);
 	
 	/**
 	 * Remove a host from the selection strategy. This is useful when the underlying dynomite topology changes.
 	 * @param HostToken
 	 * @return true/false indicating whether the pool was indeed removed
 	 */
-	public boolean removeHostPool(HostToken host);
+	boolean removeHostPool(HostToken host);
+
+	boolean isTokenAware();
 
 	public static interface HostSelectionStrategyFactory<CL> {
 		

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/MonitorConsole.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/MonitorConsole.java
@@ -159,6 +159,7 @@ public class MonitorConsole implements MonitorConsoleMBean {
             config.put("socketTimeout", String.valueOf(cpConfig.getSocketTimeout()));
             config.put("timingCountersResetFrequencyInSecs",
                     String.valueOf(cpConfig.getTimingCountersResetFrequencySeconds()));
+            config.put("replicationFactor", String.valueOf(pool.getTopology().getReplicationFactor()));
 
             return Collections.unmodifiableMap(config);
         }

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/health/SimpleErrorMonitorImpl.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/health/SimpleErrorMonitorImpl.java
@@ -44,5 +44,7 @@ public class SimpleErrorMonitorImpl implements ErrorMonitor {
 		public ErrorMonitor createErrorMonitor() {
 			return new SimpleErrorMonitorImpl(threshold);
 		}
+
+		// TODO add setter and keep error threshold in sync with maxConnsPerHost OR switch to error rate monitor
 	}
 }

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/lb/HostSelectionWithFallback.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/lb/HostSelectionWithFallback.java
@@ -120,9 +120,14 @@ public class HostSelectionWithFallback<CL> {
 			try { 
 				return hostPool.borrowConnection(duration, unit);
 			} catch (DynoConnectException e) {
-				lastEx = e;
-				cpMonitor.incOperationFailure(null, e);
-				useFallback = true;
+				if (e instanceof PoolExhaustedException) {
+                    // Don't failover, re-throw so the health tracker records it
+                    throw e;
+                }
+                lastEx = e;
+                cpMonitor.incOperationFailure(null, e);
+                useFallback = true;
+
 			}
 		}
 		

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/lb/RoundRobinSelection.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/lb/RoundRobinSelection.java
@@ -142,7 +142,12 @@ public class RoundRobinSelection<CL> implements HostSelectionStrategy<CL> {
 		}
 		return prevPool != null;
 	}
-	
+
+	@Override
+	public boolean isTokenAware() {
+		return false;
+	}
+
 	public String toString() {
 		return "RoundRobinSelector: list: " + circularList.toString();
 	}

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/lb/TokenAwareSelection.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/lb/TokenAwareSelection.java
@@ -134,6 +134,11 @@ public class TokenAwareSelection<CL> implements HostSelectionStrategy<CL> {
 		}
 	}
 
+	@Override
+	public boolean isTokenAware() {
+		return true;
+	}
+
 	public Long getKeyHash(String key) {
 		Long keyHash = tokenMapper.hash(key);
 		return keyHash;

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/CountingConnectionPoolMonitorTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/CountingConnectionPoolMonitorTest.java
@@ -36,7 +36,7 @@ public class CountingConnectionPoolMonitorTest {
 		counter.incOperationFailure(host2, null);
 
 		counter.incOperationFailure(host2, new PoolTimeoutException(""));
-		counter.incOperationFailure(host2, new PoolExhaustedException(""));
+		counter.incOperationFailure(host2, new PoolExhaustedException(null, ""));
 		counter.incOperationFailure(host2, new NoAvailableHostsException(""));
 
 		// VERIFY COUNTS

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/lb/HostSelectionWithFallbackTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/lb/HostSelectionWithFallbackTest.java
@@ -326,6 +326,65 @@ public class HostSelectionWithFallbackTest {
 		verifyExactly(hostnames, "h5", "h6");
 	}
 
+	@Test
+    public void testReplicationFactorOf3() {
+		cpConfig.setLoadBalancingStrategy(LoadBalancingStrategy.TokenAware);
+		cpConfig.withTokenSupplier(getTokenMapSupplier());
+
+		HostSelectionWithFallback<Integer> selection = new HostSelectionWithFallback<Integer>(cpConfig, cpMonitor);
+
+        List<HostToken> hostTokens = Arrays.asList(
+                new HostToken(1111L, h1),
+                new HostToken(2222L, h2),
+                new HostToken(1111L, h3),
+                new HostToken(1111L, h4),
+                new HostToken(2222L, h5),
+                new HostToken(2222L, h6)
+        );
+
+		int rf = selection.calculateReplicationFactor(hostTokens);
+
+        Assert.assertEquals(3, rf);
+	}
+
+    @Test
+    public void testReplicationFactorOf2() {
+        cpConfig.setLoadBalancingStrategy(LoadBalancingStrategy.TokenAware);
+        cpConfig.withTokenSupplier(getTokenMapSupplier());
+
+        HostSelectionWithFallback<Integer> selection = new HostSelectionWithFallback<Integer>(cpConfig, cpMonitor);
+
+        List<HostToken> hostTokens = Arrays.asList(
+                new HostToken(1111L, h1),
+                new HostToken(2222L, h2),
+                new HostToken(1111L, h3),
+                new HostToken(2222L, h5)
+        );
+
+        int rf = selection.calculateReplicationFactor(hostTokens);
+
+        Assert.assertEquals(2, rf);
+    }
+
+    @Test
+    public void testReplicationFactorOf1() {
+        cpConfig.setLoadBalancingStrategy(LoadBalancingStrategy.TokenAware);
+        cpConfig.withTokenSupplier(getTokenMapSupplier());
+
+        HostSelectionWithFallback<Integer> selection = new HostSelectionWithFallback<Integer>(cpConfig, cpMonitor);
+
+        List<HostToken> hostTokens = Arrays.asList(
+                new HostToken(1111L, h1),
+                new HostToken(2222L, h2),
+                new HostToken(3333L, h3),
+                new HostToken(4444L, h4)
+        );
+
+        int rf = selection.calculateReplicationFactor(hostTokens);
+
+        Assert.assertEquals(1, rf);
+    }
+
 	private Collection<String> runConnectionsToRingTest(HostSelectionWithFallback<Integer> selection) {
 
 		Collection<Connection<Integer>> connections = selection.getConnectionsToRing(10, TimeUnit.MILLISECONDS);


### PR DESCRIPTION
**Detailed Description**
The 1.4.0 release discards connections that encounter socket exceptions due to an insidious underlying buffer issue. If the dynomite connection is severed while all connections are in use all of them will be discarded and the pool will not replenish itself immediately. The result is that all requests will fail-over to a secondary AZ. The fail-over is by design and the correct behavior and if the HostSupplier notifies the client that dynomite is Down, all is well. If the network connection simply had an issue and Dynomite is actually UP, then the HostSupplier will not notify the client and the pool will never replenish its connections to that host.

This is particularly problematic if the client application has wrapped the dyno client call in a load-shedding layer such as Hystrix and left the default timeouts in place (Hystrix is 1 second, Dyno client timeout default is 2 seconds) therefore since the client app timeout fires first the fallback for dyno client does not occur and all requests fail.

**Solution**
Detect when the pool is exhausted and notify the health tracker which will immediately put the pool into a reconnect state after which, all of the client's current reconnect + failover logic will apply.