### PR TITLE
Cross-zone (rack) fallback implementation

### DIFF
--- a/dyno-contrib/src/main/java/com/netflix/dyno/contrib/ArchaiusConnectionPoolConfiguration.java
+++ b/dyno-contrib/src/main/java/com/netflix/dyno/contrib/ArchaiusConnectionPoolConfiguration.java
@@ -43,7 +43,7 @@ public class ArchaiusConnectionPoolConfiguration extends ConnectionPoolConfigura
 	private final DynamicIntProperty connectTimeout;
 	private final DynamicIntProperty socketTimeout;
 	private final DynamicIntProperty poolShutdownDelay;
-	private final DynamicBooleanProperty localDcAffinity;
+	private final DynamicBooleanProperty localZoneAffinity;
 	private final DynamicIntProperty resetTimingsFrequency;
     private final DynamicStringProperty configPublisherConfig;
     private final DynamicIntProperty compressionThreshold;
@@ -66,7 +66,7 @@ public class ArchaiusConnectionPoolConfiguration extends ConnectionPoolConfigura
 		connectTimeout = DynamicPropertyFactory.getInstance().getIntProperty(propertyPrefix + ".connection.connectTimeout", super.getConnectTimeout());
 		socketTimeout = DynamicPropertyFactory.getInstance().getIntProperty(propertyPrefix + ".connection.socketTimeout", super.getSocketTimeout());
 		poolShutdownDelay = DynamicPropertyFactory.getInstance().getIntProperty(propertyPrefix + ".connection.poolShutdownDelay", super.getPoolShutdownDelay());
-		localDcAffinity = DynamicPropertyFactory.getInstance().getBooleanProperty(propertyPrefix + ".connection.localDcAffinity", super.localDcAffinity());
+		localZoneAffinity = DynamicPropertyFactory.getInstance().getBooleanProperty(propertyPrefix + ".connection.localZoneAffinity", super.localZoneAffinity());
 		resetTimingsFrequency = DynamicPropertyFactory.getInstance().getIntProperty(propertyPrefix + ".connection.metrics.resetFrequencySeconds", super.getTimingCountersResetFrequencySeconds());
         configPublisherConfig = DynamicPropertyFactory.getInstance().getStringProperty(propertyPrefix + ".config.publisher.address", super.getConfigurationPublisherConfig());
 		failOnStartupIfNoHosts = DynamicPropertyFactory.getInstance().getBooleanProperty(propertyPrefix + ".config.startup.failIfNoHosts", super.getFailOnStartupIfNoHosts());
@@ -127,8 +127,8 @@ public class ArchaiusConnectionPoolConfiguration extends ConnectionPoolConfigura
 	}
 
 	@Override
