### PR TITLE
Dualwriteapi

### DIFF
--- a/dyno-contrib/src/main/java/com/netflix/dyno/contrib/ConnectionPoolConfigPublisherFactory.java
+++ b/dyno-contrib/src/main/java/com/netflix/dyno/contrib/ConnectionPoolConfigPublisherFactory.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dyno.contrib;
 
 import com.netflix.dyno.connectionpool.ConnectionPoolConfiguration;

--- a/dyno-contrib/src/main/java/com/netflix/dyno/contrib/DynoCPMonitor.java
+++ b/dyno-contrib/src/main/java/com/netflix/dyno/contrib/DynoCPMonitor.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dyno.contrib;
 
 import org.slf4j.Logger;

--- a/dyno-contrib/src/main/java/com/netflix/dyno/contrib/DynoOPMonitor.java
+++ b/dyno-contrib/src/main/java/com/netflix/dyno/contrib/DynoOPMonitor.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dyno.contrib;
 
 import java.util.concurrent.ConcurrentHashMap;

--- a/dyno-contrib/src/main/java/com/netflix/dyno/contrib/ElasticConnectionPoolConfigurationPublisher.java
+++ b/dyno-contrib/src/main/java/com/netflix/dyno/contrib/ElasticConnectionPoolConfigurationPublisher.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dyno.contrib;
 
 import java.io.IOException;

--- a/dyno-contrib/src/main/java/com/netflix/dyno/contrib/EstimatedHistogramBasedCounter.java
+++ b/dyno-contrib/src/main/java/com/netflix/dyno/contrib/EstimatedHistogramBasedCounter.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dyno.contrib;
 
 import com.google.common.base.Objects;

--- a/dyno-contrib/src/main/java/com/netflix/dyno/contrib/EurekaHostsSupplier.java
+++ b/dyno-contrib/src/main/java/com/netflix/dyno/contrib/EurekaHostsSupplier.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dyno.contrib;
 
 import java.util.ArrayList;

