### PR TITLE
Track connection pools via the MonitorConsole.

### DIFF
--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/MonitorConsole.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/MonitorConsole.java
@@ -54,8 +54,17 @@ public class MonitorConsole implements MonitorConsoleMBean {
 	}
 	
 	public void registerConnectionPool(ConnectionPoolImpl<?> cp) {
-		connectionPools.put(cp.getName(), cp);
-		addMonitorConsole(cp.getName(), cp.getMonitor());
+        ConnectionPoolImpl<?> cpImpl = connectionPools.putIfAbsent(cp.getName(), cp);
+
+        if (cpImpl != null) {
+            // Need a unique id, so append a timestamp
+            String name = cp.getName() + System.currentTimeMillis();
+            connectionPools.put(name, cp);
+            addMonitorConsole(name, cp.getMonitor());
+        } else {
+            addMonitorConsole(cp.getName(), cp.getMonitor());
+        }
+
 	}
 
     @Override


### PR DESCRIPTION
**Description**
Since the Dyno client is not a singleton (by design) there have been instances where client applications were instantiating a Dyno client per application thread but did not realize they were doing so. The code in the monitor console uses the connection pool name and relies on it to be unique.

**Resolution**
Ensure the name is unique and if not, make it so by appending the current system time to the name. The names can be discovered using `MonitorConsole.getMonitorNames()`. Note this does not affect metrics reporting or anything else; the scope of this is confined to the Monitor Console only.