-	public boolean localDcAffinity() {
-		return localDcAffinity.get();
+	public boolean localZoneAffinity() {
+		return localZoneAffinity.get();
 	}
 	
 	@Override

--- a/dyno-contrib/src/main/java/com/netflix/dyno/contrib/EurekaHostsSupplier.java
+++ b/dyno-contrib/src/main/java/com/netflix/dyno/contrib/EurekaHostsSupplier.java
@@ -24,7 +24,7 @@ import com.netflix.dyno.connectionpool.HostSupplier;
  * Simple class that implements {@link Supplier}<{@link List}<{@link Host}>>. It provides a List<{@link Host}>
  * using the {@link DiscoveryManager} which is the eureka client. 
  * 
- * Note that the class needs the eureka application name to discover all instances for that application. 
+ * Note that the class needs the eureka application name to discover all instances for that application.
  * 
  * @author poberai
  */
@@ -32,7 +32,7 @@ public class EurekaHostsSupplier implements HostSupplier {
 
 	private static final Logger Logger = LoggerFactory.getLogger(EurekaHostsSupplier.class);
 
-	// The C* cluster name for discovering nodes
+	// The Dynomite cluster name for discovering nodes
 	private final String applicationName;
 	private final DiscoveryClient discoveryClient;
 	

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/ConnectionPoolConfiguration.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/ConnectionPoolConfiguration.java
@@ -87,7 +87,7 @@ public interface ConnectionPoolConfiguration {
      * 
      * @return
      */
-    boolean localDcAffinity();
+    boolean localZoneAffinity();
     
     /**
      * 
@@ -123,7 +123,9 @@ public interface ConnectionPoolConfiguration {
      * 
      * @return
      */
-    String getLocalDC();
+    String getLocalRack();
+
+    String getLocalDataCenter();
 
     /**
      * Returns the amount of time the histogram accumulates data before it is cleared, in seconds.

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/Host.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/Host.java
@@ -76,8 +76,8 @@ public class Host {
 		return rack;
 	}
 	
-	public Host setRack(String datacenter) {
-		this.rack = datacenter;
+	public Host setRack(String rack) {
+		this.rack = rack;
 		return this;
 	}
 	
@@ -123,6 +123,6 @@ public class Host {
 
 	@Override
 	public String toString() {
-		return "Host [name=" + name + ", port=" + port + ", dc: " + rack + ", status: " + status.name() + "]";
+		return "Host [name=" + name + ", port=" + port + ", rack: " + rack + ", status: " + status.name() + "]";
 	}
 }

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/HostConnectionPool.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/HostConnectionPool.java
@@ -41,7 +41,7 @@ import com.netflix.dyno.connectionpool.exception.DynoException;
  *     </ol>
  *     
  * This class is intended to be used within a collection of {@link HostConnectionPool} tracked by a
- * {@link ConnectionPool} for all the {@link Host}(s) within a cassandra cluster. 
+ * {@link ConnectionPool} for all the {@link Host}(s) within a Dynomite cluster.
  * 
  * @see {@link ConnectionPool} for references to this class.
  *  

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/RetryPolicy.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/RetryPolicy.java
@@ -47,7 +47,7 @@ public interface RetryPolicy {
      * Ask the policy is a retry can use a remote dc 
      * @return boolean
      */
-    boolean allowRemoteDCFallback();
+    boolean allowCrossZoneFallback();
     
     /**
      * Return the number of attempts since begin was called

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/TokenPoolTopology.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/TokenPoolTopology.java
@@ -33,9 +33,9 @@ public class TokenPoolTopology {
 		return replicationFactor;
 	}
 
-	public TokenStatus getTokensForRack(String rack) {
+	public List<TokenStatus> getTokensForRack(String rack) {
 		if (rack != null && map.containsKey(rack)) {
-			map.get(rack);
+			return map.get(rack);
 		}
 
 		return null;

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolConfigurationImpl.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolConfigurationImpl.java
@@ -62,9 +62,10 @@ public class ConnectionPoolConfigurationImpl implements ConnectionPoolConfigurat
 	private int poolShutdownDelay = DEFAULT_POOL_SHUTDOWN_DELAY; 
 	private int pingFrequencySeconds = DEFAULT_PING_FREQ_SECONDS;
 	private int flushTimingsFrequencySeconds = DEFAULT_FLUSH_TIMINGS_FREQ_SECONDS;
-	private boolean localDcAffinity = DEFAULT_LOCAL_DC_AFFINITY;
+	private boolean localZoneAffinity = DEFAULT_LOCAL_DC_AFFINITY;
 	private LoadBalancingStrategy lbStrategy = DEFAULT_LB_STRATEGY; 
-	private String localDC;
+	private String localRack;
+	private String localDataCenter;
     private String configPublisherAddress = DEFAULT_CONFIG_PUBLISHER_ADDRESS;
     private boolean failOnStartupIfNoHosts = DEFAULT_FAIL_ON_STARTUP_IFNOHOSTS;
     private int failOnStarupIfNoHostsSeconds = DEFAULT_FAIL_ON_STARTUP_IFNOHOSTS_SECONDS;
@@ -83,7 +84,8 @@ public class ConnectionPoolConfigurationImpl implements ConnectionPoolConfigurat
 	
 	public ConnectionPoolConfigurationImpl(String name) {
 		this.name = name;
-		this.localDC = ConfigUtils.getLocalZone();
+		this.localRack = ConfigUtils.getLocalZone();
+		this.localDataCenter = ConfigUtils.getDataCenter();
 	}
 	
 	@Override
@@ -137,8 +139,8 @@ public class ConnectionPoolConfigurationImpl implements ConnectionPoolConfigurat
 	}
 
 	@Override
-	public boolean localDcAffinity() {
-		return localDcAffinity;
+	public boolean localZoneAffinity() {
+		return localZoneAffinity;
 	}
 
 	@Override
@@ -157,8 +159,13 @@ public class ConnectionPoolConfigurationImpl implements ConnectionPoolConfigurat
 	}
 
     @Override
-    public String getLocalDC() {
-        return localDC;
+    public String getLocalRack() {
+        return localRack;
+    }
+
+    @Override
+    public String getLocalDataCenter() {
+        return localDataCenter;
     }
 
     @Override
@@ -236,8 +243,8 @@ public class ConnectionPoolConfigurationImpl implements ConnectionPoolConfigurat
 		return this;
 	}
 
-	public ConnectionPoolConfigurationImpl setLocalDcAffinity(boolean condition) {
-		localDcAffinity = condition;
+	public ConnectionPoolConfigurationImpl setLocalZoneAffinity(boolean condition) {
+		localZoneAffinity = condition;
 		return this;
 	}
 
@@ -350,9 +357,14 @@ public class ConnectionPoolConfigurationImpl implements ConnectionPoolConfigurat
 		}
 	}
 
-    public ConnectionPoolConfigurationImpl setLocalDC(String dc) {
-		this.localDC = dc;
+    public ConnectionPoolConfigurationImpl setLocalRack(String rack) {
+		this.localRack = rack;
 		return this;
 	}
+
+    public ConnectionPoolConfigurationImpl setLocalDataCenter(String dc) {
+        this.localRack = dc;
+        return this;
+    }
 
 }

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolConfigurationImpl.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolConfigurationImpl.java
@@ -40,7 +40,7 @@ public class ConnectionPoolConfigurationImpl implements ConnectionPoolConfigurat
 	private static final int DEFAULT_POOL_SHUTDOWN_DELAY = 60000; 
 	private static final int DEFAULT_PING_FREQ_SECONDS = 30;
 	private static final int DEFAULT_FLUSH_TIMINGS_FREQ_SECONDS = 300;
-	private static final boolean DEFAULT_LOCAL_DC_AFFINITY = true; 
+	private static final boolean DEFAULT_LOCAL_RACK_AFFINITY = true;
 	private static final LoadBalancingStrategy DEFAULT_LB_STRATEGY = LoadBalancingStrategy.TokenAware;
 	private static final CompressionStrategy DEFAULT_COMPRESSION_STRATEGY = CompressionStrategy.NONE;
     private static final String DEFAULT_CONFIG_PUBLISHER_ADDRESS = null;
@@ -62,7 +62,7 @@ public class ConnectionPoolConfigurationImpl implements ConnectionPoolConfigurat
 	private int poolShutdownDelay = DEFAULT_POOL_SHUTDOWN_DELAY; 
 	private int pingFrequencySeconds = DEFAULT_PING_FREQ_SECONDS;
 	private int flushTimingsFrequencySeconds = DEFAULT_FLUSH_TIMINGS_FREQ_SECONDS;
-	private boolean localZoneAffinity = DEFAULT_LOCAL_DC_AFFINITY;
+	private boolean localZoneAffinity = DEFAULT_LOCAL_RACK_AFFINITY;
 	private LoadBalancingStrategy lbStrategy = DEFAULT_LB_STRATEGY; 
 	private String localRack;
 	private String localDataCenter;

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolImpl.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolImpl.java
@@ -285,12 +285,13 @@ public class ConnectionPoolImpl<CL> implements ConnectionPool<CL>, TopologyView 
 			Connection<CL> connection = null;
 			
 			try {
-					connection = selectionStrategy.getConnectionUsingRetryPolicy(
-                            op,
-                            cpConfiguration.getMaxTimeoutWhenExhausted(),
-                            TimeUnit.MILLISECONDS,
-                            retry
-                    );
+					connection =
+                            selectionStrategy.getConnectionUsingRetryPolicy(
+                                    op,
+                                    cpConfiguration.getMaxTimeoutWhenExhausted(),
+                                    TimeUnit.MILLISECONDS,
+                                    retry
+                            );
 
 				OperationResult<R> result = connection.execute(op);
 				

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolImpl.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolImpl.java
@@ -250,7 +250,7 @@ public class ConnectionPoolImpl<CL> implements ConnectionPool<CL>, TopologyView 
 
 	@Override
 	public Future<Boolean> updateHosts(Collection<Host> hostsUp, Collection<Host> hostsDown) {
-		Logger.debug("Updating hosts: UP=%s, DOWN=%s", hostsUp, hostsDown);
+		Logger.debug(String.format("Updating hosts: UP=%s, DOWN=%s", hostsUp, hostsDown));
 		boolean condition = false;
 		if (hostsUp != null && !hostsUp.isEmpty()) {
 			for (Host hostUp : hostsUp) {
@@ -284,9 +284,13 @@ public class ConnectionPoolImpl<CL> implements ConnectionPool<CL>, TopologyView 
 		do  {
 			Connection<CL> connection = null;
 			
-			try { 
-					connection = 
-							selectionStrategy.getConnection(op, cpConfiguration.getMaxTimeoutWhenExhausted(), TimeUnit.MILLISECONDS);
+			try {
+					connection = selectionStrategy.getConnectionUsingRetryPolicy(
+                            op,
+                            cpConfiguration.getMaxTimeoutWhenExhausted(),
+                            TimeUnit.MILLISECONDS,
+                            retry
+                    );
 
 				OperationResult<R> result = connection.execute(op);
 				

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/MonitorConsole.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/MonitorConsole.java
@@ -156,7 +156,7 @@ public class MonitorConsole implements MonitorConsoleMBean {
             final Map<String, String> config = new LinkedHashMap<>();
 
             // Rather than use reflection to iterate and find getters, simply provide the base configuration
-            config.put("localRack", cpConfig.getLocalDC());
+            config.put("localRack", cpConfig.getLocalRack());
             config.put("compressionStrategy", cpConfig.getCompressionStrategy().name());
             config.put("compressionThreshold", String.valueOf(cpConfig.getValueCompressionThreshold()));
             config.put("connectTimeout", String.valueOf(cpConfig.getConnectTimeout()));
@@ -169,6 +169,8 @@ public class MonitorConsole implements MonitorConsoleMBean {
             config.put("timingCountersResetFrequencyInSecs",
                     String.valueOf(cpConfig.getTimingCountersResetFrequencySeconds()));
             config.put("replicationFactor", String.valueOf(pool.getTopology().getReplicationFactor()));
+            config.put("retryPolicy", pool.getConfiguration().getRetryPolicyFactory().getRetryPolicy().toString());
+            config.put("localRackAffinity", String.valueOf(pool.getConfiguration().localZoneAffinity()));
 
             return Collections.unmodifiableMap(config);
         }

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/RetryNTimes.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/RetryNTimes.java
@@ -66,7 +66,16 @@ public class RetryNTimes implements RetryPolicy {
 	public boolean allowCrossZoneFallback() {
 		return allowCrossZoneFallback;
 	}
-	
+
+	@Override
+	public String toString() {
+		return "RetryNTimes{" +
+				"n=" + n +
+				", count=" + count +
+				", allowCrossZoneFallback=" + allowCrossZoneFallback +
+				'}';
+	}
+
 	public static class RetryFactory implements RetryPolicyFactory {
 		
 		int n; 

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/RetryNTimes.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/RetryNTimes.java
@@ -31,11 +31,11 @@ public class RetryNTimes implements RetryPolicy {
 
 	private int n; 
 	private final AtomicInteger count = new AtomicInteger(0);
-	private final boolean allowRemoteDCFallback; 
+	private final boolean allowCrossZoneFallback;
 	
 	public RetryNTimes(int n, boolean allowFallback) {
 		this.n = n;
-		this.allowRemoteDCFallback = allowFallback;
+		this.allowCrossZoneFallback = allowFallback;
 	}
 
 	@Override
@@ -63,14 +63,14 @@ public class RetryNTimes implements RetryPolicy {
 	}
 
 	@Override
-	public boolean allowRemoteDCFallback() {
-		return allowRemoteDCFallback;
+	public boolean allowCrossZoneFallback() {
+		return allowCrossZoneFallback;
 	}
 	
 	public static class RetryFactory implements RetryPolicyFactory {
 		
 		int n; 
-		boolean allowDCFallback;
+		boolean allowCrossZoneFallback;
 		
 		public RetryFactory(int n) {
 			this(n, true);
@@ -78,12 +78,20 @@ public class RetryNTimes implements RetryPolicy {
 		
 		public RetryFactory(int n, boolean allowFallback) {
 			this.n = n;
-			this.allowDCFallback = allowFallback;
+			this.allowCrossZoneFallback = allowFallback;
 		}
 		
 		@Override
 		public RetryPolicy getRetryPolicy() {
-			return new RetryNTimes(n, allowDCFallback);
+			return new RetryNTimes(n, allowCrossZoneFallback);
+		}
+
+		@Override
+		public String toString() {
+			return "RetryFactory{" +
+					"n=" + n +
+					", allowCrossZoneFallback=" + allowCrossZoneFallback +
+					'}';
 		}
 	}
 }

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/RunOnce.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/RunOnce.java
@@ -62,7 +62,12 @@ public class RunOnce implements RetryPolicy {
 	}
 
 	@Override
-	public boolean allowRemoteDCFallback() {
+	public boolean allowCrossZoneFallback() {
 		return false;
+	}
+
+	@Override
+	public String toString() {
+		return "RunOnce";
 	}
 }

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/utils/ConfigUtils.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/utils/ConfigUtils.java
@@ -16,4 +16,22 @@ public class ConfigUtils {
 
         return az;
     }
+
+    public static String getDataCenter() {
+        String dc = System.getenv("EC2_REGION");
+
+        if (dc == null) {
+            dc = System.getProperty("EC2_REGION");
+        }
+
+        if (dc == null) {
+            String rack = getLocalZone();
+            if (rack != null) {
+                dc = rack.substring(0, rack.length() - 1);
+            }
+        }
+
+        return dc;
+    }
+
 }

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolImplTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolImplTest.java
@@ -127,9 +127,9 @@ public class ConnectionPoolImplTest {
 		}
 	};
 	
-	private Host host1 = new Host("host1", 8080, Status.Up).setRack("localDC");
-	private Host host2 = new Host("host2", 8080, Status.Up).setRack("localDC");
-	private Host host3 = new Host("host3", 8080, Status.Up).setRack("localDC");
+	private Host host1 = new Host("host1", 8080, Status.Up).setRack("localRack");
+	private Host host2 = new Host("host2", 8080, Status.Up).setRack("localRack");
+	private Host host3 = new Host("host3", 8080, Status.Up).setRack("localRack");
 
     // Used for Cross Rack fallback testing
     private Host host4 = new Host("host4", 8080, Status.Up).setRack("remoteRack");
@@ -153,7 +153,7 @@ public class ConnectionPoolImplTest {
 			}
 		});
 		
-		cpConfig.setLocalRack("localDC");
+		cpConfig.setLocalRack("localRack");
 		cpConfig.setLoadBalancingStrategy(LoadBalancingStrategy.RoundRobin);
 		
 		cpConfig.withTokenSupplier(getTokenMapSupplier());
@@ -627,9 +627,9 @@ public class ConnectionPoolImplTest {
 
         final ConnectionPoolImpl<TestClient> pool = new ConnectionPoolImpl<TestClient>(connFactory, cpConfig, cpMonitor);
 
-        hostSupplierHosts.add(new Host("host1_down", 8080, Status.Down).setRack("localDC"));
-        hostSupplierHosts.add(new Host("host2_down", 8080, Status.Down).setRack("localDC"));
-        hostSupplierHosts.add(new Host("host3_down", 8080, Status.Down).setRack("localDC"));
+        hostSupplierHosts.add(new Host("host1_down", 8080, Status.Down).setRack("localRack"));
+        hostSupplierHosts.add(new Host("host2_down", 8080, Status.Down).setRack("localRack"));
+        hostSupplierHosts.add(new Host("host3_down", 8080, Status.Down).setRack("localRack"));
 
         pool.start();
 

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/HostConnectionPoolImplTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/HostConnectionPoolImplTest.java
@@ -154,12 +154,18 @@ public class HostConnectionPoolImplTest {
 
 		pool.shutdown();
 
+        Thread.sleep(300);
+
 		Assert.assertEquals(config.getMaxConnsPerHost(), numConns);
-		Assert.assertEquals(result.opCount.get(), cpMonitor.getConnectionBorrowedCount());
-		Assert.assertEquals(result.opCount.get(), cpMonitor.getConnectionReturnedCount());
-		Assert.assertEquals(config.getMaxConnsPerHost(), cpMonitor.getConnectionCreatedCount());
+
+        int expected = result.successCount.get();
+		Assert.assertTrue(expected - cpMonitor.getConnectionBorrowedCount() <= 5);
+		Assert.assertTrue(expected - cpMonitor.getConnectionReturnedCount() <= 5);
+
+        Assert.assertEquals(config.getMaxConnsPerHost(), cpMonitor.getConnectionCreatedCount());
 		Assert.assertEquals(config.getMaxConnsPerHost(), cpMonitor.getConnectionClosedCount());
-		Assert.assertEquals(0, result.failureCount.get());
+
+        Assert.assertEquals(0, result.failureCount.get());
 	}
 
 	@Test
@@ -182,12 +188,17 @@ public class HostConnectionPoolImplTest {
 
 		pool.shutdown();
 
+        Thread.sleep(300);
+
 		Assert.assertEquals(config.getMaxConnsPerHost(), numConns);
 
-		Assert.assertEquals(result.successCount.get(), cpMonitor.getConnectionBorrowedCount());
-		Assert.assertEquals(result.successCount.get(), cpMonitor.getConnectionReturnedCount());
+		int expected = result.successCount.get();
+		Assert.assertTrue(expected - cpMonitor.getConnectionBorrowedCount() <= 5);
+		Assert.assertTrue(expected - cpMonitor.getConnectionReturnedCount() <= 5);
+
 		Assert.assertEquals(config.getMaxConnsPerHost(), cpMonitor.getConnectionCreatedCount());
 		Assert.assertEquals(config.getMaxConnsPerHost(), cpMonitor.getConnectionClosedCount());
+
 		Assert.assertEquals(0, cpMonitor.getConnectionCreateFailedCount());
 
 		Assert.assertTrue(result.failureCount.get() > 0);

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/HostConnectionPoolImplTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/HostConnectionPoolImplTest.java
@@ -171,7 +171,7 @@ public class HostConnectionPoolImplTest {
 		final BasicResult result = new BasicResult();
 		final TestControl control = new TestControl(4);
 
-		for (int i=0; i<4; i++) {   // Note 4 threads .. which is more than the no of available conns .. hence we should see timeouts
+		for (int i=0; i<5; i++) {   // Note 5 threads .. which is more than the no of available conns .. hence we should see timeouts
 			threadPool.submit(new BasicWorker(result, control, 55));
 		}
 

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/lb/HostSelectionWithFallbackTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/lb/HostSelectionWithFallbackTest.java
@@ -15,6 +15,8 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import com.netflix.dyno.connectionpool.RetryPolicy;
+import com.netflix.dyno.connectionpool.impl.RetryNTimes;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -54,19 +56,20 @@ public class HostSelectionWithFallbackTest {
 	private final ConnectionPoolConfigurationImpl cpConfig = new ConnectionPoolConfigurationImpl("test");
 	private final ConnectionPoolMonitor cpMonitor = new CountingConnectionPoolMonitor();
 
-	Host h1 = new Host("h1", Status.Up).setRack("localTestDC");
-	Host h2 = new Host("h2", Status.Up).setRack("localTestDC");
-	Host h3 = new Host("h3", Status.Up).setRack("remoteDC1");
-	Host h4 = new Host("h4", Status.Up).setRack("remoteDC1");
-	Host h5 = new Host("h5", Status.Up).setRack("remoteDC2");
-	Host h6 = new Host("h6", Status.Up).setRack("remoteDC2");
+	Host h1 = new Host("h1", Status.Up).setRack("localTestRack");
+	Host h2 = new Host("h2", Status.Up).setRack("localTestRack");
+	Host h3 = new Host("h3", Status.Up).setRack("remoteRack1");
+	Host h4 = new Host("h4", Status.Up).setRack("remoteRack1");
+	Host h5 = new Host("h5", Status.Up).setRack("remoteRack2");
+	Host h6 = new Host("h6", Status.Up).setRack("remoteRack2");
 
 	Host[] arr = {h1, h2, h3, h4, h5, h6};
 	List<Host> hosts = Arrays.asList(arr);
 
 	@Before
 	public void beforeTest() {
-		cpConfig.setLocalDC("localTestDC");
+		cpConfig.setLocalRack("localTestRack");
+        cpConfig.setLocalDataCenter("localTestRack");
 		cpConfig.setLoadBalancingStrategy(LoadBalancingStrategy.RoundRobin);
 		cpConfig.withTokenSupplier(getTokenMapSupplier());
 	}
@@ -184,6 +187,43 @@ public class HostSelectionWithFallbackTest {
 		}
 
 		verifyExactly(hostnames, "h1", "h2");
+
+        // Verify that failover metric has increased
+        Assert.assertTrue(cpMonitor.getFailoverCount() > 0);
+	}
+
+	@Test
+	public void testCrossRackFallback() throws Exception {
+
+		HostSelectionWithFallback<Integer> selection = new HostSelectionWithFallback<Integer>(cpConfig, cpMonitor);
+        RetryPolicy retry = new RetryNTimes(3, true);
+
+		Map<Host, HostConnectionPool<Integer>> pools = new HashMap<Host, HostConnectionPool<Integer>>();
+
+		for (Host host : hosts) {
+			poolStatus.put(host, new AtomicBoolean(true));
+			pools.put(host, getMockHostConnectionPool(host, poolStatus.get(host)));
+		}
+
+		selection.initWithHosts(pools);
+
+		Set<String> hostnames = new HashSet<String>();
+
+		for (int i = 0; i < 10; i++) {
+			Connection<Integer> conn = selection.getConnectionUsingRetryPolicy(testOperation, 1, TimeUnit.MILLISECONDS,
+                    retry);
+			hostnames.add(conn.getHost().getHostName());
+		}
+
+		verifyExactly(hostnames, "h1", "h2");
+
+        // Record a failure so that retry attempt is not 0 and get another connection
+        retry.failure(new Exception("Unit Test Retry Exception"));
+        Connection<Integer> conn = selection.getConnectionUsingRetryPolicy(testOperation, 1, TimeUnit.MILLISECONDS,
+                retry);
+        String fallbackHost = conn.getHost().getHostName();
+
+        Assert.assertTrue(!fallbackHost.equals("h1") && !fallbackHost.equals("h2"));
 	}
 
 	@Test
@@ -334,21 +374,21 @@ public class HostSelectionWithFallbackTest {
         HostSelectionWithFallback<Integer> selection = new HostSelectionWithFallback<Integer>(cpConfig, cpMonitor);
 
         List<HostToken> hostTokens = Arrays.asList(
-                new HostToken(1383429731L, new Host("host-1", -1)), // Use -1 otherwise the port is opened which works
-                new HostToken(2815085496L, new Host("host-2", -1)), // but slows down the test
-                new HostToken(4246741261L, new Host("host-3", -1)),
-                new HostToken(1383429731L, new Host("host-4", -1)),
-                new HostToken(2815085496L, new Host("host-5", -1)),
-                new HostToken(4246741261L, new Host("host-6", -1)),
-                new HostToken(1383429731L, new Host("host-7", -1)),
-                new HostToken(2815085496L, new Host("host-8", -1)),
-                new HostToken(4246741261L, new Host("host-9", -1)),
-                new HostToken(1383429731L, new Host("host-7", -1)),
-                new HostToken(2815085496L, new Host("host-8", -1)),
-                new HostToken(4246741261L, new Host("host-9", -1)),
-                new HostToken(1383429731L, new Host("host-7", -1)),
-                new HostToken(2815085496L, new Host("host-8", -1)),
-                new HostToken(4246741261L, new Host("host-9", -1))
+                new HostToken(1383429731L, new Host("host-1", -1).setRack("localTestRack")), // Use -1 otherwise the port is opened which works
+                new HostToken(2815085496L, new Host("host-2", -1).setRack("localTestRack")), // but slows down the test
+                new HostToken(4246741261L, new Host("host-3", -1).setRack("localTestRack")),
+                new HostToken(1383429731L, new Host("host-4", -1).setRack("localTestRack")),
+                new HostToken(2815085496L, new Host("host-5", -1).setRack("localTestRack")),
+                new HostToken(4246741261L, new Host("host-6", -1).setRack("localTestRack")),
+                new HostToken(1383429731L, new Host("host-7", -1).setRack("localTestRack")),
+                new HostToken(2815085496L, new Host("host-8", -1).setRack("localTestRack")),
+                new HostToken(4246741261L, new Host("host-9", -1).setRack("localTestRack")),
+                new HostToken(1383429731L, new Host("host-7", -1).setRack("localTestRack")),
+                new HostToken(2815085496L, new Host("host-8", -1).setRack("localTestRack")),
+                new HostToken(4246741261L, new Host("host-9", -1).setRack("localTestRack")),
+                new HostToken(1383429731L, new Host("host-7", -1).setRack("localTestRack")),
+                new HostToken(2815085496L, new Host("host-8", -1).setRack("localTestRack")),
+                new HostToken(4246741261L, new Host("host-9", -1).setRack("localTestRack"))
 
         );
 
@@ -359,18 +399,19 @@ public class HostSelectionWithFallbackTest {
 
 	@Test
     public void testReplicationFactorOf3() {
+        cpConfig.setLocalRack("us-east-1c");
 		cpConfig.setLoadBalancingStrategy(LoadBalancingStrategy.TokenAware);
 		cpConfig.withTokenSupplier(getTokenMapSupplier());
 
 		HostSelectionWithFallback<Integer> selection = new HostSelectionWithFallback<Integer>(cpConfig, cpMonitor);
 
         List<HostToken> hostTokens = Arrays.asList(
-                new HostToken(1111L, h1),
-                new HostToken(2222L, h2),
-                new HostToken(1111L, h3),
-                new HostToken(1111L, h4),
-                new HostToken(2222L, h5),
-                new HostToken(2222L, h6)
+                new HostToken(1111L, new Host("host-1", -1).setRack("us-east-1c")),
+                new HostToken(1111L, new Host("host-2", -1).setRack("us-east-1d")),
+                new HostToken(1111L, new Host("host-3", -1).setRack("us-east-1e")),
+                new HostToken(2222L, new Host("host-4", -1).setRack("us-east-1c")),
+                new HostToken(2222L, new Host("host-5", -1).setRack("us-east-1d")),
+                new HostToken(2222L, new Host("host-6", -1).setRack("us-east-1e"))
         );
 
 		int rf = selection.calculateReplicationFactor(hostTokens);
@@ -380,16 +421,17 @@ public class HostSelectionWithFallbackTest {
 
     @Test
     public void testReplicationFactorOf2() {
+        cpConfig.setLocalRack("us-east-1c");
         cpConfig.setLoadBalancingStrategy(LoadBalancingStrategy.TokenAware);
         cpConfig.withTokenSupplier(getTokenMapSupplier());
 
         HostSelectionWithFallback<Integer> selection = new HostSelectionWithFallback<Integer>(cpConfig, cpMonitor);
 
         List<HostToken> hostTokens = Arrays.asList(
-                new HostToken(1111L, h1),
-                new HostToken(2222L, h2),
-                new HostToken(1111L, h3),
-                new HostToken(2222L, h5)
+                new HostToken(1111L, new Host("host-1", -1).setRack("us-east-1c")),
+                new HostToken(1111L, new Host("host-2", -1).setRack("us-east-1d")),
+                new HostToken(2222L, new Host("host-4", -1).setRack("us-east-1c")),
+                new HostToken(2222L, new Host("host-5", -1).setRack("us-east-1d"))
         );
 
         int rf = selection.calculateReplicationFactor(hostTokens);
@@ -418,22 +460,57 @@ public class HostSelectionWithFallbackTest {
 
     @Test(expected = RuntimeException.class)
     public void testIllegalReplicationFactor() {
+        cpConfig.setLocalRack("us-east-1c");
         cpConfig.setLoadBalancingStrategy(LoadBalancingStrategy.TokenAware);
         cpConfig.withTokenSupplier(getTokenMapSupplier());
 
         HostSelectionWithFallback<Integer> selection = new HostSelectionWithFallback<Integer>(cpConfig, cpMonitor);
 
         List<HostToken> hostTokens = Arrays.asList(
-                new HostToken(1111L, h1),
-                new HostToken(2222L, h2),
-                new HostToken(3333L, h3),
-                new HostToken(4444L, h4),
-                new HostToken(4444L, h5)
+                new HostToken(1111L, new Host("host-1", -1).setRack("us-east-1c")),
+                new HostToken(1111L, new Host("host-2", -1).setRack("us-east-1d")),
+                new HostToken(2222L, new Host("host-4", -1).setRack("us-east-1c"))
         );
 
         selection.calculateReplicationFactor(hostTokens);
 
     }
+
+    @Test
+	public void testReplicationFactorForMultiRegionCluster() {
+        cpConfig.setLocalRack("us-east-1d");
+        cpConfig.setLoadBalancingStrategy(LoadBalancingStrategy.TokenAware);
+        cpConfig.withTokenSupplier(getTokenMapSupplier());
+
+        HostSelectionWithFallback<Integer> selection = new HostSelectionWithFallback<Integer>(cpConfig, cpMonitor);
+
+        List<HostToken> hostTokens = Arrays.asList(
+                new HostToken(3530913378L, new Host("host-1", -1).setRack("us-east-1c")),
+                new HostToken(1383429731L, new Host("host-1", -1).setRack("us-east-1c")),
+                new HostToken(3530913378L, new Host("host-2", -1).setRack("us-east-1d")),
+                new HostToken(1383429731L, new Host("host-2", -1).setRack("us-east-1d")),
+                new HostToken(1383429731L, new Host("host-3", -1).setRack("us-east-1e")),
+                new HostToken(3530913378L, new Host("host-3", -1).setRack("us-east-1e")),
+
+                new HostToken(3530913378L, new Host("host-4", -1).setRack("us-west-2a")),
+                new HostToken(1383429731L, new Host("host-4", -1).setRack("us-west-2a")),
+                new HostToken(3530913378L, new Host("host-5", -1).setRack("us-west-2b")),
+                new HostToken(1383429731L, new Host("host-5", -1).setRack("us-west-2b")),
+                new HostToken(3530913378L, new Host("host-6", -1).setRack("us-west-2c")),
+                new HostToken(1383429731L, new Host("host-6", -1).setRack("us-west-2c")),
+
+                new HostToken(3530913378L, new Host("host-7", -1).setRack("eu-west-1a")),
+                new HostToken(1383429731L, new Host("host-7", -1).setRack("eu-west-1a")),
+                new HostToken(1383429731L, new Host("host-8", -1).setRack("eu-west-1b")),
+                new HostToken(3530913378L, new Host("host-8", -1).setRack("eu-west-1b")),
+                new HostToken(3530913378L, new Host("host-9", -1).setRack("eu-west-1c")),
+                new HostToken(1383429731L, new Host("host-9", -1).setRack("eu-west-1c"))
+        );
+
+        int rf = selection.calculateReplicationFactor(hostTokens);
+
+        Assert.assertEquals(3, rf);
+	}
 
 	private Collection<String> runConnectionsToRingTest(HostSelectionWithFallback<Integer> selection) {
 

--- a/dyno-demo/src/main/java/com/netflix/dyno/demo/redis/DynoJedisDemo.java
+++ b/dyno-demo/src/main/java/com/netflix/dyno/demo/redis/DynoJedisDemo.java
@@ -27,7 +27,6 @@ import org.xml.sax.helpers.DefaultHandler;
 import redis.clients.jedis.Response;
 
 import com.netflix.dyno.connectionpool.Host.Status;
-import com.netflix.dyno.connectionpool.impl.ConnectionPoolConfigurationImpl;
 import com.netflix.dyno.connectionpool.impl.lb.HostToken;
 import com.netflix.dyno.jedis.DynoJedisClient;
 import com.netflix.dyno.jedis.DynoJedisPipeline;
@@ -42,10 +41,10 @@ public class DynoJedisDemo {
 
     protected int numKeys;
 
-    protected final String localDC;
+    protected final String localRack;
 
-	public DynoJedisDemo(String localDC) {
-        this.localDC = localDC;
+	public DynoJedisDemo(String localRack) {
+        this.localRack = localRack;
     }
 
 	public void initWithLocalHost() throws Exception {
@@ -108,10 +107,10 @@ public class DynoJedisDemo {
 		.withHostSupplier(hostSupplier)
 //		.withCPConfig(
 //                new ConnectionPoolConfigurationImpl("demo")
-                        //.setLocalDC(this.localDC)
                         //.setCompressionStrategy(ConnectionPoolConfiguration.CompressionStrategy.THRESHOLD)
                         //.setCompressionThreshold(2)
-//        )
+                        //.setLocalRack(this.localRack)
+//      )
 		.withPort(port)
 		.build();
 	}

--- a/dyno-jedis/src/main/java/com/netflix/dyno/jedis/DynoJedisClient.java
+++ b/dyno-jedis/src/main/java/com/netflix/dyno/jedis/DynoJedisClient.java
@@ -3280,7 +3280,7 @@ public class DynoJedisClient implements JedisCommands, BinaryJedisCommands, Mult
 
             if (ConnectionPoolConfiguration.LoadBalancingStrategy.TokenAware == cpConfig.getLoadBalancingStrategy()) {
                 if (cpConfig.getTokenSupplier() == null) {
-                    Logger.info("TOKEN AWARE selected and no token supplier found, using default HttpEndpointBasedTokenMapSupplier()");
+                    Logger.warn("TOKEN AWARE selected and no token supplier found, using default HttpEndpointBasedTokenMapSupplier()");
                     cpConfig.withTokenSupplier(new HttpEndpointBasedTokenMapSupplier(port));
                 }
 


### PR DESCRIPTION
Currently cross-zone fallback only occurs when dyno client recognizes that a dynomite server is down. With this change any time an error occurs either obtaining a connection from the pool or with the execution of an operation the connection for the retry will be borrowed from a remote zone rather than the same local host pool where the error just occurred.

This change also contains the following minor fixes:
* Bug fix in failover metric reporting (regression)
* Automatic disabling of local zone affinity if the local zone has not been set. This often happens w/local laptop development + unit testing.
* Cleanup of 'datacenter' terminology to rack/zone. Initially datacenter was equivalent to zone/rack in Dynomite terminology. This changed however the dyno client code was never changed to reflect this which makes reading the code confusing. Cleanup is not complete; there is more to do.