### PR TITLE
Using the private IP address if it can find it, otherwise the hostname.

### DIFF
--- a/dyno-contrib/src/main/java/com/netflix/dyno/contrib/EurekaHostsSupplier.java
+++ b/dyno-contrib/src/main/java/com/netflix/dyno/contrib/EurekaHostsSupplier.java
@@ -90,7 +90,7 @@ public class EurekaHostsSupplier implements HostSupplier {
 					public Host apply(InstanceInfo info) {
 						
 						Host.Status status = info.getStatus() == InstanceStatus.UP ? Host.Status.Up : Host.Status.Down;
-						Host host = new Host(info.getHostName(), status);
+						Host host = new Host(info.getHostName(), info.getIPAddr(), status);
 
 						try {
 							if (info.getDataCenterInfo() instanceof AmazonInfo) {
@@ -99,7 +99,7 @@ public class EurekaHostsSupplier implements HostSupplier {
 							}
 						}
 						catch (Throwable t) {
-							Logger.error("Error getting rack for host " + host.getHostName(), t);
+							Logger.error("Error getting rack for host " + host.getHostAddress(), t);
 						}
 
 						return host;

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/Host.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/Host.java
@@ -24,7 +24,8 @@ import java.net.InetSocketAddress;
  */
 public class Host {
 
-	private final String name;
+	private final String hostname;
+	private final String ipAddress;
 	private int port;
 	private Status status = Status.Down;
 	private InetSocketAddress socketAddress = null;
@@ -35,18 +36,41 @@ public class Host {
 		Up, Down;
 	}
 	
-	public Host(String name, int port) {
-		this(name, port, Status.Down);
+	public Host(String hostname, int port) {
+		this(hostname, null, port, Status.Down);
 	}
 	
-	public Host(String name, Status status) {
-		this.name = name;
+	public Host(String hostname, Status status) {
+		this.hostname = hostname;
+		this.ipAddress = null;
+		this.port = -1;
+		this.status = status;
+	}
+	
+	public Host(String name, int port, Status status) {
+		this.hostname = name;
+		this.ipAddress = null;
+		this.port = port;
+		this.status = status;
+		if (port != -1) {
+			this.socketAddress = new InetSocketAddress(name, port);
+		}
+	}
+	
+	public Host(String hostname, String ipAddress, int port) {
+		this(hostname, ipAddress, port, Status.Down);
+	}
+	
+	public Host(String hostname, String ipAddress, Status status) {
+		this.hostname = hostname;
+		this.ipAddress = ipAddress;
 		this.port = -1;
 		this.status = status;
 	}
 
-	public Host(String name, int port, Status status) {
-		this.name = name;
+	public Host(String name, String ipAddress, int port, Status status) {
+		this.hostname = name;
+		this.ipAddress = ipAddress;
 		this.port = port;
 		this.status = status;
 		if (port != -1) {
@@ -54,8 +78,15 @@ public class Host {
 		}
 	}
 
-	public String getHostName() {
-		return name;
+	public String getHostAddress() {
+		if (this.ipAddress != null) {
+			return ipAddress;
+		}
+		return hostname;
+	}
+	
+	public String getIpAddress() {
+		return ipAddress;
 	}
 	
 	public int getPort() {
@@ -64,7 +95,7 @@ public class Host {
 	
 	public Host setPort(int p) {
 		this.port = p;
-		this.socketAddress = new InetSocketAddress(name, port);
+		this.socketAddress = new InetSocketAddress(hostname, port);
 		return this;
 	}
 
@@ -94,13 +125,13 @@ public class Host {
 		return socketAddress;
 	}
 	
-	public static final Host NO_HOST = new Host("UNKNOWN", 0);
+	public static final Host NO_HOST = new Host("UNKNOWN", "UNKNOWN", 0);
 
 	@Override
 	public int hashCode() {
 		final int prime = 31;
 		int result = 1;
-		result = prime * result + ((name == null) ? 0 : name.hashCode());
+		result = prime * result + ((hostname == null) ? 0 : hostname.hashCode());
 		result = prime * result + ((rack == null) ? 0 : rack.hashCode());
 		return result;
 	}
@@ -115,7 +146,7 @@ public class Host {
 		Host other = (Host) obj;
 		boolean equals = true;
 		
-		equals &= (name != null) ? name.equals(other.name) : other.name == null;
+		equals &= (hostname != null) ? hostname.equals(other.hostname) : other.hostname == null;
 		equals &= (rack != null) ? rack.equals(other.rack) : other.rack == null;
 		
 		return equals;
@@ -123,6 +154,6 @@ public class Host {
 
 	@Override
 	public String toString() {
-		return "Host [name=" + name + ", port=" + port + ", rack: " + rack + ", status: " + status.name() + "]";
+		return "Host [hostname=" + hostname + ", ipAddress=" + ipAddress + ", port=" + port + ", rack: " + rack + ", status: " + status.name() + "]";
 	}
 }

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/HostGroup.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/HostGroup.java
@@ -22,9 +22,9 @@ import java.util.List;
 import com.netflix.dyno.connectionpool.exception.DynoConnectException;
 
 /**
- * Class representing a group of hosts. This is useful for underlying conection pool implementations
+ * Class representing a group of hosts. This is useful for underlying connection pool implementations
  * where a single multiplexed connection can be used to talk to a group of hosts. 
- * e.g  spy memcached uses this apprach where there is a single selector for a group of hosts. 
+ * e.g  spy memcached uses this approach where there is a single selector for a group of hosts. 
  * 
  * @author poberai
  *
@@ -33,8 +33,8 @@ public class HostGroup extends Host {
 
 	private final List<Host> hostList = new ArrayList<Host>();
 	
-	public HostGroup(String name, int port) {
-		super(name, port);
+	public HostGroup(String hostname, String ipAddress, int port) {
+		super(hostname, ipAddress, port);
 	}
 
 	public void add(Collection<Host> hosts) {

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolImpl.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolImpl.java
@@ -197,10 +197,10 @@ public class ConnectionPoolImpl<CL> implements ConnectionPool<CL>, TopologyView 
 			cpHealthTracker.removeHost(host);
 			cpMonitor.hostRemoved(host);
 			hostPool.shutdown();
-            Logger.info(String.format("Remove host: Successfully removed host %s from connection pool", host.getHostName()));
+            Logger.info(String.format("Remove host: Successfully removed host %s from connection pool", host.getHostAddress()));
             return true;
 		} else {
-            Logger.info(String.format("Remove host: Host %s NOT FOUND in the connection pool", host.getHostName()));
+            Logger.info(String.format("Remove host: Host %s NOT FOUND in the connection pool", host.getHostAddress()));
 			return false;
 		}
 	}
@@ -366,7 +366,7 @@ public class ConnectionPoolImpl<CL> implements ConnectionPool<CL>, TopologyView 
 
 				do {
 					try {
-                        connection.getContext().setMetadata("host", connection.getHost().getHostName());
+                        connection.getContext().setMetadata("host", connection.getHost().getHostAddress());
 						OperationResult<R> result = connection.execute(op);
 
 						// Add context to the result from the successful execution

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/CountingConnectionPoolMonitor.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/CountingConnectionPoolMonitor.java
@@ -340,7 +340,7 @@ public class CountingConnectionPoolMonitor implements ConnectionPoolMonitor {
 		private final AtomicLong returned  = new AtomicLong();
 
 		private HostConnectionStatsImpl(Host host) {
-			this.name = host.getHostName();
+			this.name = host.getHostAddress();
 		}
 
 		@Override

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/MonitorConsole.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/MonitorConsole.java
@@ -100,12 +100,12 @@ public class MonitorConsole implements MonitorConsoleMBean {
 		 Map<Host, HostConnectionStats> hostStats = cpMonitor.getHostStats();
 		 for (Host host : hostStats.keySet()) {
 			 
-			 if (host.getHostName().contains("AllHosts")) {
+			 if (host.getHostAddress().contains("AllHosts")) {
 				 continue;
 			 }
 			 
 			 HostConnectionStats hStats = hostStats.get(host);
-			 sb.append("\nHost: " + host.getHostName() + ":" + host.getPort() + ":" + host.getRack() + "\t");
+			 sb.append("\nHost: " + host.getHostAddress() + ":" + host.getPort() + ":" + host.getRack() + "\t");
 			 sb.append(" borrowed: " + hStats.getConnectionsBorrowed());
 			 sb.append(" returned: " + hStats.getConnectionsReturned());
 			 sb.append(" created: " + hStats.getConnectionsCreated());
@@ -185,7 +185,7 @@ public class MonitorConsole implements MonitorConsoleMBean {
             HostConnectionPool<?> hostPool = tokenStatus.getHostPool();
 
             List<String> meta = CollectionUtils.newArrayList(
-                    hostPool.getHost().getHostName(),
+                    hostPool.getHost().getHostAddress(),
                     hostPool.isActive() ? "UP" : "DOWN"
             );
 

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/MonitorConsoleResource.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/MonitorConsoleResource.java
@@ -115,7 +115,7 @@ public class MonitorConsoleResource {
 		for (TokenStatus tokenStatus : tokens) {
 			String token = tokenStatus.getToken().toString();
 			HostConnectionPool<?> hostPool = tokenStatus.getHostPool();
-			String poolStatus = hostPool.getHost().getHostName() + "__" + (hostPool.isActive() ? "UP" : "DOWN");
+			String poolStatus = hostPool.getHost().getHostAddress() + "__" + (hostPool.isActive() ? "UP" : "DOWN");
 			map.put(token, poolStatus);
 		}
 		return map;

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/hash/BinarySearchTokenMapper.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/hash/BinarySearchTokenMapper.java
@@ -99,7 +99,7 @@ public class BinarySearchTokenMapper implements HashPartitioner {
 		HostToken theToken = null;
 		
 		for (HostToken token : tokenMap.values()) {
-			if (token.getHost().getHostName().equals(host.getHostName())) {
+			if (token.getHost().getHostAddress().equals(host.getHostAddress())) {
 				theToken = token;
 				break;
 			}

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/health/ConnectionPoolHealthTracker.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/health/ConnectionPoolHealthTracker.java
@@ -150,7 +150,7 @@ public class ConnectionPoolHealthTracker<CL> implements HealthTracker<CL> {
         if (e != null && e instanceof PoolExhaustedException) {
             String hostName = "Unknown";
             if (hostPool.getHost() != null) {
-                hostName = hostPool.getHost().getHostName();
+                hostName = hostPool.getHost().getHostAddress();
             }
             Logger.error(String.format("Attempting to reconnect pool to host %s due to PoolExhaustedException: %s",
                     e.getMessage(), hostName));

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/lb/AbstractTokenMapSupplier.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/lb/AbstractTokenMapSupplier.java
@@ -82,7 +82,7 @@ public abstract class AbstractTokenMapSupplier implements TokenMapSupplier {
 		
 		for (Host host : activeHosts) {
 			try {
-				List<HostToken> hostTokens = parseTokenListFromJson(getTopologyJsonPayload((host.getHostName())));
+				List<HostToken> hostTokens = parseTokenListFromJson(getTopologyJsonPayload((host.getHostAddress())));
 				for (HostToken hToken : hostTokens) {
 					allTokens.add(hToken);
 				}
@@ -97,7 +97,7 @@ public abstract class AbstractTokenMapSupplier implements TokenMapSupplier {
 	public HostToken getTokenForHost(final Host host, final Set<Host> activeHosts) {
         String jsonPayload;
         if (activeHosts.size() == 0) {
-            jsonPayload = getTopologyJsonPayload(host.getHostName());
+            jsonPayload = getTopologyJsonPayload(host.getHostAddress());
         } else {
             try {
                 jsonPayload = getTopologyJsonPayload(activeHosts);
@@ -105,7 +105,7 @@ public abstract class AbstractTokenMapSupplier implements TokenMapSupplier {
                 // Try using the host we just primed connections to. If that fails,
                 // let the exception bubble up to ConnectionPoolImpl which will remove
                 // the host from the host-mapping
-                jsonPayload = getTopologyJsonPayload(host.getHostName());
+                jsonPayload = getTopologyJsonPayload(host.getHostAddress());
             }
         }
 		List<HostToken> hostTokens = parseTokenListFromJson(jsonPayload);
@@ -114,7 +114,7 @@ public abstract class AbstractTokenMapSupplier implements TokenMapSupplier {
 
 			@Override
 			public boolean apply(HostToken x) {
-				return x.getHost().getHostName().equals(host.getHostName());
+				return x.getHost().getHostAddress().equals(host.getHostAddress());
 			}
 		});
 	}

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/lb/HttpEndpointBasedTokenMapSupplier.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/lb/HttpEndpointBasedTokenMapSupplier.java
@@ -143,6 +143,6 @@ public class HttpEndpointBasedTokenMapSupplier extends AbstractTokenMapSupplier 
 			}
 		}));
 		
-		return hostsUp.get(random.nextInt(hostsUp.size())).getHostName();
+		return hostsUp.get(random.nextInt(hostsUp.size())).getHostAddress();
 	}
 }

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolImplTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolImplTest.java
@@ -642,9 +642,9 @@ public class ConnectionPoolImplTest {
 
         final ConnectionPoolImpl<TestClient> pool = new ConnectionPoolImpl<TestClient>(connFactory, cpConfig, cpMonitor);
 
-        hostSupplierHosts.add(new Host("host1_down", "ipAddress1_down", 8080, Status.Down).setRack("localRack"));
-        hostSupplierHosts.add(new Host("host2_down", "ipAddress2_down", 8080, Status.Down).setRack("localRack"));
-        hostSupplierHosts.add(new Host("host3_down", "ipAddress3_down", 8080, Status.Down).setRack("localRack"));
+        hostSupplierHosts.add(new Host("host1_down", 8080, Status.Down).setRack("localRack"));
+        hostSupplierHosts.add(new Host("host2_down", 8080, Status.Down).setRack("localRack"));
+        hostSupplierHosts.add(new Host("host3_down", 8080, Status.Down).setRack("localRack"));
 
         pool.start();
 

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolImplTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolImplTest.java
@@ -142,14 +142,14 @@ public class ConnectionPoolImplTest {
 		}
 	};
 	
-	private Host host1 = new Host("host1", 8080, Status.Up).setRack("localRack");
-	private Host host2 = new Host("host2", 8080, Status.Up).setRack("localRack");
-	private Host host3 = new Host("host3", 8080, Status.Up).setRack("localRack");
+	private Host host1 = new Host("host1","ipAddress1", 8080, Status.Up).setRack("localRack");
+	private Host host2 = new Host("host2","ipAddress2",  8080, Status.Up).setRack("localRack");
+	private Host host3 = new Host("host3","ipAddress3",  8080, Status.Up).setRack("localRack");
 
     // Used for Cross Rack fallback testing
-    private Host host4 = new Host("host4", 8080, Status.Up).setRack("remoteRack");
-    private Host host5 = new Host("host5", 8080, Status.Up).setRack("remoteRack");
-    private Host host6 = new Host("host6", 8080, Status.Up).setRack("remoteRack");
+    private Host host4 = new Host("host4","ipAddress4",  8080, Status.Up).setRack("remoteRack");
+    private Host host5 = new Host("host5","ipAddress5",  8080, Status.Up).setRack("remoteRack");
+    private Host host6 = new Host("host6","ipAddress6",  8080, Status.Up).setRack("remoteRack");
 
     private final List<Host> hostSupplierHosts = new ArrayList<Host>();
 	
@@ -259,7 +259,7 @@ public class ConnectionPoolImplTest {
             public List<HostToken> getTokens(Set<Host> activeHosts) {
                 if (activeHosts.size() < tokenMap.size()) {
                     List<HostToken> hostTokens = new ArrayList<HostToken>(activeHosts.size());
-                    Iterator iterator = activeHosts.iterator();
+                    Iterator<Host> iterator = activeHosts.iterator();
                     while (iterator.hasNext()) {
                         Host activeHost = (Host) iterator.next();
                         hostTokens.add(tokenMap.get(activeHost));
@@ -492,7 +492,7 @@ public class ConnectionPoolImplTest {
 
 					@Override
 					public <R> OperationResult<R> execute(Operation<TestClient, R> op) throws DynoException {
-						if (pool.getHost().getHostName().equals(badHost.get())) {
+						if (pool.getHost().getHostAddress().equals(badHost.get())) {
 							throw new FatalConnectionException("Fail for bad host");
 						}
 						return super.execute(op);
@@ -642,9 +642,9 @@ public class ConnectionPoolImplTest {
 
         final ConnectionPoolImpl<TestClient> pool = new ConnectionPoolImpl<TestClient>(connFactory, cpConfig, cpMonitor);
 
-        hostSupplierHosts.add(new Host("host1_down", 8080, Status.Down).setRack("localRack"));
-        hostSupplierHosts.add(new Host("host2_down", 8080, Status.Down).setRack("localRack"));
-        hostSupplierHosts.add(new Host("host3_down", 8080, Status.Down).setRack("localRack"));
+        hostSupplierHosts.add(new Host("host1_down", "ipAddress1_down", 8080, Status.Down).setRack("localRack"));
+        hostSupplierHosts.add(new Host("host2_down", "ipAddress2_down", 8080, Status.Down).setRack("localRack"));
+        hostSupplierHosts.add(new Host("host3_down", "ipAddress3_down", 8080, Status.Down).setRack("localRack"));
 
         pool.start();
 

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolImplTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolImplTest.java
@@ -142,14 +142,14 @@ public class ConnectionPoolImplTest {
 		}
 	};
 	
-	private Host host1 = new Host("host1","ipAddress1", 8080, Status.Up).setRack("localRack");
-	private Host host2 = new Host("host2","ipAddress2",  8080, Status.Up).setRack("localRack");
-	private Host host3 = new Host("host3","ipAddress3",  8080, Status.Up).setRack("localRack");
+	private Host host1 = new Host("host1", 8080, Status.Up).setRack("localRack");
+	private Host host2 = new Host("host2", 8080, Status.Up).setRack("localRack");
+	private Host host3 = new Host("host3", 8080, Status.Up).setRack("localRack");
 
     // Used for Cross Rack fallback testing
-    private Host host4 = new Host("host4","ipAddress4",  8080, Status.Up).setRack("remoteRack");
-    private Host host5 = new Host("host5","ipAddress5",  8080, Status.Up).setRack("remoteRack");
-    private Host host6 = new Host("host6","ipAddress6",  8080, Status.Up).setRack("remoteRack");
+    private Host host4 = new Host("host4", 8080, Status.Up).setRack("remoteRack");
+    private Host host5 = new Host("host5", 8080, Status.Up).setRack("remoteRack");
+    private Host host6 = new Host("host6", 8080, Status.Up).setRack("remoteRack");
 
     private final List<Host> hostSupplierHosts = new ArrayList<Host>();
 	

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/CountingConnectionPoolMonitorTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/CountingConnectionPoolMonitorTest.java
@@ -30,8 +30,8 @@ public class CountingConnectionPoolMonitorTest {
 
 		CountingConnectionPoolMonitor counter = new CountingConnectionPoolMonitor();
 
-		Host host1 = new Host("host1", 1111);
-		Host host2 = new Host("host2", 2222);
+		Host host1 = new Host("host1","address1", 1111);
+		Host host2 = new Host("host2","address2", 2222);
 
 		// Host 1
 		counter.incConnectionCreated(host1);

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/HostConnectionPoolImplTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/HostConnectionPoolImplTest.java
@@ -47,7 +47,7 @@ import com.netflix.dyno.connectionpool.exception.ThrottledException;
 
 public class HostConnectionPoolImplTest {
 
-	private static final Host TestHost = new Host("TestHost", 1234);
+	private static final Host TestHost = new Host("TestHost", "TestAddress", 1234);
 
 	// TEST UTILS SETUP
 	private class TestClient {

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/HostStatusTrackerTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/HostStatusTrackerTest.java
@@ -157,7 +157,7 @@ public class HostStatusTrackerTest {
 
 			@Override
 			public String get(Host x) {
-				return x.getHostName();
+				return x.getHostAddress();
 			}
 		}));
 

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/OperationResultImplTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/OperationResultImplTest.java
@@ -30,7 +30,7 @@ public class OperationResultImplTest {
 
 		OperationMonitor monitor = new LastOperationMonitor();
 		OperationResultImpl<Integer> opResult = new OperationResultImpl<Integer>("test", 11, monitor);
-		Host host = new Host("testHost", 1234);
+		Host host = new Host("testHost", "rand_ip", 1234);
 
 		opResult.attempts(2)
 		.addMetadata("foo", "f1").addMetadata("bar", "b1")

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/SimpleAsyncConnectionPoolImplTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/SimpleAsyncConnectionPoolImplTest.java
@@ -44,7 +44,7 @@ import com.netflix.dyno.connectionpool.exception.ThrottledException;
 public class SimpleAsyncConnectionPoolImplTest {
 
 	// TEST UTILS SETUP
-	private static final Host TestHost = new Host("TestHost", 1234);
+	private static final Host TestHost = new Host("TestHost", "TestIp", 1234);
 
 	private class TestClient {}
 

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/hash/BinarySearchTokenMapperTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/hash/BinarySearchTokenMapperTest.java
@@ -109,7 +109,7 @@ public class BinarySearchTokenMapperTest {
 			final long hash = counter.get();
 
 			HostToken hToken = tokenMapper.getToken(hash);
-			if (!(hToken.getHost().getHostName().equals(expectedToken))) {
+			if (!(hToken.getHost().getHostAddress().equals(expectedToken))) {
 				failures.incrementAndGet();
 			}
 		}

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/lb/AbstractTokenMapSupplierTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/lb/AbstractTokenMapSupplierTest.java
@@ -71,20 +71,20 @@ public class AbstractTokenMapSupplierTest {
 		});
 
 		Assert.assertTrue(hTokens.get(0).getToken().equals(188627880L));
-		Assert.assertTrue(hTokens.get(0).getHost().getHostName().equals("ec2-50-17-65-2.compute-1.amazonaws.com"));
+		Assert.assertTrue(hTokens.get(0).getHost().getHostAddress().equals("ec2-50-17-65-2.compute-1.amazonaws.com"));
 		Assert.assertTrue(hTokens.get(1).getToken().equals(237822755L));
-		Assert.assertTrue(hTokens.get(1).getHost().getHostName().equals("ec2-54-211-220-55.compute-1.amazonaws.com"));
+		Assert.assertTrue(hTokens.get(1).getHost().getHostAddress().equals("ec2-54-211-220-55.compute-1.amazonaws.com"));
 		Assert.assertTrue(hTokens.get(2).getToken().equals(587531700L));
-		Assert.assertTrue(hTokens.get(2).getHost().getHostName().equals("ec2-54-82-176-215.compute-1.amazonaws.com"));
+		Assert.assertTrue(hTokens.get(2).getHost().getHostAddress().equals("ec2-54-82-176-215.compute-1.amazonaws.com"));
 		Assert.assertTrue(hTokens.get(3).getToken().equals(1669478519L));
-		Assert.assertTrue(hTokens.get(3).getHost().getHostName().equals("ec2-54-80-65-203.compute-1.amazonaws.com"));
+		Assert.assertTrue(hTokens.get(3).getHost().getHostAddress().equals("ec2-54-80-65-203.compute-1.amazonaws.com"));
 		Assert.assertTrue(hTokens.get(4).getToken().equals(2019187467L));
-		Assert.assertTrue(hTokens.get(4).getHost().getHostName().equals("ec2-54-83-87-174.compute-1.amazonaws.com"));
+		Assert.assertTrue(hTokens.get(4).getHost().getHostAddress().equals("ec2-54-83-87-174.compute-1.amazonaws.com"));
 		Assert.assertTrue(hTokens.get(5).getToken().equals(3051939411L));
-		Assert.assertTrue(hTokens.get(5).getHost().getHostName().equals("ec2-54-237-143-4.compute-1.amazonaws.com"));
+		Assert.assertTrue(hTokens.get(5).getHost().getHostAddress().equals("ec2-54-237-143-4.compute-1.amazonaws.com"));
 		Assert.assertTrue(hTokens.get(6).getToken().equals(3101134286L));
-		Assert.assertTrue(hTokens.get(6).getHost().getHostName().equals("ec2-54-82-83-115.compute-1.amazonaws.com"));
+		Assert.assertTrue(hTokens.get(6).getHost().getHostAddress().equals("ec2-54-82-83-115.compute-1.amazonaws.com"));
 		Assert.assertTrue(hTokens.get(7).getToken().equals(3450843231L));
-		Assert.assertTrue(hTokens.get(7).getHost().getHostName().equals("ec2-54-81-138-73.compute-1.amazonaws.com"));
+		Assert.assertTrue(hTokens.get(7).getHost().getHostAddress().equals("ec2-54-81-138-73.compute-1.amazonaws.com"));
 	}
 }

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/lb/HostSelectionWithFallbackTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/lb/HostSelectionWithFallbackTest.java
@@ -107,7 +107,7 @@ public class HostSelectionWithFallbackTest {
 
 		for (int i=0; i<10; i++) {
 			Connection<Integer> conn = selection.getConnection(testOperation, 1, TimeUnit.MILLISECONDS);
-			hostnames.add(conn.getHost().getHostName());
+			hostnames.add(conn.getHost().getHostAddress());
 		}
 
 		verifyExactly(hostnames, "h1", "h2");
@@ -119,7 +119,7 @@ public class HostSelectionWithFallbackTest {
 
 		for (int i=0; i<10; i++) {
 			Connection<Integer> conn = selection.getConnection(testOperation, 1, TimeUnit.MILLISECONDS);
-			hostnames.add(conn.getHost().getHostName());
+			hostnames.add(conn.getHost().getHostAddress());
 		}
 
 		verifyExactly(hostnames, "h3", "h4", "h5", "h6");
@@ -130,7 +130,7 @@ public class HostSelectionWithFallbackTest {
 
 		for (int i=0; i<10; i++) {
 			Connection<Integer> conn = selection.getConnection(testOperation, 1, TimeUnit.MILLISECONDS);
-			hostnames.add(conn.getHost().getHostName());
+			hostnames.add(conn.getHost().getHostAddress());
 		}
 
 		verifyExactly(hostnames, "h1");
@@ -140,7 +140,7 @@ public class HostSelectionWithFallbackTest {
 		hostnames.clear();
 		for (int i=0; i<10; i++) {
 			Connection<Integer> conn = selection.getConnection(testOperation, 1, TimeUnit.MILLISECONDS);
-			hostnames.add(conn.getHost().getHostName());
+			hostnames.add(conn.getHost().getHostAddress());
 		}
 
 		verifyExactly(hostnames, "h1", "h2");
@@ -164,7 +164,7 @@ public class HostSelectionWithFallbackTest {
 
 		for (int i=0; i<10; i++) {
 			Connection<Integer> conn = selection.getConnection(testOperation, 1, TimeUnit.MILLISECONDS);
-			hostnames.add(conn.getHost().getHostName());
+			hostnames.add(conn.getHost().getHostAddress());
 		}
 
 		verifyExactly(hostnames, "h1", "h2");
@@ -176,7 +176,7 @@ public class HostSelectionWithFallbackTest {
 
 		for (int i=0; i<10; i++) {
 			Connection<Integer> conn = selection.getConnection(testOperation, 1, TimeUnit.MILLISECONDS);
-			hostnames.add(conn.getHost().getHostName());
+			hostnames.add(conn.getHost().getHostAddress());
 		}
 
 		verifyExactly(hostnames, "h3", "h4", "h5", "h6");
@@ -187,7 +187,7 @@ public class HostSelectionWithFallbackTest {
 
 		for (int i=0; i<10; i++) {
 			Connection<Integer> conn = selection.getConnection(testOperation, 1, TimeUnit.MILLISECONDS);
-			hostnames.add(conn.getHost().getHostName());
+			hostnames.add(conn.getHost().getHostAddress());
 		}
 
 		System.out.println(" " + hostnames);
@@ -198,7 +198,7 @@ public class HostSelectionWithFallbackTest {
 		hostnames.clear();
 		for (int i=0; i<10; i++) {
 			Connection<Integer> conn = selection.getConnection(testOperation, 1, TimeUnit.MILLISECONDS);
-			hostnames.add(conn.getHost().getHostName());
+			hostnames.add(conn.getHost().getHostAddress());
 		}
 
 		verifyExactly(hostnames, "h1", "h2");
@@ -227,7 +227,7 @@ public class HostSelectionWithFallbackTest {
 		for (int i = 0; i < 10; i++) {
 			Connection<Integer> conn = selection.getConnectionUsingRetryPolicy(testOperation, 1, TimeUnit.MILLISECONDS,
                     retry);
-			hostnames.add(conn.getHost().getHostName());
+			hostnames.add(conn.getHost().getHostAddress());
 		}
 
 		verifyExactly(hostnames, "h1", "h2");
@@ -236,7 +236,7 @@ public class HostSelectionWithFallbackTest {
         retry.failure(new Exception("Unit Test Retry Exception"));
         Connection<Integer> conn = selection.getConnectionUsingRetryPolicy(testOperation, 1, TimeUnit.MILLISECONDS,
                 retry);
-        String fallbackHost = conn.getHost().getHostName();
+        String fallbackHost = conn.getHost().getHostAddress();
 
         Assert.assertTrue(!fallbackHost.equals("h1") && !fallbackHost.equals("h2"));
 	}
@@ -534,7 +534,7 @@ public class HostSelectionWithFallbackTest {
 		return CollectionUtils.transform(connections, new Transform<Connection<Integer>, String>() {
 			@Override
 			public String get(Connection<Integer> x) {
-				return x.getHost().getHostName();
+				return x.getHost().getHostAddress();
 			}
 		});
 

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/lb/RoundRobinSelectionTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/lb/RoundRobinSelectionTest.java
@@ -76,7 +76,7 @@ public class RoundRobinSelectionTest {
 
 			@Override
 			public int compare(HostToken o1, HostToken o2) {
-				return o1.getHost().getHostName().compareTo(o2.getHost().getHostName());
+				return o1.getHost().getHostAddress().compareTo(o2.getHost().getHostAddress());
 			}
 		});
 
@@ -111,7 +111,7 @@ public class RoundRobinSelectionTest {
 		for (int i=1; i<=iterations; i++) {
 
 			HostConnectionPool<Integer> pool = rrSelection.getPoolForOperation(testOperation);
-			String hostName = pool.getHost().getHostName();
+			String hostName = pool.getHost().getHostAddress();
 
 			Integer count = result.get(hostName);
 			if (count == null) {

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/lb/TokenAwareSelectionTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/lb/TokenAwareSelectionTest.java
@@ -65,7 +65,7 @@ public class TokenAwareSelectionTest {
 
 			@Override
 			public int compare(HostToken o1, HostToken o2) {
-				return o1.getHost().getHostName().compareTo(o2.getHost().getHostName());
+				return o1.getHost().getHostAddress().compareTo(o2.getHost().getHostAddress());
 			}
 		});
 
@@ -108,7 +108,7 @@ public class TokenAwareSelectionTest {
 			BaseOperation<Integer, Long> op = getTestOperation(i);
 			HostConnectionPool<Integer> pool = tokenAwareSelector.getPoolForOperation(op);
 
-			String hostName = pool.getHost().getHostName();
+			String hostName = pool.getHost().getHostAddress();
 
 			verifyKeyHash(op.getKey(), hostName);
 

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/lb/TokenMapSupplierTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/lb/TokenMapSupplierTest.java
@@ -56,20 +56,20 @@ public class TokenMapSupplierTest {
 		List<HostToken> hTokens = tokenSupplier.parseTokenListFromJson(json);
 
 		Assert.assertTrue(hTokens.get(0).getToken().equals(3051939411L));
-		Assert.assertTrue(hTokens.get(0).getHost().getHostName().equals("ec2-54-237-143-4.compute-1.amazonaws.com"));
+		Assert.assertTrue(hTokens.get(0).getHost().getHostAddress().equals("ec2-54-237-143-4.compute-1.amazonaws.com"));
 		Assert.assertTrue(hTokens.get(1).getToken().equals(188627880L));
-		Assert.assertTrue(hTokens.get(1).getHost().getHostName().equals("ec2-50-17-65-2.compute-1.amazonaws.com"));
+		Assert.assertTrue(hTokens.get(1).getHost().getHostAddress().equals("ec2-50-17-65-2.compute-1.amazonaws.com"));
 		Assert.assertTrue(hTokens.get(2).getToken().equals(2019187467L));
-		Assert.assertTrue(hTokens.get(2).getHost().getHostName().equals("ec2-54-83-87-174.compute-1.amazonaws.com"));
+		Assert.assertTrue(hTokens.get(2).getHost().getHostAddress().equals("ec2-54-83-87-174.compute-1.amazonaws.com"));
 		Assert.assertTrue(hTokens.get(3).getToken().equals(3450843231L));
-		Assert.assertTrue(hTokens.get(3).getHost().getHostName().equals("ec2-54-81-138-73.compute-1.amazonaws.com"));
+		Assert.assertTrue(hTokens.get(3).getHost().getHostAddress().equals("ec2-54-81-138-73.compute-1.amazonaws.com"));
 		Assert.assertTrue(hTokens.get(4).getToken().equals(587531700L));
-		Assert.assertTrue(hTokens.get(4).getHost().getHostName().equals("ec2-54-82-176-215.compute-1.amazonaws.com"));
+		Assert.assertTrue(hTokens.get(4).getHost().getHostAddress().equals("ec2-54-82-176-215.compute-1.amazonaws.com"));
 		Assert.assertTrue(hTokens.get(5).getToken().equals(3101134286L));
-		Assert.assertTrue(hTokens.get(5).getHost().getHostName().equals("ec2-54-82-83-115.compute-1.amazonaws.com"));
+		Assert.assertTrue(hTokens.get(5).getHost().getHostAddress().equals("ec2-54-82-83-115.compute-1.amazonaws.com"));
 		Assert.assertTrue(hTokens.get(6).getToken().equals(237822755L));
-		Assert.assertTrue(hTokens.get(6).getHost().getHostName().equals("ec2-54-211-220-55.compute-1.amazonaws.com"));
+		Assert.assertTrue(hTokens.get(6).getHost().getHostAddress().equals("ec2-54-211-220-55.compute-1.amazonaws.com"));
 		Assert.assertTrue(hTokens.get(7).getToken().equals(1669478519L));
-		Assert.assertTrue(hTokens.get(7).getHost().getHostName().equals("ec2-54-80-65-203.compute-1.amazonaws.com"));
+		Assert.assertTrue(hTokens.get(7).getHost().getHostAddress().equals("ec2-54-80-65-203.compute-1.amazonaws.com"));
 	}
 }

--- a/dyno-jedis/src/main/java/com/netflix/dyno/jedis/DynoJedisClient.java
+++ b/dyno-jedis/src/main/java/com/netflix/dyno/jedis/DynoJedisClient.java
@@ -3183,7 +3183,7 @@ public class DynoJedisClient implements JedisCommands, BinaryJedisCommands, Mult
 
         List<OperationResult<ScanResult<String>>> opResults = scatterGatherScan(cursor, pattern);
         for (OperationResult<ScanResult<String>> opResult: opResults) {
-            results.put(opResult.getNode().getHostName(), opResult.getResult());
+            results.put(opResult.getNode().getHostAddress(), opResult.getResult());
         }
 
         return new CursorBasedResultImpl<>(results);

--- a/dyno-jedis/src/main/java/com/netflix/dyno/jedis/JedisConnectionFactory.java
+++ b/dyno-jedis/src/main/java/com/netflix/dyno/jedis/JedisConnectionFactory.java
@@ -70,7 +70,7 @@ public class JedisConnectionFactory implements ConnectionFactory<Jedis> {
 		public JedisConnection(HostConnectionPool<Jedis> hostPool) {
 			this.hostPool = hostPool;
 			Host host = hostPool.getHost();
-			jedisClient = new Jedis(host.getHostName(), host.getPort(), hostPool.getConnectionTimeout());
+			jedisClient = new Jedis(host.getHostAddress(), host.getPort(), hostPool.getConnectionTimeout());
 		}
 		
 		@Override

--- a/dyno-redisson/src/main/java/com/netflix/dyno/redisson/RedissonConnectionFactory.java
+++ b/dyno-redisson/src/main/java/com/netflix/dyno/redisson/RedissonConnectionFactory.java
@@ -71,7 +71,7 @@ public class RedissonConnectionFactory implements ConnectionFactory<RedisAsyncCo
 			this.hostPool = hPool;
 			Host host = hostPool.getHost();
 			this.opMonitor = opMonitor;
-			this.client = new RedisClient(eventGroupLoop, host.getHostName(), host.getPort());
+			this.client = new RedisClient(eventGroupLoop, host.getHostAddress(), host.getPort());
 		}
 		
 		@Override


### PR DESCRIPTION
Creating new `Host` constructors that can take the private IP address. If private IP address is provided by the Discovery service (Eureka), then the client will use that. If a private IP address is not found then it will use the hostname. 