### PR TITLE
Bug fix for issue # 51 (https://github.com/Netflix/dyno/issues/51)

### DIFF
--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolImpl.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolImpl.java
@@ -443,7 +443,7 @@ public class ConnectionPoolImpl<CL> implements ConnectionPool<CL>, TopologyView 
 	 * @return
 	 */
 	public <R> Connection<CL> getConnectionForOperation(BaseOperation<CL, R> baseOperation) {
-		return selectionStrategy.getConnection(baseOperation, cpConfiguration.getConnectTimeout(), TimeUnit.MILLISECONDS);
+		return selectionStrategy.getConnection(baseOperation, cpConfiguration.getMaxTimeoutWhenExhausted(), TimeUnit.MILLISECONDS);
 	}
 	
 	@Override


### PR DESCRIPTION
Using maxTimeoutWhenExhausted rather than connectTimeout when borrowing a connection.