--- a/dyno-contrib/src/test/java/com/netflix/dyno/contrib/ElasticConnectionPoolConfigurationPublisherTest.java
+++ b/dyno-contrib/src/test/java/com/netflix/dyno/contrib/ElasticConnectionPoolConfigurationPublisherTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dyno.contrib;
 
 import static org.junit.Assert.assertTrue;

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/DecoratingFuture.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/DecoratingFuture.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dyno.connectionpool;
 
 import java.util.concurrent.ExecutionException;

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/DecoratingListenableFuture.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/DecoratingListenableFuture.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dyno.connectionpool;
 
 import java.util.concurrent.ExecutionException;

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/HealthTracker.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/HealthTracker.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dyno.connectionpool;
 
 import com.netflix.dyno.connectionpool.exception.DynoException;

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/ListenableFuture.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/ListenableFuture.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dyno.connectionpool;
 
 import java.util.concurrent.Executor;

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/TokenPoolTopology.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/TokenPoolTopology.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dyno.connectionpool;
 
 import java.util.ArrayList;

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/exception/BadRequestException.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/exception/BadRequestException.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dyno.connectionpool.exception;
 
 public class BadRequestException extends DynoException {

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/exception/DynoConnectException.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/exception/DynoConnectException.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dyno.connectionpool.exception;
 
 import java.util.concurrent.TimeUnit;

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/exception/DynoException.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/exception/DynoException.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 /*******************************************************************************
  * Copyright 2011 Netflix

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/exception/FatalConnectionException.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/exception/FatalConnectionException.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dyno.connectionpool.exception;
 
 public class FatalConnectionException extends DynoConnectException {

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/exception/IsDeadConnectionException.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/exception/IsDeadConnectionException.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dyno.connectionpool.exception;
 
 public interface IsDeadConnectionException {

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/exception/IsRetryableException.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/exception/IsRetryableException.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dyno.connectionpool.exception;
 
 public interface IsRetryableException {

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/exception/NoAvailableHostsException.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/exception/NoAvailableHostsException.java
@@ -2,6 +2,9 @@ package com.netflix.dyno.connectionpool.exception;
 
 public class NoAvailableHostsException extends DynoConnectException {
 
+
+	private static final long serialVersionUID = -6345231310492496030L;
+
 	public NoAvailableHostsException(String message) {
 		super(message);
 	}

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/exception/NoAvailableHostsException.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/exception/NoAvailableHostsException.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dyno.connectionpool.exception;
 
 public class NoAvailableHostsException extends DynoConnectException {

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/exception/PoolExhaustedException.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/exception/PoolExhaustedException.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dyno.connectionpool.exception;
 
 import com.netflix.dyno.connectionpool.HostConnectionPool;

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/exception/PoolOfflineException.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/exception/PoolOfflineException.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dyno.connectionpool.exception;
 
 import com.netflix.dyno.connectionpool.Host;

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/exception/PoolTimeoutException.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/exception/PoolTimeoutException.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dyno.connectionpool.exception;
 
 

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/exception/ThrottledException.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/exception/ThrottledException.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dyno.connectionpool.exception;
 
 

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/exception/TimeoutException.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/exception/TimeoutException.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dyno.connectionpool.exception;
 
 

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/HostConnectionPoolFactory.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/HostConnectionPoolFactory.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dyno.connectionpool.impl;
 
 import com.netflix.dyno.connectionpool.Host;

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/HostsUpdater.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/HostsUpdater.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dyno.connectionpool.impl;
 
 import java.util.ArrayList;

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/MonitorConsoleMBean.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/MonitorConsoleMBean.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dyno.connectionpool.impl;
 
 import java.util.Collection;

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/SimpleAsyncConnectionPoolImpl.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/SimpleAsyncConnectionPoolImpl.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dyno.connectionpool.impl;
 
 import java.util.ArrayList;

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/hash/Murmur1Hash.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/hash/Murmur1Hash.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dyno.connectionpool.impl.hash;
 
 import java.nio.ByteBuffer;

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/hash/Murmur1HashPartitioner.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/hash/Murmur1HashPartitioner.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dyno.connectionpool.impl.hash;
 
 import java.nio.ByteBuffer;

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/hash/Murmur2Hash.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/hash/Murmur2Hash.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dyno.connectionpool.impl.hash;
 
 /** 

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/hash/Murmur2HashPartitioner.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/hash/Murmur2HashPartitioner.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dyno.connectionpool.impl.hash;
 
 import java.nio.ByteBuffer;

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/hash/Murmur3Hash.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/hash/Murmur3Hash.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dyno.connectionpool.impl.hash;
 
 public class Murmur3Hash {

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/hash/Murmur3HashPartitioner.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/hash/Murmur3HashPartitioner.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dyno.connectionpool.impl.hash;
 
 import java.nio.ByteBuffer;

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/hash/UnsignedIntsUtils.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/hash/UnsignedIntsUtils.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dyno.connectionpool.impl.hash;
 
 public class UnsignedIntsUtils {

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/health/ErrorMonitor.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/health/ErrorMonitor.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dyno.connectionpool.impl.health;
 
 

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/health/SimpleErrorMonitorImpl.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/health/SimpleErrorMonitorImpl.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dyno.connectionpool.impl.health;
 
 import java.util.concurrent.atomic.AtomicInteger;

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/lb/AbstractTokenMapSupplier.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/lb/AbstractTokenMapSupplier.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dyno.connectionpool.impl.lb;
 
 import java.util.ArrayList;

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/lb/HttpEndpointBasedTokenMapSupplier.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/lb/HttpEndpointBasedTokenMapSupplier.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dyno.connectionpool.impl.lb;
 
 import java.io.InputStream;

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/utils/ConfigUtils.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/utils/ConfigUtils.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dyno.connectionpool.impl.utils;
 
 /**

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/utils/EstimatedHistogram.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/utils/EstimatedHistogram.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dyno.connectionpool.impl.utils;
 
 import java.util.Arrays;

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/utils/RateLimitUtil.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/utils/RateLimitUtil.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dyno.connectionpool.impl.utils;
 
 import java.util.concurrent.atomic.AtomicInteger;

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/ConnectionContextImplTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/ConnectionContextImplTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dyno.connectionpool.impl;
 
 import org.junit.Assert;

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolImplTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolImplTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dyno.connectionpool.impl;
 
 import java.util.*;

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/CountingConnectionPoolMonitorTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/CountingConnectionPoolMonitorTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dyno.connectionpool.impl;
 
 import org.junit.Assert;

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/FutureOperationalResultImplTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/FutureOperationalResultImplTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dyno.connectionpool.impl;
 
 import java.util.concurrent.Callable;

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/HostConnectionPoolImplTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/HostConnectionPoolImplTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dyno.connectionpool.impl;
 
 import java.util.concurrent.Callable;

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/HostStatusTrackerTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/HostStatusTrackerTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dyno.connectionpool.impl;
 
 import java.util.Collection;

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/OperationResultImplTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/OperationResultImplTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dyno.connectionpool.impl;
 
 import java.util.concurrent.TimeUnit;

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/RetryNTimesTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/RetryNTimesTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dyno.connectionpool.impl;
 
 import org.junit.Assert;

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/RunOnceTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/RunOnceTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dyno.connectionpool.impl;
 
 import org.junit.Assert;

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/SimpleAsyncConnectionPoolImplTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/SimpleAsyncConnectionPoolImplTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dyno.connectionpool.impl;
 
 import static org.mockito.Mockito.mock;

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/hash/BinarySearchTokenMapperTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/hash/BinarySearchTokenMapperTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dyno.connectionpool.impl.hash;
 
 import java.util.ArrayList;

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/hash/DynoBinarySearchTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/hash/DynoBinarySearchTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dyno.connectionpool.impl.hash;
 
 import java.util.Arrays;

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/hash/Murmur1HashPartitionerTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/hash/Murmur1HashPartitionerTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dyno.connectionpool.impl.hash;
 
 import java.io.File;

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/health/ConnectionPoolHealthTrackerTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/health/ConnectionPoolHealthTrackerTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dyno.connectionpool.impl.health;
 
 import static org.mockito.Matchers.any;

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/health/ErrorRateMonitorTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/health/ErrorRateMonitorTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dyno.connectionpool.impl.health;
 
 import java.util.ArrayList;

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/health/RateTrackerTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/health/RateTrackerTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dyno.connectionpool.impl.health;
 
 import java.util.List;

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/lb/AbstractTokenMapSupplierTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/lb/AbstractTokenMapSupplierTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dyno.connectionpool.impl.lb;
 
 import java.util.*;

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/lb/CircularListTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/lb/CircularListTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dyno.connectionpool.impl.lb;
 
 import java.util.ArrayList;

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/lb/HostSelectionWithFallbackTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/lb/HostSelectionWithFallbackTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dyno.connectionpool.impl.lb;
 
 import static org.mockito.Matchers.any;

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/lb/HostTokenTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/lb/HostTokenTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dyno.connectionpool.impl.lb;
 
 import java.util.Arrays;

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/lb/RoundRobinSelectionTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/lb/RoundRobinSelectionTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dyno.connectionpool.impl.lb;
 
 import static org.mockito.Mockito.mock;

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/lb/TokenAwareSelectionTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/lb/TokenAwareSelectionTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dyno.connectionpool.impl.lb;
 
 import static org.mockito.Mockito.mock;

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/lb/TokenMapSupplierTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/lb/TokenMapSupplierTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dyno.connectionpool.impl.lb;
 
 import java.util.ArrayList;

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/utils/RateLimitUtilTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/utils/RateLimitUtilTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dyno.connectionpool.impl.utils;
 
 import java.util.concurrent.Callable;

--- a/dyno-demo/src/main/java/com/netflix/dyno/demo/memcached/DynoMCacheDriver.java
+++ b/dyno-demo/src/main/java/com/netflix/dyno/demo/memcached/DynoMCacheDriver.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dyno.demo.memcached;
 
 

--- a/dyno-demo/src/main/java/com/netflix/dyno/demo/redis/CustomTokenSupplierExample.java
+++ b/dyno-demo/src/main/java/com/netflix/dyno/demo/redis/CustomTokenSupplierExample.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dyno.demo.redis;
 
 import com.netflix.dyno.connectionpool.Host;

--- a/dyno-demo/src/main/java/com/netflix/dyno/demo/redis/DynoJedisDemo.java
+++ b/dyno-demo/src/main/java/com/netflix/dyno/demo/redis/DynoJedisDemo.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dyno.demo.redis;
 
 import java.io.BufferedReader;

--- a/dyno-jedis/src/main/java/com/netflix/dyno/jedis/DynoDualWriterClient.java
+++ b/dyno-jedis/src/main/java/com/netflix/dyno/jedis/DynoDualWriterClient.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dyno.jedis;
 
 import com.netflix.dyno.connectionpool.ConnectionPool;

--- a/dyno-jedis/src/main/java/com/netflix/dyno/jedis/DynoDualWriterClient.java
+++ b/dyno-jedis/src/main/java/com/netflix/dyno/jedis/DynoDualWriterClient.java
@@ -138,7 +138,7 @@ public class DynoDualWriterClient extends DynoJedisClient {
 
         boolean isInRange(byte[] key);
 
-		void setRange(int range);
+        void setRange(int range);
     }
 
     /**

--- a/dyno-jedis/src/main/java/com/netflix/dyno/jedis/DynoDualWriterClient.java
+++ b/dyno-jedis/src/main/java/com/netflix/dyno/jedis/DynoDualWriterClient.java
@@ -533,7 +533,7 @@ public class DynoDualWriterClient extends DynoJedisClient {
     }
     
     @Override
-    public Boolean setbit(final String key, final long offset, final boolean value)  {
+    public Boolean setbit(final String key, final long offset, final boolean value) {
         writeAsync(key, new Callable<OperationResult<Boolean>>(){
             @Override
             public OperationResult<Boolean> call() throws Exception {
@@ -593,7 +593,7 @@ public class DynoDualWriterClient extends DynoJedisClient {
     }
     
     @Override
-    public Long smove(final String srckey, final String dstkey, final String member)  {
+    public Long smove(final String srckey, final String dstkey, final String member) {
         writeAsync(srckey, new Callable<OperationResult<Long>>(){
             @Override
             public OperationResult<Long> call() throws Exception {
@@ -629,7 +629,7 @@ public class DynoDualWriterClient extends DynoJedisClient {
     }
     
     @Override
-    public Long srem(final String key, final String... members)  {
+    public Long srem(final String key, final String... members) {
         writeAsync(key, new Callable<OperationResult<Long>>(){
             @Override
             public OperationResult<Long> call() throws Exception {
@@ -641,7 +641,7 @@ public class DynoDualWriterClient extends DynoJedisClient {
     }
     
     @Override
-    public ScanResult<String> sscan(final String key, final String cursor)  {
+    public ScanResult<String> sscan(final String key, final String cursor) {
         writeAsync(key, new Callable<OperationResult<ScanResult<String>>>(){
             @Override
             public OperationResult<ScanResult<String>> call() throws Exception {
@@ -653,7 +653,7 @@ public class DynoDualWriterClient extends DynoJedisClient {
     }
     
     @Override
-    public ScanResult<String> sscan(final String key, final String cursor, final ScanParams params)  {
+    public ScanResult<String> sscan(final String key, final String cursor, final ScanParams params) {
         writeAsync(key, new Callable<OperationResult<ScanResult<String>>>(){
             @Override
             public OperationResult<ScanResult<String>> call() throws Exception {
@@ -677,7 +677,7 @@ public class DynoDualWriterClient extends DynoJedisClient {
     }   
     
     @Override
-    public Long zadd(final String key, final double score, final String member)  {
+    public Long zadd(final String key, final double score, final String member) {
         writeAsync(key, new Callable<OperationResult<Long>>(){
             @Override
             public OperationResult<Long> call() throws Exception {
@@ -689,7 +689,7 @@ public class DynoDualWriterClient extends DynoJedisClient {
     }
     
     @Override
-    public Long zadd(final String key, final Map<String, Double> scoreMembers)  {
+    public Long zadd(final String key, final Map<String, Double> scoreMembers) {
         writeAsync(key, new Callable<OperationResult<Long>>(){
             @Override
             public OperationResult<Long> call() throws Exception {
@@ -701,7 +701,7 @@ public class DynoDualWriterClient extends DynoJedisClient {
     }
     
     @Override
-    public Double zincrby(final String key, final double score, final String member)  {
+    public Double zincrby(final String key, final double score, final String member) {
         writeAsync(key, new Callable<OperationResult<Double>>(){
             @Override
             public OperationResult<Double> call() throws Exception {
@@ -713,7 +713,7 @@ public class DynoDualWriterClient extends DynoJedisClient {
     }
     
     @Override
-    public Long zrem(final String key, final String... member)  {
+    public Long zrem(final String key, final String... member) {
         writeAsync(key, new Callable<OperationResult<Long>>(){
             @Override
             public OperationResult<Long> call() throws Exception {
@@ -725,7 +725,7 @@ public class DynoDualWriterClient extends DynoJedisClient {
     }
     
     @Override
-    public List<String> blpop(final int timeout, final String key)  {
+    public List<String> blpop(final int timeout, final String key) {
         writeAsync(key, new Callable<OperationResult<List<String>>>(){
             @Override
             public OperationResult<List<String>> call() throws Exception {
@@ -737,7 +737,7 @@ public class DynoDualWriterClient extends DynoJedisClient {
     }
     
     @Override
-    public List<String> brpop(final int timeout, final String key)  {
+    public List<String> brpop(final int timeout, final String key) {
         writeAsync(key, new Callable<OperationResult<List<String>>>(){
             @Override
             public OperationResult<List<String>> call() throws Exception {
@@ -752,7 +752,7 @@ public class DynoDualWriterClient extends DynoJedisClient {
 
     
     @Override
-    public String set(final byte[] key, final byte[] value)  {
+    public String set(final byte[] key, final byte[] value) {
         writeAsync(key, new Callable<OperationResult<String>>(){
             @Override
             public OperationResult<String> call() throws Exception {
@@ -763,6 +763,16 @@ public class DynoDualWriterClient extends DynoJedisClient {
         return targetClient.set(key, value);
     }
 
+    @Override
+    public String setex(final byte[] key, final int seconds, final byte[] value) {
+    writeAsync(key, new Callable<OperationResult<String>>(){
+        @Override
+        public OperationResult<String> call() throws Exception {
+            return d_setex(key, seconds, value);
+        }
+    });
 
+    return targetClient.setex(key, seconds, value);
+}
     
 }

--- a/dyno-jedis/src/main/java/com/netflix/dyno/jedis/DynoDualWriterClient.java
+++ b/dyno-jedis/src/main/java/com/netflix/dyno/jedis/DynoDualWriterClient.java
@@ -21,8 +21,12 @@ import com.netflix.dyno.contrib.DynoOPMonitor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import redis.clients.jedis.Jedis;
+import redis.clients.jedis.ScanParams;
+import redis.clients.jedis.ScanResult;
 
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -83,6 +87,25 @@ public class DynoDualWriterClient extends DynoJedisClient {
 
         return null;
     }
+    
+    /**
+     *  writeAsync() for binary commands
+     */
+    private <R> Future<OperationResult<R>> writeAsync(final byte[] key, Callable<OperationResult<R>> func) {
+        if (sendShadowRequest(key)) {
+            try {
+                return executor.submit(func);
+            } catch (Throwable th) {
+                opMonitor.recordFailure("shadowPool_submit", th.getMessage());
+            }
+
+            // if we need to do any other processing (logging, etc) now's the time...
+
+        }
+
+        return null;
+    }
+    
 
     /**
      * Returns true if the connection pool
@@ -99,6 +122,13 @@ public class DynoDualWriterClient extends DynoJedisClient {
                 this.getConnPool().getActivePools().size() > 0 &&
                 dial.isInRange(key);
     }
+    
+    private boolean sendShadowRequest(byte[] key) {
+        return  this.getConnPool().getConfiguration().isDualWriteEnabled() &&
+                !this.getConnPool().isIdle() &&
+                this.getConnPool().getActivePools().size() > 0 &&
+                dial.isInRange(key);
+    }
 
     public interface Dial {
         /**
@@ -106,7 +136,9 @@ public class DynoDualWriterClient extends DynoJedisClient {
          */
         boolean isInRange(String key);
 
-        void setRange(int range);
+        boolean isInRange(byte[] key);
+
+		void setRange(int range);
     }
 
     /**
@@ -125,12 +157,18 @@ public class DynoDualWriterClient extends DynoJedisClient {
         public boolean isInRange(String key) {
             return range.get() >  (System.currentTimeMillis() % 100);
         }
+        
+        @Override
+        public boolean isInRange(byte[] key) {
+            return range.get() >  (System.currentTimeMillis() % 100);
+        }
 
         @Override
         public void setRange(int range) {
             this.range.set(range);
         }
-    }
+    }   
+    
 
     //----------------------------- JEDIS COMMANDS --------------------------------------
 
@@ -206,5 +244,525 @@ public class DynoDualWriterClient extends DynoJedisClient {
         return targetClient.setex(key, seconds, value);
     }
 
+    @Override
+    public Long del(final String key) {
+        writeAsync(key, new Callable<OperationResult<Long>>(){
+            @Override
+            public OperationResult<Long> call() throws Exception {
+                return d_del(key);
+            }
+        });
 
+        return targetClient.del(key);
+    }
+    
+    @Override
+    public Boolean exists(final String key) {
+        writeAsync(key, new Callable<OperationResult<Boolean>>(){
+            @Override
+            public OperationResult<Boolean> call() throws Exception {
+                return d_exists(key);
+            }
+        });
+
+        return targetClient.exists(key);
+    }
+    
+    @Override
+    public Long expire(final String key, final int seconds) {
+        writeAsync(key, new Callable<OperationResult<Long>>(){
+            @Override
+            public OperationResult<Long> call() throws Exception {
+                return d_expire(key, seconds);
+            }
+        });
+
+        return targetClient.expire(key, seconds);
+    }
+    
+    @Override
+    public Long expireAt(final String key, final long unixTime) {
+        writeAsync(key, new Callable<OperationResult<Long>>(){
+            @Override
+            public OperationResult<Long> call() throws Exception {
+                return d_expireAt(key, unixTime);
+            }
+        });
+
+        return targetClient.expireAt(key, unixTime);
+    }
+    
+    @Override
+    public String getSet(final String key, final String value) {
+        writeAsync(key, new Callable<OperationResult<String>>(){
+            @Override
+            public OperationResult<String> call() throws Exception {
+                return d_getSet(key, value);
+            }
+        });
+
+        return targetClient.getSet(key, value);
+    }
+    
+    @Override
+    public Long hdel(final String key, final String... fields) {
+        writeAsync(key, new Callable<OperationResult<Long>>(){
+            @Override
+            public OperationResult<Long> call() throws Exception {
+                return d_hdel(key, fields);
+            }
+        });
+
+        return targetClient.hdel(key);
+    }
+    
+    @Override
+    public  Long hincrBy(final String key, final String field, final long value) {
+        writeAsync(key, new Callable<OperationResult<Long>>(){
+            @Override
+            public OperationResult<Long> call() throws Exception {
+                return d_hincrBy(key, field, value);
+            }
+        });
+
+        return targetClient.hincrBy(key, field, value);
+    }
+    
+    @Override
+    public  Double hincrByFloat(final String key, final String field, final double value)  {
+        writeAsync(key, new Callable<OperationResult<Double>>(){
+            @Override
+            public OperationResult<Double> call() throws Exception {
+                return d_hincrByFloat(key, field, value);
+            }
+        });
+
+        return targetClient.hincrByFloat(key, field, value);
+    }
+    
+    @Override
+    public  Long hsetnx(final String key, final String field, final String value) {
+        writeAsync(key, new Callable<OperationResult<Long>>(){
+            @Override
+            public OperationResult<Long> call() throws Exception {
+                return d_hsetnx(key, field, value);
+            }
+        });
+
+        return targetClient.hsetnx(key, field, value);
+    }
+    
+    @Override
+    public Long incr(final String key) {
+        writeAsync(key, new Callable<OperationResult<Long>>(){
+            @Override
+            public OperationResult<Long> call() throws Exception {
+                return d_incr(key);
+            }
+        });
+
+        return targetClient.incr(key);
+    }
+    
+    @Override
+    public Long incrBy(final String key, final long delta) {
+        writeAsync(key, new Callable<OperationResult<Long>>(){
+            @Override
+            public OperationResult<Long> call() throws Exception {
+                return d_incrBy(key, delta);
+            }
+        });
+
+        return targetClient.incrBy(key, delta);
+    }
+    
+    @Override
+    public Double incrByFloat(final String key, final double increment) {
+        writeAsync(key, new Callable<OperationResult<Double>>(){
+            @Override
+            public OperationResult<Double> call() throws Exception {
+                return d_incrByFloat(key, increment);
+            }
+        });
+
+        return targetClient.incrByFloat(key, increment);
+    }
+    
+    @Override
+    public String lpop(final String key) {
+        writeAsync(key, new Callable<OperationResult<String>>(){
+            @Override
+            public OperationResult<String> call() throws Exception {
+                return d_lpop(key);
+            }
+        });
+
+        return targetClient.lpop(key);
+    }
+    
+    @Override
+    public Long lpush(final String key, final String... values) {
+        writeAsync(key, new Callable<OperationResult<Long>>(){
+            @Override
+            public OperationResult<Long> call() throws Exception {
+                return d_lpush(key, values);
+            }
+        });
+
+        return targetClient.lpush(key, values);
+    }
+     
+    @Override
+    public Long lrem(final String key, final long count, final String value) {
+        writeAsync(key, new Callable<OperationResult<Long>>(){
+            @Override
+            public OperationResult<Long> call() throws Exception {
+                return d_lrem(key, count, value);
+            }
+        });
+
+        return targetClient.lrem(key, count, value);
+    }
+    
+    @Override
+    public String lset(final String key, final long count, final String value) {
+        writeAsync(key, new Callable<OperationResult<String>>(){
+            @Override
+            public OperationResult<String> call() throws Exception {
+                return d_lset(key, count, value);
+            }
+        });
+
+        return targetClient.lset(key, count, value);
+    }
+    
+    @Override
+    public String ltrim(final String key, final long start, final long end) {
+        writeAsync(key, new Callable<OperationResult<String>>(){
+            @Override
+            public OperationResult<String> call() throws Exception {
+                return d_ltrim(key, start, end);
+            }
+        });
+
+        return targetClient.ltrim(key, start, end);
+    }
+    
+    @Override
+    public Long persist(final String key) {
+        writeAsync(key, new Callable<OperationResult<Long>>(){
+            @Override
+            public OperationResult<Long> call() throws Exception {
+                return d_persist(key);
+            }
+        });
+
+        return targetClient.persist(key);
+    }
+    
+    @Override
+    public Long pexpireAt(final String key, final long millisecondsTimestamp) {
+        writeAsync(key, new Callable<OperationResult<Long>>(){
+            @Override
+            public OperationResult<Long> call() throws Exception {
+                return d_pexpireAt(key, millisecondsTimestamp);
+            }
+        });
+
+        return targetClient.pexpireAt(key, millisecondsTimestamp);
+    }
+    
+    @Override
+    public String psetex(final String key, final int milliseconds, final String value) {
+        writeAsync(key, new Callable<OperationResult<String>>(){
+            @Override
+            public OperationResult<String> call() throws Exception {
+                return d_psetex(key, milliseconds, value);
+            }
+        });
+
+        return targetClient.psetex(key, milliseconds, value);
+    }
+    
+    @Override
+    public Long pttl(final String key) {
+        writeAsync(key, new Callable<OperationResult<Long>>(){
+            @Override
+            public OperationResult<Long> call() throws Exception {
+                return d_pttl(key);
+            }
+        });
+
+        return targetClient.pttl(key);
+    }
+    
+    @Override
+    public String rename(final String oldkey, final String newkey) {
+        writeAsync(oldkey, new Callable<OperationResult<String>>(){
+            @Override
+            public OperationResult<String> call() throws Exception {
+                return d_rename(oldkey, oldkey);
+            }
+        });
+
+        return targetClient.rename(oldkey, oldkey);
+    }
+    
+    @Override
+    public String rpop(final String key) {
+        writeAsync(key, new Callable<OperationResult<String>>(){
+            @Override
+            public OperationResult<String> call() throws Exception {
+                return d_rpop(key);
+            }
+        });
+
+        return targetClient.rpop(key);
+    }
+    
+    @Override
+    public Long scard(final String key) {
+        writeAsync(key, new Callable<OperationResult<Long>>(){
+            @Override
+            public OperationResult<Long> call() throws Exception {
+                return d_scard(key);
+            }
+        });
+
+        return targetClient.scard(key);
+    }
+    
+    @Override
+    public Boolean setbit(final String key, final long offset, final boolean value)  {
+        writeAsync(key, new Callable<OperationResult<Boolean>>(){
+            @Override
+            public OperationResult<Boolean> call() throws Exception {
+                return d_setbit(key, offset, value);
+            }
+        });
+
+        return targetClient.setbit(key, offset, value);
+    }
+    
+    @Override
+    public Boolean setbit(final String key, final long offset, final String value) {
+        writeAsync(key, new Callable<OperationResult<Boolean>>(){
+            @Override
+            public OperationResult<Boolean> call() throws Exception {
+                return d_setbit(key, offset, value);
+            }
+        });
+
+        return targetClient.setbit(key, offset, value);
+    }
+    
+    @Override
+    public Long setnx(final String key, final String value) {
+        writeAsync(key, new Callable<OperationResult<Long>>(){
+            @Override
+            public OperationResult<Long> call() throws Exception {
+                return d_setnx(key, value);
+            }
+        });
+
+        return targetClient.setnx(key, value);
+    }
+    
+    @Override
+    public Long setrange(final String key, final long offset, final String value) {
+        writeAsync(key, new Callable<OperationResult<Long>>(){
+            @Override
+            public OperationResult<Long> call() throws Exception {
+                return d_setrange(key, offset, value);
+            }
+        });
+
+        return targetClient.setrange(key, offset, value);
+    }
+    
+    @Override
+    public Set<String> smembers(final String key) {
+        writeAsync(key, new Callable<OperationResult<Set<String>>>(){
+            @Override
+            public OperationResult<Set<String>> call() throws Exception {
+                return d_smembers(key);
+            }
+        });
+
+        return targetClient.smembers(key);
+    }
+    
+    @Override
+    public Long smove(final String srckey, final String dstkey, final String member)  {
+        writeAsync(srckey, new Callable<OperationResult<Long>>(){
+            @Override
+            public OperationResult<Long> call() throws Exception {
+                return d_smove(srckey,dstkey,member);
+            }
+        });
+
+        return targetClient.smove(srckey,dstkey,member);
+    }
+    
+    @Override
+    public List<String> sort(final String key) {
+        writeAsync(key, new Callable<OperationResult<List<String>>>(){
+            @Override
+            public OperationResult<List<String>> call() throws Exception {
+                return d_sort(key);
+            }
+        });
+
+        return targetClient.sort(key);
+    }    
+    
+    @Override
+    public String spop(final String key) {
+        writeAsync(key, new Callable<OperationResult<String>>(){
+            @Override
+            public OperationResult<String> call() throws Exception {
+                return d_spop(key);
+            }
+        });
+
+        return targetClient.spop(key);
+    }
+    
+    @Override
+    public Long srem(final String key, final String... members)  {
+        writeAsync(key, new Callable<OperationResult<Long>>(){
+            @Override
+            public OperationResult<Long> call() throws Exception {
+                return d_srem(key,members);
+            }
+        });
+
+        return targetClient.srem(key,members);
+    }
+    
+    @Override
+    public ScanResult<String> sscan(final String key, final String cursor)  {
+        writeAsync(key, new Callable<OperationResult<ScanResult<String>>>(){
+            @Override
+            public OperationResult<ScanResult<String>> call() throws Exception {
+                return d_sscan(key,cursor);
+            }
+        });
+
+        return targetClient.sscan(key,cursor);
+    }
+    
+    @Override
+    public ScanResult<String> sscan(final String key, final String cursor, final ScanParams params)  {
+        writeAsync(key, new Callable<OperationResult<ScanResult<String>>>(){
+            @Override
+            public OperationResult<ScanResult<String>> call() throws Exception {
+                return d_sscan(key,cursor,params);
+            }
+        });
+
+        return targetClient.sscan(key,cursor,params);
+    }
+       
+    @Override
+    public Long ttl(final String key) {
+        writeAsync(key, new Callable<OperationResult<Long>>(){
+            @Override
+            public OperationResult<Long> call() throws Exception {
+                return d_ttl(key);
+            }
+        });
+
+        return targetClient.ttl(key);
+    }   
+    
+    @Override
+    public Long zadd(final String key, final double score, final String member)  {
+        writeAsync(key, new Callable<OperationResult<Long>>(){
+            @Override
+            public OperationResult<Long> call() throws Exception {
+                return d_zadd(key, score, member);
+            }
+        });
+
+        return targetClient.zadd(key, score, member);
+    }
+    
+    @Override
+    public Long zadd(final String key, final Map<String, Double> scoreMembers)  {
+        writeAsync(key, new Callable<OperationResult<Long>>(){
+            @Override
+            public OperationResult<Long> call() throws Exception {
+                return d_zadd(key, scoreMembers);
+            }
+        });
+
+        return targetClient.zadd(key, scoreMembers);
+    }
+    
+    @Override
+    public Double zincrby(final String key, final double score, final String member)  {
+        writeAsync(key, new Callable<OperationResult<Double>>(){
+            @Override
+            public OperationResult<Double> call() throws Exception {
+                return d_zincrby(key, score, member);
+            }
+        });
+
+        return targetClient.zincrby(key, score, member);
+    }
+    
+    @Override
+    public Long zrem(final String key, final String... member)  {
+        writeAsync(key, new Callable<OperationResult<Long>>(){
+            @Override
+            public OperationResult<Long> call() throws Exception {
+                return d_zrem(key, member);
+            }
+        });
+
+        return targetClient.zrem(key, member);
+    }
+    
+    @Override
+    public List<String> blpop(final int timeout, final String key)  {
+        writeAsync(key, new Callable<OperationResult<List<String>>>(){
+            @Override
+            public OperationResult<List<String>> call() throws Exception {
+                return d_blpop(timeout, key);
+            }
+        });
+
+        return targetClient.blpop(timeout, key);
+    }
+    
+    @Override
+    public List<String> brpop(final int timeout, final String key)  {
+        writeAsync(key, new Callable<OperationResult<List<String>>>(){
+            @Override
+            public OperationResult<List<String>> call() throws Exception {
+                return d_brpop(timeout, key);
+            }
+        });
+
+        return targetClient.brpop(timeout, key);
+    }
+    
+    /******************* Jedis Dual write for binary commands **************/
+
+    
+    @Override
+    public String set(final byte[] key, final byte[] value)  {
+        writeAsync(key, new Callable<OperationResult<String>>(){
+            @Override
+            public OperationResult<String> call() throws Exception {
+                return d_set(key, value);
+            }
+        });
+
+        return targetClient.set(key, value);
+    }
+
+
+    
 }

