### PR TITLE
RF=2 metrics bug fix

### DIFF
--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/TokenPoolTopology.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/TokenPoolTopology.java
@@ -33,6 +33,14 @@ public class TokenPoolTopology {
 		return replicationFactor;
 	}
 
+	public TokenStatus getTokensForRack(String rack) {
+		if (map.containsKey(rack)) {
+			map.get(rack);
+		}
+
+		return null;
+	}
+
 	public String toString() {
 		
 		ArrayList<String> keyList = new ArrayList<String>(map.keySet());
@@ -52,7 +60,7 @@ public class TokenPoolTopology {
 		
 		return sb.toString();
 	}
-	
+
 	public static class TokenStatus implements Comparable<TokenStatus> {
 		
 		private Long token; 

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/HostSelectionStrategy.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/HostSelectionStrategy.java
@@ -15,18 +15,16 @@
  ******************************************************************************/
 package com.netflix.dyno.connectionpool.impl;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
-
 import com.netflix.dyno.connectionpool.BaseOperation;
 import com.netflix.dyno.connectionpool.Connection;
 import com.netflix.dyno.connectionpool.Host;
 import com.netflix.dyno.connectionpool.HostConnectionPool;
 import com.netflix.dyno.connectionpool.exception.NoAvailableHostsException;
-import com.netflix.dyno.connectionpool.exception.PoolExhaustedException;
 import com.netflix.dyno.connectionpool.impl.lb.HostToken;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Interface that encapsulates a strategy for selecting a {@link Connection} to a {@link Host} for the given {@link BaseOperation}
@@ -90,7 +88,7 @@ public interface HostSelectionStrategy<CL> {
 	
 	/**
 	 * Add a host to the selection strategy. This is useful when the underlying dynomite topology changes.
-	 * @param HostToken
+	 * @param {@link com.netflix.dyno.connectionpool.impl.lb.HostToken}
 	 * @param hostPool
 	 * @return true/false indicating whether the pool was indeed added
 	 */
@@ -98,14 +96,16 @@ public interface HostSelectionStrategy<CL> {
 	
 	/**
 	 * Remove a host from the selection strategy. This is useful when the underlying dynomite topology changes.
-	 * @param HostToken
+	 * @param {@link com.netflix.dyno.connectionpool.impl.lb.HostToken}
 	 * @return true/false indicating whether the pool was indeed removed
 	 */
 	boolean removeHostPool(HostToken host);
 
 	boolean isTokenAware();
 
-	public static interface HostSelectionStrategyFactory<CL> {
+	boolean isEmpty();
+
+	interface HostSelectionStrategyFactory<CL> {
 		
 		/**
 		 * Create/Return a HostSelectionStrategy 

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/lb/RoundRobinSelection.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/lb/RoundRobinSelection.java
@@ -148,6 +148,11 @@ public class RoundRobinSelection<CL> implements HostSelectionStrategy<CL> {
 		return false;
 	}
 
+	@Override
+	public boolean isEmpty() {
+		return tokenPools.isEmpty();
+	}
+
 	public String toString() {
 		return "RoundRobinSelector: list: " + circularList.toString();
 	}

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/lb/TokenAwareSelection.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/lb/TokenAwareSelection.java
@@ -32,7 +32,7 @@ import com.netflix.dyno.connectionpool.impl.utils.CollectionUtils;
 import com.netflix.dyno.connectionpool.impl.utils.CollectionUtils.Transform;
 
 /**
- * Simple class that implements {@link HostSelectionStrategy} using the TOKEN AWARE algorithm. 
+ * Concrete implementation of the {@link HostSelectionStrategy} interface using the TOKEN AWARE algorithm.
  * Note that this component needs to be aware of the dynomite ring topology to be able to 
  * successfully map to the correct token owner for any key of an {@link Operation}
  * 

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/lb/TokenAwareSelection.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/lb/TokenAwareSelection.java
@@ -139,6 +139,11 @@ public class TokenAwareSelection<CL> implements HostSelectionStrategy<CL> {
 		return true;
 	}
 
+	@Override
+	public boolean isEmpty() {
+		return tokenPools.isEmpty();
+	}
+
 	public Long getKeyHash(String key) {
 		Long keyHash = tokenMapper.hash(key);
 		return keyHash;


### PR DESCRIPTION
When the server topology has replication factor of 2 AND there are dyno client instances that are located in a rack that has no corresponding dynomite hosts, the failover metrics are not accurate since every request is viewed as failing over to a remote rack.

For example, if dynomite hosts are in us-east-1c and us-east-1d but dyno client instances are in 1c, 1d, **and also 1e** all requests from dyno client instances in 1e would be recorded as failover requests.

This PR fixes this issue.