--- a/dyno-jedis/src/main/java/com/netflix/dyno/jedis/DynoJedisClient.java
+++ b/dyno-jedis/src/main/java/com/netflix/dyno/jedis/DynoJedisClient.java
@@ -295,12 +295,7 @@ public class DynoJedisClient implements JedisCommands, BinaryJedisCommands, Mult
     public Long expire(final String key, final int seconds) {
         return d_expire(key, seconds).getResult();
     }
-
-    @Override
-    public Long pexpire(String key, long milliseconds) {
-        throw new UnsupportedOperationException("not yet implemented");
-    }
-
+    
     public OperationResult<Long> d_expire(final String key, final Integer seconds) {
 
         return connPool.executeWithFailover(new BaseKeyOperation<Long>(key, OpName.EXPIRE) {
@@ -312,6 +307,7 @@ public class DynoJedisClient implements JedisCommands, BinaryJedisCommands, Mult
 
         });
     }
+
 
     @Override
     public Long expireAt(final String key, final long unixTime) {
@@ -2258,21 +2254,21 @@ public class DynoJedisClient implements JedisCommands, BinaryJedisCommands, Mult
 
     @Override
     public List<String> blpop(String arg) {
-        return d_blpop(arg).getResult();
+        throw new UnsupportedOperationException("not yet implemented");
     }
 
     @Override
     public List<String> blpop(int timeout, String key) {
-        throw new UnsupportedOperationException("not yet implemented");
+        return d_blpop(timeout,key).getResult();
     }
 
-    public OperationResult<List<String>> d_blpop(final String arg) {
+    public OperationResult<List<String>> d_blpop(final int timeout, final String key) {
 
-        return connPool.executeWithFailover(new BaseKeyOperation<List<String>>(arg, OpName.BLPOP) {
+        return connPool.executeWithFailover(new BaseKeyOperation<List<String>>(key, OpName.BLPOP) {
 
             @Override
             public List<String> execute(Jedis client, ConnectionContext state) {
-                return client.blpop(arg);
+                return client.blpop(timeout,key);
             }
 
         });
@@ -2280,25 +2276,26 @@ public class DynoJedisClient implements JedisCommands, BinaryJedisCommands, Mult
 
     @Override
     public List<String> brpop(String arg) {
-        return d_brpop(arg).getResult();
+        throw new UnsupportedOperationException("not yet implemented");
     }
 
     @Override
     public List<String> brpop(int timeout, String key) {
-        throw new UnsupportedOperationException("not yet implemented");
+        return d_brpop(timeout,key).getResult();
     }
 
-    public OperationResult<List<String>> d_brpop(final String arg) {
+    public OperationResult<List<String>> d_brpop(final int timeout, final String key) {
 
-        return connPool.executeWithFailover(new BaseKeyOperation<List<String>>(arg, OpName.BRPOP) {
+        return connPool.executeWithFailover(new BaseKeyOperation<List<String>>(key, OpName.BRPOP) {
 
             @Override
             public List<String> execute(Jedis client, ConnectionContext state) {
-                return client.brpop(arg);
+                return client.brpop(timeout,key);
             }
 
         });
     }
+
 
     @Override
     public String echo(String string) {
@@ -2436,6 +2433,11 @@ public class DynoJedisClient implements JedisCommands, BinaryJedisCommands, Mult
         });
 
         return results;
+    }
+    
+    @Override
+    public Long pexpire(String key, long milliseconds) {
+        throw new UnsupportedOperationException("not yet implemented");
     }
 
     @Override

--- a/dyno-jedis/src/main/java/com/netflix/dyno/jedis/DynoJedisClient.java
+++ b/dyno-jedis/src/main/java/com/netflix/dyno/jedis/DynoJedisClient.java
@@ -1293,7 +1293,7 @@ public class DynoJedisClient implements JedisCommands, BinaryJedisCommands, Mult
     }
 
     @Override
-    public Boolean setbit(String key, long offset, String value) {
+    public Boolean setbit(final String key, final long offset, final String value) {
         return d_setbit(key, offset, value).getResult();
     }
 

--- a/dyno-jedis/src/main/java/com/netflix/dyno/jedis/DynoJedisPipeline.java
+++ b/dyno-jedis/src/main/java/com/netflix/dyno/jedis/DynoJedisPipeline.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dyno.jedis;
 
 import com.netflix.dyno.connectionpool.*;

--- a/dyno-jedis/src/main/java/com/netflix/dyno/jedis/DynoJedisPipelineMonitor.java
+++ b/dyno-jedis/src/main/java/com/netflix/dyno/jedis/DynoJedisPipelineMonitor.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dyno.jedis;
 
 import java.util.Map;

--- a/dyno-jedis/src/main/java/com/netflix/dyno/jedis/OpName.java
+++ b/dyno-jedis/src/main/java/com/netflix/dyno/jedis/OpName.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dyno.jedis;
 
 public enum OpName {

--- a/dyno-jedis/src/test/java/com/netflix/dyno/jedis/UnitTestConnectionPool.java
+++ b/dyno-jedis/src/test/java/com/netflix/dyno/jedis/UnitTestConnectionPool.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dyno.jedis;
 
 import com.netflix.dyno.connectionpool.*;

--- a/dyno-memcache/src/main/java/com/netflix/dyno/memcache/DynoMCacheClient.java
+++ b/dyno-memcache/src/main/java/com/netflix/dyno/memcache/DynoMCacheClient.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dyno.memcache;
 
 

--- a/dyno-recipes/src/main/java/com/netflix/dyno/recipes/util/Tuple.java
+++ b/dyno-recipes/src/main/java/com/netflix/dyno/recipes/util/Tuple.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dyno.recipes.util;
 
 public class Tuple<T1, T2>  {

--- a/dyno-redisson/src/main/java/com/netflix/dyno/redisson/DynoRedissonClient.java
+++ b/dyno-redisson/src/main/java/com/netflix/dyno/redisson/DynoRedissonClient.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dyno.redisson;
 
 import io.netty.channel.nio.NioEventLoopGroup;

--- a/dyno-redisson/src/main/java/com/netflix/dyno/redisson/DynoRedissonDemoResource.java
+++ b/dyno-redisson/src/main/java/com/netflix/dyno/redisson/DynoRedissonDemoResource.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dyno.redisson;
 
 import java.util.concurrent.atomic.AtomicReference;

--- a/dyno-redisson/src/main/java/com/netflix/dyno/redisson/RedissonConnectionFactory.java
+++ b/dyno-redisson/src/main/java/com/netflix/dyno/redisson/RedissonConnectionFactory.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dyno.redisson;
 
 import io.netty.channel.EventLoopGroup;

--- a/dyno-redisson/src/main/java/com/netflix/dyno/redisson/RedissonDemo.java
+++ b/dyno-redisson/src/main/java/com/netflix/dyno/redisson/RedissonDemo.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dyno.redisson;
 
 import io.netty.channel.EventLoopGroup;


### PR DESCRIPTION
* Adding missing Apache Licenses so that building does not complain anymore;
* Replaced deprecated `blpop` and `brpop` commands with newer implementations from Jedis 2.8;
* Adding support for dual-write Jedis commands;
* Adding support for  binary`set` and `setex` in dual-write;
* Further minor fixes.