### PR TITLE
Issue #50

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Dyno
+# Dyno [![Build Status](https://secure.travis-ci.org/Netflix/dyno.png)](http://travis-ci.org/Netflix/dyno)
  
  Dyno encapsulates features necessary to scale a client application utilizing [Dynomite](https://github.com/Netflix/dynomite).
  

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,5 @@
-
 plugins {
     id 'nebula.netflixoss' version '3.2.3'
-    id 'nebula.maven-publish' version '4.8.1'
 }
 
 // Establish version and status
@@ -10,39 +8,19 @@ ext.githubProjectName = rootProject.name // Change if github project name is not
 apply plugin: 'osgi'
 apply plugin: 'project-report'
 
+
 subprojects {
     apply plugin: 'nebula.netflixoss'
     apply plugin: 'java'
     apply plugin: 'idea'
     apply plugin: 'eclipse'    
-//    apply plugin: 'maven-publish'
-    apply plugin: 'nebula.maven-base-publish'
-//    version = "1.4.6.1-sovrn"
 
-publishing {
-    publications {
-        mavenJava(MavenPublication) {
-            from components.java
-        }
-    }
-    repositories {
-        maven {
-            // change to point to your repo, e.g. http://my.org/repo
-            url "http://192.168.1.5:8080/repository/internal"
-        }
-    }
-}
     sourceCompatibility = 1.7
     targetCompatibility = 1.7
 
     repositories {
-//        jcenter()
-	maven {
-              url "http://192.168.1.5:8080/repository/internal"
-    	}
+        jcenter()
     }
-
-
     group = "com.netflix.${githubProjectName}"
 
     dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,7 @@
+
 plugins {
     id 'nebula.netflixoss' version '3.2.3'
+    id 'nebula.maven-publish' version '4.8.1'
 }
 
 // Establish version and status
@@ -8,19 +10,39 @@ ext.githubProjectName = rootProject.name // Change if github project name is not
 apply plugin: 'osgi'
 apply plugin: 'project-report'
 
-
 subprojects {
     apply plugin: 'nebula.netflixoss'
     apply plugin: 'java'
     apply plugin: 'idea'
     apply plugin: 'eclipse'    
+//    apply plugin: 'maven-publish'
+    apply plugin: 'nebula.maven-base-publish'
+//    version = "1.4.6.1-sovrn"
 
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            from components.java
+        }
+    }
+    repositories {
+        maven {
+            // change to point to your repo, e.g. http://my.org/repo
+            url "http://192.168.1.5:8080/repository/internal"
+        }
+    }
+}
     sourceCompatibility = 1.7
     targetCompatibility = 1.7
 
     repositories {
-        jcenter()
+//        jcenter()
+	maven {
+              url "http://192.168.1.5:8080/repository/internal"
+    	}
     }
+
+
     group = "com.netflix.${githubProjectName}"
 
     dependencies {

--- a/dyno-contrib/src/main/java/com/netflix/dyno/contrib/ArchaiusConnectionPoolConfiguration.java
+++ b/dyno-contrib/src/main/java/com/netflix/dyno/contrib/ArchaiusConnectionPoolConfiguration.java
@@ -63,7 +63,6 @@ public class ArchaiusConnectionPoolConfiguration extends ConnectionPoolConfigura
 		
 		String propertyPrefix = DynoPrefix + name; 
 		
-		//port = DynamicPropertyFactory.getInstance().getIntProperty(propertyPrefix + ".connection.port", super.getPort());
 		maxConnsPerHost = DynamicPropertyFactory.getInstance().getIntProperty(propertyPrefix + ".connection.maxConnsPerHost", super.getMaxConnsPerHost());
 		maxTimeoutWhenExhausted = DynamicPropertyFactory.getInstance().getIntProperty(propertyPrefix + ".connection.maxTimeoutWhenExhausted", super.getMaxTimeoutWhenExhausted());
 		maxFailoverCount = DynamicPropertyFactory.getInstance().getIntProperty(propertyPrefix + ".connection.maxFailoverCount", super.getMaxFailoverCount());
@@ -92,10 +91,6 @@ public class ArchaiusConnectionPoolConfiguration extends ConnectionPoolConfigura
 		return super.getName();
 	}
 
-//	@Override
-//	public int getPort() {
-//		return port.get();
-//	}
 
 	@Override
 	public int getMaxConnsPerHost() {
@@ -187,7 +182,6 @@ public class ArchaiusConnectionPoolConfiguration extends ConnectionPoolConfigura
     public String toString() {
         return "ArchaiusConnectionPoolConfiguration{" +
                 "name=" + getName() +
-                ", port=" + port +
                 ", maxConnsPerHost=" + maxConnsPerHost +
                 ", maxTimeoutWhenExhausted=" + maxTimeoutWhenExhausted +
                 ", maxFailoverCount=" + maxFailoverCount +

--- a/dyno-contrib/src/main/java/com/netflix/dyno/contrib/ArchaiusConnectionPoolConfiguration.java
+++ b/dyno-contrib/src/main/java/com/netflix/dyno/contrib/ArchaiusConnectionPoolConfiguration.java
@@ -36,7 +36,7 @@ public class ArchaiusConnectionPoolConfiguration extends ConnectionPoolConfigura
 	
 	private static final String DynoPrefix = "dyno.";
 	
-	private final DynamicIntProperty port;
+	//private final DynamicIntProperty port;
 	private final DynamicIntProperty maxConnsPerHost;
 	private final DynamicIntProperty maxTimeoutWhenExhausted;
 	private final DynamicIntProperty maxFailoverCount;
@@ -63,7 +63,7 @@ public class ArchaiusConnectionPoolConfiguration extends ConnectionPoolConfigura
 		
 		String propertyPrefix = DynoPrefix + name; 
 		
-		port = DynamicPropertyFactory.getInstance().getIntProperty(propertyPrefix + ".connection.port", super.getPort());
+		//port = DynamicPropertyFactory.getInstance().getIntProperty(propertyPrefix + ".connection.port", super.getPort());
 		maxConnsPerHost = DynamicPropertyFactory.getInstance().getIntProperty(propertyPrefix + ".connection.maxConnsPerHost", super.getMaxConnsPerHost());
 		maxTimeoutWhenExhausted = DynamicPropertyFactory.getInstance().getIntProperty(propertyPrefix + ".connection.maxTimeoutWhenExhausted", super.getMaxTimeoutWhenExhausted());
 		maxFailoverCount = DynamicPropertyFactory.getInstance().getIntProperty(propertyPrefix + ".connection.maxFailoverCount", super.getMaxFailoverCount());
@@ -92,10 +92,10 @@ public class ArchaiusConnectionPoolConfiguration extends ConnectionPoolConfigura
 		return super.getName();
 	}
 
-	@Override
-	public int getPort() {
-		return port.get();
-	}
+//	@Override
+//	public int getPort() {
+//		return port.get();
+//	}
 
 	@Override
 	public int getMaxConnsPerHost() {

--- a/dyno-contrib/src/main/java/com/netflix/dyno/contrib/EurekaHostsSupplier.java
+++ b/dyno-contrib/src/main/java/com/netflix/dyno/contrib/EurekaHostsSupplier.java
@@ -90,18 +90,21 @@ public class EurekaHostsSupplier implements HostSupplier {
 					public Host apply(InstanceInfo info) {
 						
 						Host.Status status = info.getStatus() == InstanceStatus.UP ? Host.Status.Up : Host.Status.Down;
-						Host host = new Host(info.getHostName(), info.getIPAddr(), status);
-
+						
+						String rack = null;
 						try {
 							if (info.getDataCenterInfo() instanceof AmazonInfo) {
 								AmazonInfo amazonInfo = (AmazonInfo)info.getDataCenterInfo();
-								host.setRack(amazonInfo.get(MetaDataKey.availabilityZone));
+								rack = amazonInfo.get(MetaDataKey.availabilityZone);
 							}
 						}
 						catch (Throwable t) {
-							Logger.error("Error getting rack for host " + host.getHostAddress(), t);
+						    Logger.error("Error getting rack for host " + info.getHostName(), t);
 						}
-
+						if(rack == null) {
+						    Logger.error("Rack wasn't found for host:" + info.getHostName() + " there may be issues matching it up to the token map");
+						}
+						Host host = new Host(info.getHostName(), info.getIPAddr(), rack, status);
 						return host;
 					}
 				}));

--- a/dyno-contrib/src/test/java/com/netflix/dyno/contrib/ElasticConnectionPoolConfigurationPublisherTest.java
+++ b/dyno-contrib/src/test/java/com/netflix/dyno/contrib/ElasticConnectionPoolConfigurationPublisherTest.java
@@ -77,7 +77,6 @@ public class ElasticConnectionPoolConfigurationPublisherTest {
         assertTrue(json.has("ApplicationName"));
         assertTrue(json.has("DynomiteClusterName"));
         assertTrue(json.has("MaxConnsPerHost"));
-        //assertTrue(json.has("Port"));
 
     }
 }

--- a/dyno-contrib/src/test/java/com/netflix/dyno/contrib/ElasticConnectionPoolConfigurationPublisherTest.java
+++ b/dyno-contrib/src/test/java/com/netflix/dyno/contrib/ElasticConnectionPoolConfigurationPublisherTest.java
@@ -77,7 +77,7 @@ public class ElasticConnectionPoolConfigurationPublisherTest {
         assertTrue(json.has("ApplicationName"));
         assertTrue(json.has("DynomiteClusterName"));
         assertTrue(json.has("MaxConnsPerHost"));
-        assertTrue(json.has("Port"));
+        //assertTrue(json.has("Port"));
 
     }
 }

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/ConnectionPoolConfiguration.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/ConnectionPoolConfiguration.java
@@ -20,7 +20,7 @@ import com.netflix.dyno.connectionpool.impl.health.ErrorMonitor.ErrorMonitorFact
 
 
 public interface ConnectionPoolConfiguration {
-	
+    
 	enum LoadBalancingStrategy {
 		RoundRobin, TokenAware;
 	}
@@ -38,11 +38,11 @@ public interface ConnectionPoolConfiguration {
      */
     String getName();
 
-    /**
-     * @return Data port to be used when no port is specified to a list of seeds or when
-     * doing a ring describe since the ring describe does not include a host
-     */
-    int getPort();
+//    /**
+//     * @return Data port to be used when no port is specified to a list of seeds or when
+//     * doing a ring describe since the ring describe does not include a host
+//     */
+//    int getPort();
 
     /**
      * @return Maximum number of connections to allocate for a single host's pool

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/ConnectionPoolConfiguration.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/ConnectionPoolConfiguration.java
@@ -38,11 +38,6 @@ public interface ConnectionPoolConfiguration {
      */
     String getName();
 
-//    /**
-//     * @return Data port to be used when no port is specified to a list of seeds or when
-//     * doing a ring describe since the ring describe does not include a host
-//     */
-//    int getPort();
 
     /**
      * @return Maximum number of connections to allocate for a single host's pool

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/Host.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/Host.java
@@ -19,51 +19,62 @@ import java.net.InetSocketAddress;
 
 /**
  * Class encapsulating information about a host.
+ * This is immutable except for the host status
  * @author poberai
  *
  */
-public class Host {
-
+public class Host implements Comparable<Host> {
+    public static final int DEFAULT_PORT = 8102; 
+    public static final Host NO_HOST = new Host("UNKNOWN", "UNKNOWN", 0, "UNKNOWN");
+    
 	private final String hostname;
 	private final String ipAddress;
-	private int port;
+	private final int port;
+	private final InetSocketAddress socketAddress;
+    private final String rack; 
 	private Status status = Status.Down;
-	private InetSocketAddress socketAddress = null;
+
 	
-	private String rack; 
+
 	
 	public static enum Status {
 		Up, Down;
 	}
 	
-	public Host(String hostname, int port) {
-		this(hostname, null, port, Status.Down);
+	public Host(String hostname, int port, String rack) {
+		this(hostname, null, port, rack, Status.Down);
 	}
 	
-	public Host(String hostname, Status status) {
-		this(hostname, null, -1, status);
+	public Host(String hostname, String rack, Status status) {
+		this(hostname, null, DEFAULT_PORT, rack, status);
 	}
 	
-	public Host(String hostname, int port, Status status) {
-		this(hostname, null, port, status);
+	public Host(String hostname, int port, String rack, Status status) {
+		this(hostname, null, port, rack, status);
 	}
 	
-	public Host(String hostname, String ipAddress, int port) {
-		this(hostname, ipAddress, port, Status.Down);
+	public Host(String hostname, String ipAddress, int port, String rack) {
+		this(hostname, ipAddress, port, rack, Status.Down);
 	}
 	
-	public Host(String hostname, String ipAddress, Status status) {
-		this(hostname, ipAddress, -1, status);
+	public Host(String hostname, String ipAddress, String rack, Status status) {
+		this(hostname, ipAddress, DEFAULT_PORT, rack, status);
 	}
 
-	public Host(String name, String ipAddress, int port, Status status) {
+	public Host(String name, String ipAddress, int port, String rack, Status status) {
 		this.hostname = name;
 		this.ipAddress = ipAddress;
 		this.port = port;
+		this.rack = rack;
 		this.status = status;
-		if (port != -1) {
-			this.socketAddress = new InetSocketAddress(name, port);
+		// Used for the unit tests to prevent host name resolution
+		if(port != -1) {
+		    this.socketAddress = new InetSocketAddress(name, port);
+		} else { 
+		    this.socketAddress = null;
 		}
+
+
 	}
 
 	public String getHostAddress() {
@@ -81,11 +92,6 @@ public class Host {
 		return port;
 	}
 	
-	public Host setPort(int p) {
-		this.port = p;
-		this.socketAddress = new InetSocketAddress(hostname, port);
-		return this;
-	}
 
 	public Status getStatus() {
 		return status;
@@ -95,10 +101,6 @@ public class Host {
 		return rack;
 	}
 	
-	public Host setRack(String rack) {
-		this.rack = rack;
-		return this;
-	}
 	
 	public Host setStatus(Status condition) {
 		status = condition;
@@ -113,7 +115,7 @@ public class Host {
 		return socketAddress;
 	}
 	
-	public static final Host NO_HOST = new Host("UNKNOWN", "UNKNOWN", 0);
+
 
 	@Override
 	public int hashCode() {
@@ -121,6 +123,7 @@ public class Host {
 		int result = 1;
 		result = prime * result + ((hostname == null) ? 0 : hostname.hashCode());
 		result = prime * result + ((rack == null) ? 0 : rack.hashCode());
+		result = prime * result + port;
 		return result;
 	}
 
@@ -136,6 +139,7 @@ public class Host {
 		
 		equals &= (hostname != null) ? hostname.equals(other.hostname) : other.hostname == null;
 		equals &= (rack != null) ? rack.equals(other.rack) : other.rack == null;
+		equals &= port == other.port;
 		
 		return equals;
 	}
@@ -143,5 +147,18 @@ public class Host {
 	@Override
 	public String toString() {
 		return "Host [hostname=" + hostname + ", ipAddress=" + ipAddress + ", port=" + port + ", rack: " + rack + ", status: " + status.name() + "]";
+	}
+
+	@Override
+	public int compareTo(Host o) {
+	    int compared = this.hostname.compareTo(o.hostname);
+	    if( compared != 0) {
+		return compared;
+	    }
+	    compared = this.rack.compareTo(o.hostname);
+	    if( compared != 0) {
+		return compared;
+	    }
+	    return Integer.compare(this.port,o.port);
 	}
 }

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/HostGroup.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/HostGroup.java
@@ -33,8 +33,8 @@ public class HostGroup extends Host {
 
 	private final List<Host> hostList = new ArrayList<Host>();
 	
-	public HostGroup(String hostname, String ipAddress, int port) {
-		super(hostname, ipAddress, port);
+	public HostGroup(String hostname, String ipAddress, int port, String rack) {
+		super(hostname, ipAddress, port, rack);
 	}
 
 	public void add(Collection<Host> hosts) {

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolConfigurationImpl.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolConfigurationImpl.java
@@ -249,7 +249,6 @@ public class ConnectionPoolConfigurationImpl implements ConnectionPoolConfigurat
 				", tokenSupplier=" + tokenSupplier +
 				", hostConnectionPoolFactory=" + hostConnectionPoolFactory +
 				", name='" + name + '\'' +
-				", port=" + port +
 				", maxConnsPerHost=" + maxConnsPerHost +
 				", maxTimeoutWhenExhausted=" + maxTimeoutWhenExhausted +
 				", maxFailoverCount=" + maxFailoverCount +

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolConfigurationImpl.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolConfigurationImpl.java
@@ -31,7 +31,6 @@ import com.netflix.dyno.connectionpool.impl.utils.ConfigUtils;
 public class ConnectionPoolConfigurationImpl implements ConnectionPoolConfiguration {
 	
 	// DEFAULTS 
-	private static final int DEFAULT_PORT = 8102; 
 	private static final int DEFAULT_MAX_CONNS_PER_HOST = 3;
 	private static final int DEFAULT_MAX_TIMEOUT_WHEN_EXHAUSTED = 800;
 	private static final int DEFAULT_MAX_FAILOVER_COUNT = 3; 
@@ -55,7 +54,6 @@ public class ConnectionPoolConfigurationImpl implements ConnectionPoolConfigurat
 	private HostConnectionPoolFactory hostConnectionPoolFactory;
 
 	private final String name;
-	private int port = DEFAULT_PORT; 
 	private int maxConnsPerHost = DEFAULT_MAX_CONNS_PER_HOST; 
 	private int maxTimeoutWhenExhausted = DEFAULT_MAX_TIMEOUT_WHEN_EXHAUSTED; 
 	private int maxFailoverCount = DEFAULT_MAX_FAILOVER_COUNT; 
@@ -118,7 +116,6 @@ public class ConnectionPoolConfigurationImpl implements ConnectionPoolConfigurat
         this.maxTimeoutWhenExhausted = config.getMaxTimeoutWhenExhausted();
         this.pingFrequencySeconds = config.getPingFrequencySeconds();
         this.poolShutdownDelay = config.getPoolShutdownDelay();
-        this.port = config.getPort();
         this.retryFactory = config.getRetryPolicyFactory();
         this.socketTimeout = config.getSocketTimeout();
         this.errorMonitorFactory = config.getErrorMonitorFactory();
@@ -133,10 +130,6 @@ public class ConnectionPoolConfigurationImpl implements ConnectionPoolConfigurat
 		return name;
 	}
 
-	@Override
-	public int getPort() {
-		return port;
-	}
 
 	@Override
 	public int getMaxConnsPerHost() {
@@ -153,10 +146,6 @@ public class ConnectionPoolConfigurationImpl implements ConnectionPoolConfigurat
 		return maxFailoverCount;
 	}
 
-	public ConnectionPoolConfigurationImpl setPort(int port) {
-		this.port = port;
-		return this;
-	}
 
 	@Override
 	public int getConnectTimeout() {

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolImpl.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolImpl.java
@@ -142,8 +142,7 @@ public class ConnectionPoolImpl<CL> implements ConnectionPool<CL>, TopologyView 
 
 	public boolean addHost(Host host, boolean refreshLoadBalancer) {
 		
-		host.setPort(cpConfiguration.getPort());
-
+		
 		HostConnectionPool<CL> connPool = cpMap.get(host);
 		
 		if (connPool != null) {
@@ -197,10 +196,10 @@ public class ConnectionPoolImpl<CL> implements ConnectionPool<CL>, TopologyView 
 			cpHealthTracker.removeHost(host);
 			cpMonitor.hostRemoved(host);
 			hostPool.shutdown();
-            Logger.info(String.format("Remove host: Successfully removed host %s from connection pool", host.getHostAddress()));
+            Logger.info(String.format("Remove host: Successfully removed host %s:%s from connection pool", host.getHostAddress(), host.getPort()));
             return true;
 		} else {
-            Logger.info(String.format("Remove host: Host %s NOT FOUND in the connection pool", host.getHostAddress()));
+            Logger.info(String.format("Remove host: Host %s:%s NOT FOUND in the connection pool", host.getHostAddress(), host.getPort()));
 			return false;
 		}
 	}
@@ -366,7 +365,8 @@ public class ConnectionPoolImpl<CL> implements ConnectionPool<CL>, TopologyView 
 
 				do {
 					try {
-                        connection.getContext().setMetadata("host", connection.getHost().getHostAddress());
+					    	connection.getContext().setMetadata("host", connection.getHost().getHostAddress());
+					    	connection.getContext().setMetadata("port", connection.getHost().getPort());
 						OperationResult<R> result = connection.execute(op);
 
 						// Add context to the result from the successful execution

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/MonitorConsole.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/MonitorConsole.java
@@ -164,7 +164,6 @@ public class MonitorConsole implements MonitorConsoleMBean {
             config.put("hostSupplier", cpConfig.getHostSupplier().toString());
             config.put("loadBalancingStrategy", cpConfig.getLoadBalancingStrategy().name());
             config.put("maxConnsPerHost", String.valueOf(cpConfig.getMaxConnsPerHost()));
-            config.put("port", String.valueOf(cpConfig.getPort()));
             config.put("socketTimeout", String.valueOf(cpConfig.getSocketTimeout()));
             config.put("timingCountersResetFrequencyInSecs",
                     String.valueOf(cpConfig.getTimingCountersResetFrequencySeconds()));

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/hash/BinarySearchTokenMapper.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/hash/BinarySearchTokenMapper.java
@@ -99,7 +99,7 @@ public class BinarySearchTokenMapper implements HashPartitioner {
 		HostToken theToken = null;
 		
 		for (HostToken token : tokenMap.values()) {
-			if (token.getHost().getHostAddress().equals(host.getHostAddress())) {
+			if (token.getHost().equals(host)) {
 				theToken = token;
 				break;
 			}

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/lb/AbstractTokenMapSupplier.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/lb/AbstractTokenMapSupplier.java
@@ -58,16 +58,23 @@ public abstract class AbstractTokenMapSupplier implements TokenMapSupplier {
 	private static final Logger Logger = LoggerFactory.getLogger(AbstractTokenMapSupplier.class);
 	
 	private final String localZone;
-	protected final int port;
+	private int unsuppliedPort = -1;
 
-    public AbstractTokenMapSupplier() {
-        this(8080);
+    public AbstractTokenMapSupplier(String localRack) {
+        this.localZone = localRack;
+    }
+    public AbstractTokenMapSupplier(String localRack, int port){
+        this.localZone = localRack;
+        unsuppliedPort = port;
     }
 
-	public AbstractTokenMapSupplier(int port) {
-		localZone = ConfigUtils.getLocalZone();
-		this.port = port;
-	}
+    public AbstractTokenMapSupplier() {
+        localZone = ConfigUtils.getLocalZone();
+    }
+    public AbstractTokenMapSupplier(int port) {
+        localZone = ConfigUtils.getLocalZone();
+        unsuppliedPort = port;
+    }
 
 	public abstract String getTopologyJsonPayload(Set<Host> activeHosts);
 	
@@ -147,8 +154,14 @@ public abstract class AbstractTokenMapSupplier implements TokenMapSupplier {
 				Long token = Long.parseLong((String)jItem.get("token"));
 				String hostname = (String)jItem.get("hostname");
 				String zone = (String)jItem.get("zone");
+				String portStr = (String) jItem.get("port");
+				int port = unsuppliedPort;
+				if(portStr != null){
+				    port = Integer.valueOf(portStr);
+				}
 				
-				Host host = new Host(hostname, port, Status.Up).setRack(zone);
+				
+				Host host = new Host(hostname, port, zone, Status.Up);
 				HostToken hostToken = new HostToken(token, host);
 				hostTokens.add(hostToken);
 			}

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/lb/HttpEndpointBasedTokenMapSupplier.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/lb/HttpEndpointBasedTokenMapSupplier.java
@@ -45,15 +45,23 @@ public class HttpEndpointBasedTokenMapSupplier extends AbstractTokenMapSupplier 
 	private static final String DefaultServerUrl = "http://{hostname}:8080/REST/v1/admin/cluster_describe";
 	private final String serverUrl;
 	private static final Integer NumRetries = 2;
+	
 
-	public HttpEndpointBasedTokenMapSupplier(int port) {
-		this(DefaultServerUrl, port);
-	}
-
-	public HttpEndpointBasedTokenMapSupplier(String url, int port) {
+    public HttpEndpointBasedTokenMapSupplier(String url) {
+        serverUrl = url;
+    }
+    public HttpEndpointBasedTokenMapSupplier() {
+        serverUrl = DefaultServerUrl;
+    }
+    public HttpEndpointBasedTokenMapSupplier(int port) {
         super(port);
-		serverUrl = url;
-	}
+        serverUrl = DefaultServerUrl;
+        
+    }
+    public HttpEndpointBasedTokenMapSupplier(String url, int port) {
+        super(port);
+        serverUrl = url;
+    }
 
 	@Override
 	public String getTopologyJsonPayload(Set<Host> activeHosts) {

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolImplTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolImplTest.java
@@ -142,14 +142,14 @@ public class ConnectionPoolImplTest {
 		}
 	};
 	
-	private Host host1 = new Host("host1", 8080, Status.Up).setRack("localRack");
-	private Host host2 = new Host("host2", 8080, Status.Up).setRack("localRack");
-	private Host host3 = new Host("host3", 8080, Status.Up).setRack("localRack");
+	private Host host1 = new Host("host1", 8080, "localRack", Status.Up);
+	private Host host2 = new Host("host2", 8080, "localRack", Status.Up);
+	private Host host3 = new Host("host3", 8080, "localRack", Status.Up);
 
     // Used for Cross Rack fallback testing
-    private Host host4 = new Host("host4", 8080, Status.Up).setRack("remoteRack");
-    private Host host5 = new Host("host5", 8080, Status.Up).setRack("remoteRack");
-    private Host host6 = new Host("host6", 8080, Status.Up).setRack("remoteRack");
+    private Host host4 = new Host("host4", 8080, "remoteRack", Status.Up);
+    private Host host5 = new Host("host5", 8080, "remoteRack", Status.Up);
+    private Host host6 = new Host("host6", 8080, "remoteRack", Status.Up);
 
     private final List<Host> hostSupplierHosts = new ArrayList<Host>();
 	
@@ -642,9 +642,9 @@ public class ConnectionPoolImplTest {
 
         final ConnectionPoolImpl<TestClient> pool = new ConnectionPoolImpl<TestClient>(connFactory, cpConfig, cpMonitor);
 
-        hostSupplierHosts.add(new Host("host1_down", 8080, Status.Down).setRack("localRack"));
-        hostSupplierHosts.add(new Host("host2_down", 8080, Status.Down).setRack("localRack"));
-        hostSupplierHosts.add(new Host("host3_down", 8080, Status.Down).setRack("localRack"));
+        hostSupplierHosts.add(new Host("host1_down", 8080, "localRack", Status.Down));
+        hostSupplierHosts.add(new Host("host2_down", 8080, "localRack",Status.Down));
+        hostSupplierHosts.add(new Host("host3_down", 8080, "localRack", Status.Down));
 
         pool.start();
 

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/CountingConnectionPoolMonitorTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/CountingConnectionPoolMonitorTest.java
@@ -30,8 +30,8 @@ public class CountingConnectionPoolMonitorTest {
 
 		CountingConnectionPoolMonitor counter = new CountingConnectionPoolMonitor();
 
-		Host host1 = new Host("host1","address1", 1111);
-		Host host2 = new Host("host2","address2", 2222);
+		Host host1 = new Host("host1","address1", 1111, "rack1");
+		Host host2 = new Host("host2","address2", 2222, "rack1");
 
 		// Host 1
 		counter.incConnectionCreated(host1);

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/HostConnectionPoolImplTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/HostConnectionPoolImplTest.java
@@ -47,7 +47,7 @@ import com.netflix.dyno.connectionpool.exception.ThrottledException;
 
 public class HostConnectionPoolImplTest {
 
-	private static final Host TestHost = new Host("TestHost", "TestAddress", 1234);
+	private static final Host TestHost = new Host("TestHost", "TestAddress", 1234, "TestRack");
 
 	// TEST UTILS SETUP
 	private class TestClient {

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/HostStatusTrackerTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/HostStatusTrackerTest.java
@@ -135,7 +135,7 @@ public class HostStatusTrackerTest {
 		if (names != null && names.length > 0) {
 			for (String name : names) {
 				if (!name.isEmpty()) {
-					set.add(new Host(name, 1234));
+					set.add(new Host(name, 1234, "r1"));
 				}
 			}
 		}

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/OperationResultImplTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/OperationResultImplTest.java
@@ -30,7 +30,7 @@ public class OperationResultImplTest {
 
 		OperationMonitor monitor = new LastOperationMonitor();
 		OperationResultImpl<Integer> opResult = new OperationResultImpl<Integer>("test", 11, monitor);
-		Host host = new Host("testHost", "rand_ip", 1234);
+		Host host = new Host("testHost", "rand_ip", 1234, "rand_rack");
 
 		opResult.attempts(2)
 		.addMetadata("foo", "f1").addMetadata("bar", "b1")

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/SimpleAsyncConnectionPoolImplTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/SimpleAsyncConnectionPoolImplTest.java
@@ -44,7 +44,7 @@ import com.netflix.dyno.connectionpool.exception.ThrottledException;
 public class SimpleAsyncConnectionPoolImplTest {
 
 	// TEST UTILS SETUP
-	private static final Host TestHost = new Host("TestHost", "TestIp", 1234);
+	private static final Host TestHost = new Host("TestHost", "TestIp", 1234, "TestRack");
 
 	private class TestClient {}
 

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/hash/BinarySearchTokenMapperTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/hash/BinarySearchTokenMapperTest.java
@@ -69,7 +69,7 @@ public class BinarySearchTokenMapperTest {
 
 		// Now construct the midpoint token between 'h2' and 'h3' 
 		Long midpoint = 309687905L + (1383429731L - 309687905L)/2;
-		tokenMapper.addHostToken(new HostToken(midpoint, new Host("h23", Status.Up)));
+		tokenMapper.addHostToken(new HostToken(midpoint, new Host("h23", -1, "r1", Status.Up)));
 
 		failures += runTest(309687905L + 1L, 309687905L + 10L, "h23", tokenMapper);
 		Assert.assertTrue("Failures: " + failures, failures == 0);
@@ -93,7 +93,7 @@ public class BinarySearchTokenMapperTest {
 		Assert.assertTrue("Failures: " + failures, failures == 0);
 
 		// Now remove token 'h3'
-		tokenMapper.remoteHostToken(new HostToken(1383429731L, new Host("h2", Status.Up)));
+		tokenMapper.remoteHostToken(new HostToken(1383429731L, new Host("h2", -1, "r1", Status.Up)));
 
 		failures += runTest(309687905L + 1L, 309687905L + 10L, "h3", tokenMapper);
 		Assert.assertTrue("Failures: " + failures, failures == 0);
@@ -137,10 +137,10 @@ cqlsh:dyno_bootstrap>
 
 		List<HostToken> tokens = new ArrayList<HostToken>();
 
-		tokens.add(new HostToken(309687905L, new Host("h1", -1, Status.Up)));
-		tokens.add(new HostToken(1383429731L, new Host("h2", -1, Status.Up)));
-		tokens.add(new HostToken(2457171554L, new Host("h3", -1, Status.Up)));
-		tokens.add(new HostToken(3530913377L, new Host("h4", -1, Status.Up)));
+		tokens.add(new HostToken(309687905L, new Host("h1", -1, "r1", Status.Up)));
+		tokens.add(new HostToken(1383429731L, new Host("h2", -1, "r1", Status.Up)));
+		tokens.add(new HostToken(2457171554L, new Host("h3", -1, "r1", Status.Up)));
+		tokens.add(new HostToken(3530913377L, new Host("h4", -1, "r1", Status.Up)));
 
 		return tokens;
 	}

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/health/ConnectionPoolHealthTrackerTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/health/ConnectionPoolHealthTrackerTest.java
@@ -66,7 +66,7 @@ public class ConnectionPoolHealthTrackerTest {
 		ConnectionPoolHealthTracker<Integer> tracker = new ConnectionPoolHealthTracker<Integer>(config, threadPool, 1000, -1);
 		tracker.start();
 
-		Host h1 = new Host("h1", Status.Up);
+		Host h1 = new Host("h1", "r1", Status.Up);
 		AtomicBoolean poolStatus = new AtomicBoolean(false); 
 		HostConnectionPool<Integer> hostPool = getMockConnectionPool(h1, poolStatus);
 
@@ -94,7 +94,7 @@ public class ConnectionPoolHealthTrackerTest {
 		ConnectionPoolHealthTracker<Integer> tracker = new ConnectionPoolHealthTracker<Integer>(config, threadPool, 1000, -1);
 		tracker.start();
 
-		Host h1 = new Host("h1", Status.Up);
+		Host h1 = new Host("h1", "r1", Status.Up);
 		AtomicBoolean poolStatus = new AtomicBoolean(false); 
 		HostConnectionPool<Integer> hostPool = getMockConnectionPool(h1, poolStatus, true);
 

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/lb/AbstractTokenMapSupplierTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/lb/AbstractTokenMapSupplierTest.java
@@ -26,14 +26,14 @@ import com.netflix.dyno.connectionpool.Host.Status;
 
 public class AbstractTokenMapSupplierTest {
 
-	final String json = "[{\"token\":\"3051939411\",\"hostname\":\"ec2-54-237-143-4.compute-1.amazonaws.com\",\"dc\":\"florida\",\"ip\":\"54.237.143.4\",\"zone\":\"us-east-1d\",\"location\":\"us-east-1\"}\"," +
-			"\"{\"token\":\"188627880\",\"hostname\":\"ec2-50-17-65-2.compute-1.amazonaws.com\",\"dc\":\"florida\",\"ip\":\"50.17.65.2\",\"zone\":\"us-east-1d\",\"location\":\"us-east-1\"},\"" +
-			"\"{\"token\":\"2019187467\",\"hostname\":\"ec2-54-83-87-174.compute-1.amazonaws.com\",\"dc\":\"florida-v001\",\"ip\":\"54.83.87.174\",\"zone\":\"us-east-1c\",\"location\":\"us-east-1\"},\"" +
-			"\"{\"token\":\"3450843231\",\"hostname\":\"ec2-54-81-138-73.compute-1.amazonaws.com\",\"dc\":\"florida-v001\",\"ip\":\"54.81.138.73\",\"zone\":\"us-east-1c\",\"location\":\"us-east-1\"},\""+
-			"\"{\"token\":\"587531700\",\"hostname\":\"ec2-54-82-176-215.compute-1.amazonaws.com\",\"dc\":\"florida-v001\",\"ip\":\"54.82.176.215\",\"zone\":\"us-east-1c\",\"location\":\"us-east-1\"},\"" +
-			"\"{\"token\":\"3101134286\",\"hostname\":\"ec2-54-82-83-115.compute-1.amazonaws.com\",\"dc\":\"florida-v000\",\"ip\":\"54.82.83.115\",\"zone\":\"us-east-1e\",\"location\":\"us-east-1\"},\"" +
-			"\"{\"token\":\"237822755\",\"hostname\":\"ec2-54-211-220-55.compute-1.amazonaws.com\",\"dc\":\"florida-v000\",\"ip\":\"54.211.220.55\",\"zone\":\"us-east-1e\",\"location\":\"us-east-1\"},\"" +
-			"\"{\"token\":\"1669478519\",\"hostname\":\"ec2-54-80-65-203.compute-1.amazonaws.com\",\"dc\":\"florida-v000\",\"ip\":\"54.80.65.203\",\"zone\":\"us-east-1e\",\"location\":\"us-east-1\"}]\"";
+	final String json = "[{\"token\":\"3051939411\",\"hostname\":\"ec2-54-237-143-4.compute-1.amazonaws.com\",\"port\":\"11211\",\"dc\":\"florida\",\"ip\":\"54.237.143.4\",\"zone\":\"us-east-1d\",\"location\":\"us-east-1\"}\"," +
+			"\"{\"token\":\"188627880\",\"hostname\":\"ec2-50-17-65-2.compute-1.amazonaws.com\",\"port\":\"11211\",\"dc\":\"florida\",\"ip\":\"50.17.65.2\",\"zone\":\"us-east-1d\",\"location\":\"us-east-1\"},\"" +
+			"\"{\"token\":\"2019187467\",\"hostname\":\"ec2-54-83-87-174.compute-1.amazonaws.com\",\"port\":\"11211\",\"dc\":\"florida-v001\",\"ip\":\"54.83.87.174\",\"zone\":\"us-east-1c\",\"location\":\"us-east-1\"},\"" +
+			"\"{\"token\":\"3450843231\",\"hostname\":\"ec2-54-81-138-73.compute-1.amazonaws.com\",\"port\":\"11211\",\"dc\":\"florida-v001\",\"ip\":\"54.81.138.73\",\"zone\":\"us-east-1c\",\"location\":\"us-east-1\"},\""+
+			"\"{\"token\":\"587531700\",\"hostname\":\"ec2-54-82-176-215.compute-1.amazonaws.com\",\"port\":\"11211\",\"dc\":\"florida-v001\",\"ip\":\"54.82.176.215\",\"zone\":\"us-east-1c\",\"location\":\"us-east-1\"},\"" +
+			"\"{\"token\":\"3101134286\",\"hostname\":\"ec2-54-82-83-115.compute-1.amazonaws.com\",\"port\":\"11211\",\"dc\":\"florida-v000\",\"ip\":\"54.82.83.115\",\"zone\":\"us-east-1e\",\"location\":\"us-east-1\"},\"" +
+			"\"{\"token\":\"237822755\",\"hostname\":\"ec2-54-211-220-55.compute-1.amazonaws.com\",\"port\":\"11211\",\"dc\":\"florida-v000\",\"ip\":\"54.211.220.55\",\"zone\":\"us-east-1e\",\"location\":\"us-east-1\"},\"" +
+			"\"{\"token\":\"1669478519\",\"hostname\":\"ec2-54-80-65-203.compute-1.amazonaws.com\",\"port\":\"11211\",\"dc\":\"florida-v000\",\"ip\":\"54.80.65.203\",\"zone\":\"us-east-1e\",\"location\":\"us-east-1\"}]\"";
 
 	private TokenMapSupplier testTokenMapSupplier = new AbstractTokenMapSupplier() {
 
@@ -53,14 +53,14 @@ public class AbstractTokenMapSupplierTest {
 
 		List<Host> hostList = new ArrayList<Host>();
 
-		hostList.add(new Host("ec2-54-237-143-4.compute-1.amazonaws.com", 11211, Status.Up));
-		hostList.add(new Host("ec2-50-17-65-2.compute-1.amazonaws.com", 11211, Status.Up));
-		hostList.add(new Host("ec2-54-83-87-174.compute-1.amazonaws.com", 11211, Status.Up));
-		hostList.add(new Host("ec2-54-81-138-73.compute-1.amazonaws.com", 11211, Status.Up));
-		hostList.add(new Host("ec2-54-82-176-215.compute-1.amazonaws.com", 11211, Status.Up));
-		hostList.add(new Host("ec2-54-82-83-115.compute-1.amazonaws.com", 11211, Status.Up));
-		hostList.add(new Host("ec2-54-211-220-55.compute-1.amazonaws.com", 11211, Status.Up));
-		hostList.add(new Host("ec2-54-80-65-203.compute-1.amazonaws.com", 11211, Status.Up));
+		hostList.add(new Host("ec2-54-237-143-4.compute-1.amazonaws.com", 11211,"us-east-1d",  Status.Up));
+		hostList.add(new Host("ec2-50-17-65-2.compute-1.amazonaws.com", 11211, "us-east-1d" , Status.Up));
+		hostList.add(new Host("ec2-54-83-87-174.compute-1.amazonaws.com", 11211, "us-east-1c", Status.Up));
+		hostList.add(new Host("ec2-54-81-138-73.compute-1.amazonaws.com", 11211, "us-east-1c", Status.Up));
+		hostList.add(new Host("ec2-54-82-176-215.compute-1.amazonaws.com", 11211, "us-east-1c", Status.Up));
+		hostList.add(new Host("ec2-54-82-83-115.compute-1.amazonaws.com", 11211, "us-east-1e", Status.Up));
+		hostList.add(new Host("ec2-54-211-220-55.compute-1.amazonaws.com", 11211, "us-east-1c", Status.Up));
+		hostList.add(new Host("ec2-54-80-65-203.compute-1.amazonaws.com", 11211, "us-east-1c", Status.Up));
 
 		List<HostToken> hTokens = testTokenMapSupplier.getTokens(new HashSet<Host>(hostList));
 		Collections.sort(hTokens, new Comparator<HostToken>() {

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/lb/HostSelectionWithFallbackTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/lb/HostSelectionWithFallbackTest.java
@@ -71,12 +71,12 @@ public class HostSelectionWithFallbackTest {
 	private final ConnectionPoolConfigurationImpl cpConfig = new ConnectionPoolConfigurationImpl("test");
 	private final ConnectionPoolMonitor cpMonitor = new CountingConnectionPoolMonitor();
 
-	Host h1 = new Host("h1", Status.Up).setRack("localTestRack");
-	Host h2 = new Host("h2", Status.Up).setRack("localTestRack");
-	Host h3 = new Host("h3", Status.Up).setRack("remoteRack1");
-	Host h4 = new Host("h4", Status.Up).setRack("remoteRack1");
-	Host h5 = new Host("h5", Status.Up).setRack("remoteRack2");
-	Host h6 = new Host("h6", Status.Up).setRack("remoteRack2");
+	Host h1 = new Host("h1", "localTestRack", Status.Up);
+	Host h2 = new Host("h2", "localTestRack", Status.Up);
+	Host h3 = new Host("h3", "remoteRack1", Status.Up);
+	Host h4 = new Host("h4", "remoteRack1", Status.Up);
+	Host h5 = new Host("h5", "remoteRack2", Status.Up);
+	Host h6 = new Host("h6", "remoteRack2", Status.Up);
 
 	Host[] arr = {h1, h2, h3, h4, h5, h6};
 	List<Host> hosts = Arrays.asList(arr);
@@ -389,21 +389,21 @@ public class HostSelectionWithFallbackTest {
         HostSelectionWithFallback<Integer> selection = new HostSelectionWithFallback<Integer>(cpConfig, cpMonitor);
 
         List<HostToken> hostTokens = Arrays.asList(
-                new HostToken(1383429731L, new Host("host-1", -1).setRack("localTestRack")), // Use -1 otherwise the port is opened which works
-                new HostToken(2815085496L, new Host("host-2", -1).setRack("localTestRack")), // but slows down the test
-                new HostToken(4246741261L, new Host("host-3", -1).setRack("localTestRack")),
-                new HostToken(1383429731L, new Host("host-4", -1).setRack("localTestRack")),
-                new HostToken(2815085496L, new Host("host-5", -1).setRack("localTestRack")),
-                new HostToken(4246741261L, new Host("host-6", -1).setRack("localTestRack")),
-                new HostToken(1383429731L, new Host("host-7", -1).setRack("localTestRack")),
-                new HostToken(2815085496L, new Host("host-8", -1).setRack("localTestRack")),
-                new HostToken(4246741261L, new Host("host-9", -1).setRack("localTestRack")),
-                new HostToken(1383429731L, new Host("host-7", -1).setRack("localTestRack")),
-                new HostToken(2815085496L, new Host("host-8", -1).setRack("localTestRack")),
-                new HostToken(4246741261L, new Host("host-9", -1).setRack("localTestRack")),
-                new HostToken(1383429731L, new Host("host-7", -1).setRack("localTestRack")),
-                new HostToken(2815085496L, new Host("host-8", -1).setRack("localTestRack")),
-                new HostToken(4246741261L, new Host("host-9", -1).setRack("localTestRack"))
+                new HostToken(1383429731L, new Host("host-1", -1, "localTestRack")), // Use -1 otherwise the port is opened which works
+                new HostToken(2815085496L, new Host("host-2", -1, "localTestRack")),
+                new HostToken(4246741261L, new Host("host-3", -1, "localTestRack" )),
+                new HostToken(1383429731L, new Host("host-4", -1, "localTestRack")),
+                new HostToken(2815085496L, new Host("host-5", -1, "localTestRack")),
+                new HostToken(4246741261L, new Host("host-6", -1, "localTestRack")),
+                new HostToken(1383429731L, new Host("host-7", -1, "localTestRack")),
+                new HostToken(2815085496L, new Host("host-8", -1, "localTestRack")),
+                new HostToken(4246741261L, new Host("host-9", -1, "localTestRack")),
+                new HostToken(1383429731L, new Host("host-7", -1, "localTestRack")),
+                new HostToken(2815085496L, new Host("host-8", -1, "localTestRack")),
+                new HostToken(4246741261L, new Host("host-9", -1, "localTestRack")),
+                new HostToken(1383429731L, new Host("host-7", -1, "localTestRack")),
+                new HostToken(2815085496L, new Host("host-8", -1, "localTestRack")),
+                new HostToken(4246741261L, new Host("host-9", -1, "localTestRack"))
 
         );
 
@@ -421,12 +421,12 @@ public class HostSelectionWithFallbackTest {
 		HostSelectionWithFallback<Integer> selection = new HostSelectionWithFallback<Integer>(cpConfig, cpMonitor);
 
         List<HostToken> hostTokens = Arrays.asList(
-                new HostToken(1111L, new Host("host-1", -1).setRack("us-east-1c")),
-                new HostToken(1111L, new Host("host-2", -1).setRack("us-east-1d")),
-                new HostToken(1111L, new Host("host-3", -1).setRack("us-east-1e")),
-                new HostToken(2222L, new Host("host-4", -1).setRack("us-east-1c")),
-                new HostToken(2222L, new Host("host-5", -1).setRack("us-east-1d")),
-                new HostToken(2222L, new Host("host-6", -1).setRack("us-east-1e"))
+                new HostToken(1111L, new Host("host-1", -1, "us-east-1c")),
+                new HostToken(1111L, new Host("host-2", -1, "us-east-1d")),
+                new HostToken(1111L, new Host("host-3", -1, "us-east-1e")),
+                new HostToken(2222L, new Host("host-4", -1, "us-east-1c")),
+                new HostToken(2222L, new Host("host-5", -1, "us-east-1d")),
+                new HostToken(2222L, new Host("host-6", -1, "us-east-1e"))
         );
 
 		int rf = selection.calculateReplicationFactor(hostTokens);
@@ -443,10 +443,10 @@ public class HostSelectionWithFallbackTest {
         HostSelectionWithFallback<Integer> selection = new HostSelectionWithFallback<Integer>(cpConfig, cpMonitor);
 
         List<HostToken> hostTokens = Arrays.asList(
-                new HostToken(1111L, new Host("host-1", -1).setRack("us-east-1c")),
-                new HostToken(1111L, new Host("host-2", -1).setRack("us-east-1d")),
-                new HostToken(2222L, new Host("host-4", -1).setRack("us-east-1c")),
-                new HostToken(2222L, new Host("host-5", -1).setRack("us-east-1d"))
+                new HostToken(1111L, new Host("host-1", -1, "us-east-1c")),
+                new HostToken(1111L, new Host("host-2", -1, "us-east-1d")),
+                new HostToken(2222L, new Host("host-4", -1, "us-east-1c")),
+                new HostToken(2222L, new Host("host-5", -1, "us-east-1d"))
         );
 
         int rf = selection.calculateReplicationFactor(hostTokens);
@@ -482,9 +482,9 @@ public class HostSelectionWithFallbackTest {
         HostSelectionWithFallback<Integer> selection = new HostSelectionWithFallback<Integer>(cpConfig, cpMonitor);
 
         List<HostToken> hostTokens = Arrays.asList(
-                new HostToken(1111L, new Host("host-1", -1).setRack("us-east-1c")),
-                new HostToken(1111L, new Host("host-2", -1).setRack("us-east-1d")),
-                new HostToken(2222L, new Host("host-4", -1).setRack("us-east-1c"))
+                new HostToken(1111L, new Host("host-1", -1, "us-east-1c")),
+                new HostToken(1111L, new Host("host-2", -1, "us-east-1d")),
+                new HostToken(2222L, new Host("host-4", -1, "us-east-1c"))
         );
 
         selection.calculateReplicationFactor(hostTokens);
@@ -500,26 +500,26 @@ public class HostSelectionWithFallbackTest {
         HostSelectionWithFallback<Integer> selection = new HostSelectionWithFallback<Integer>(cpConfig, cpMonitor);
 
         List<HostToken> hostTokens = Arrays.asList(
-                new HostToken(3530913378L, new Host("host-1", -1).setRack("us-east-1c")),
-                new HostToken(1383429731L, new Host("host-1", -1).setRack("us-east-1c")),
-                new HostToken(3530913378L, new Host("host-2", -1).setRack("us-east-1d")),
-                new HostToken(1383429731L, new Host("host-2", -1).setRack("us-east-1d")),
-                new HostToken(1383429731L, new Host("host-3", -1).setRack("us-east-1e")),
-                new HostToken(3530913378L, new Host("host-3", -1).setRack("us-east-1e")),
+                new HostToken(3530913378L, new Host("host-1", -1, "us-east-1c")),
+                new HostToken(1383429731L, new Host("host-1", -1, "us-east-1c")),
+                new HostToken(3530913378L, new Host("host-2", -1, "us-east-1d")),
+                new HostToken(1383429731L, new Host("host-2", -1, "us-east-1d")),
+                new HostToken(1383429731L, new Host("host-3", -1, "us-east-1e")),
+                new HostToken(3530913378L, new Host("host-3", -1, "us-east-1e")),
 
-                new HostToken(3530913378L, new Host("host-4", -1).setRack("us-west-2a")),
-                new HostToken(1383429731L, new Host("host-4", -1).setRack("us-west-2a")),
-                new HostToken(3530913378L, new Host("host-5", -1).setRack("us-west-2b")),
-                new HostToken(1383429731L, new Host("host-5", -1).setRack("us-west-2b")),
-                new HostToken(3530913378L, new Host("host-6", -1).setRack("us-west-2c")),
-                new HostToken(1383429731L, new Host("host-6", -1).setRack("us-west-2c")),
+                new HostToken(3530913378L, new Host("host-4", -1, "us-west-2a")),
+                new HostToken(1383429731L, new Host("host-4", -1, "us-west-2a")),
+                new HostToken(3530913378L, new Host("host-5", -1, "us-west-2b")),
+                new HostToken(1383429731L, new Host("host-5", -1, "us-west-2b")),
+                new HostToken(3530913378L, new Host("host-6", -1, "us-west-2c")),
+                new HostToken(1383429731L, new Host("host-6", -1, "us-west-2c")),
 
-                new HostToken(3530913378L, new Host("host-7", -1).setRack("eu-west-1a")),
-                new HostToken(1383429731L, new Host("host-7", -1).setRack("eu-west-1a")),
-                new HostToken(1383429731L, new Host("host-8", -1).setRack("eu-west-1b")),
-                new HostToken(3530913378L, new Host("host-8", -1).setRack("eu-west-1b")),
-                new HostToken(3530913378L, new Host("host-9", -1).setRack("eu-west-1c")),
-                new HostToken(1383429731L, new Host("host-9", -1).setRack("eu-west-1c"))
+                new HostToken(3530913378L, new Host("host-7", -1, "eu-west-1a")),
+                new HostToken(1383429731L, new Host("host-7", -1, "eu-west-1a")),
+                new HostToken(1383429731L, new Host("host-8", -1, "eu-west-1b")),
+                new HostToken(3530913378L, new Host("host-8", -1, "eu-west-1b")),
+                new HostToken(3530913378L, new Host("host-9", -1, "eu-west-1c")),
+                new HostToken(1383429731L, new Host("host-9", -1, "eu-west-1c"))
         );
 
         int rf = selection.calculateReplicationFactor(hostTokens);

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/lb/HostTokenTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/lb/HostTokenTest.java
@@ -30,28 +30,28 @@ public class HostTokenTest {
 	@Test
 	public void testEquals() throws Exception {
 
-		HostToken t1 = new HostToken(1L, new Host("foo", 1234));
-		HostToken t2 = new HostToken(1L, new Host("foo", 1234));
+		HostToken t1 = new HostToken(1L, new Host("foo", 1234, "foo_rack"));
+		HostToken t2 = new HostToken(1L, new Host("foo", 1234, "foo_rack"));
 
 		Assert.assertEquals(t1, t2);
 
 		// change token
-		HostToken t3 = new HostToken(2L, new Host("foo", 1234));
+		HostToken t3 = new HostToken(2L, new Host("foo", 1234, "foo_rack"));
 		Assert.assertFalse(t1.equals(t3));
 
 		// change host name
-		HostToken t4 = new HostToken(1L, new Host("foo1", 1234));
+		HostToken t4 = new HostToken(1L, new Host("foo1", 1234, "foo_rack"));
 		Assert.assertFalse(t1.equals(t4));
 	}
 
 	@Test
 	public void testSort() throws Exception {
 
-		HostToken t1 = new HostToken(1L, new Host("foo1", 1234));
-		HostToken t2 = new HostToken(2L, new Host("foo2", 1234));
-		HostToken t3 = new HostToken(3L, new Host("foo3", 1234));
-		HostToken t4 = new HostToken(4L, new Host("foo4", 1234));
-		HostToken t5 = new HostToken(5L, new Host("foo5", 1234));
+		HostToken t1 = new HostToken(1L, new Host("foo1", 1234, "foo_rack"));
+		HostToken t2 = new HostToken(2L, new Host("foo2", 1234, "foo_rack"));
+		HostToken t3 = new HostToken(3L, new Host("foo3", 1234, "foo_rack"));
+		HostToken t4 = new HostToken(4L, new Host("foo4", 1234, "foo_rack"));
+		HostToken t5 = new HostToken(5L, new Host("foo5", 1234, "foo_rack"));
 
 		HostToken[] arr = {t5, t2, t4, t3, t1};
 		List<HostToken> list = Arrays.asList(arr);

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/lb/RoundRobinSelectionTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/lb/RoundRobinSelectionTest.java
@@ -51,10 +51,10 @@ public class RoundRobinSelectionTest {
 	 */
 
 
-	private final HostToken h1 = new HostToken(309687905L, new Host("h1", -1, Status.Up));
-	private final HostToken h2 = new HostToken(1383429731L, new Host("h2", -1, Status.Up));
-	private final HostToken h3 = new HostToken(2457171554L, new Host("h3", -1, Status.Up));
-	private final HostToken h4 = new HostToken(3530913377L, new Host("h4", -1, Status.Up));
+	private final HostToken h1 = new HostToken(309687905L, new Host("h1", -1, "r1", Status.Up));
+	private final HostToken h2 = new HostToken(1383429731L, new Host("h2", -1, "r1", Status.Up));
+	private final HostToken h3 = new HostToken(2457171554L, new Host("h3", -1, "r1", Status.Up));
+	private final HostToken h4 = new HostToken(3530913377L, new Host("h4", -1, "r1", Status.Up));
 
 	private final BaseOperation<Integer, Integer> testOperation = new BaseOperation<Integer, Integer>() {
 

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/lb/TokenMapSupplierTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/lb/TokenMapSupplierTest.java
@@ -42,16 +42,16 @@ public class TokenMapSupplierTest {
 
 		List<Host> hostList = new ArrayList<Host>();
 
-		hostList.add(new Host("ec2-54-237-143-4.compute-1.amazonaws.com", 11211, Status.Up));
-		hostList.add(new Host("ec2-50-17-65-2.compute-1.amazonaws.com", 11211, Status.Up));
-		hostList.add(new Host("ec2-54-83-87-174.compute-1.amazonaws.com", 11211, Status.Up));
-		hostList.add(new Host("ec2-54-81-138-73.compute-1.amazonaws.com", 11211, Status.Up));
-		hostList.add(new Host("ec2-54-82-176-215.compute-1.amazonaws.com", 11211, Status.Up));
-		hostList.add(new Host("ec2-54-82-83-115.compute-1.amazonaws.com", 11211, Status.Up));
-		hostList.add(new Host("ec2-54-211-220-55.compute-1.amazonaws.com", 11211, Status.Up));
-		hostList.add(new Host("ec2-54-80-65-203.compute-1.amazonaws.com", 11211, Status.Up));
+		hostList.add(new Host("ec2-54-237-143-4.compute-1.amazonaws.com", 11211, "us-east-1d", Status.Up));
+		hostList.add(new Host("ec2-50-17-65-2.compute-1.amazonaws.com", 11211, "us-east-1d", Status.Up));
+		hostList.add(new Host("ec2-54-83-87-174.compute-1.amazonaws.com", 11211, "us-east-1c", Status.Up));
+		hostList.add(new Host("ec2-54-81-138-73.compute-1.amazonaws.com", 11211, "us-east-1c", Status.Up));
+		hostList.add(new Host("ec2-54-82-176-215.compute-1.amazonaws.com", 11211, "us-east-1c", Status.Up));
+		hostList.add(new Host("ec2-54-82-83-115.compute-1.amazonaws.com", 11211, "us-east-1e", Status.Up));
+		hostList.add(new Host("ec2-54-211-220-55.compute-1.amazonaws.com", 11211, "us-east-1e", Status.Up));
+		hostList.add(new Host("ec2-54-80-65-203.compute-1.amazonaws.com", 11211, "us-east-1e", Status.Up));
 
-        HttpEndpointBasedTokenMapSupplier tokenSupplier = new HttpEndpointBasedTokenMapSupplier(8080);
+        HttpEndpointBasedTokenMapSupplier tokenSupplier = new HttpEndpointBasedTokenMapSupplier("us-east-1d", 11211);
 
 		List<HostToken> hTokens = tokenSupplier.parseTokenListFromJson(json);
 
@@ -71,5 +71,65 @@ public class TokenMapSupplierTest {
 		Assert.assertTrue(hTokens.get(6).getHost().getHostAddress().equals("ec2-54-211-220-55.compute-1.amazonaws.com"));
 		Assert.assertTrue(hTokens.get(7).getToken().equals(1669478519L));
 		Assert.assertTrue(hTokens.get(7).getHost().getHostAddress().equals("ec2-54-80-65-203.compute-1.amazonaws.com"));
+	}
+	@Test
+	public void testParseJsonWithPorts() throws Exception {
+
+
+		String json = "[{\"token\":\"3051939411\",\"hostname\":\"ec2-54-237-143-4.compute-1.amazonaws.com\",\"port\":\"11211\",\"dc\":\"florida\",\"ip\":\"54.237.143.4\",\"zone\":\"us-east-1d\",\"location\":\"us-east-1\"}\"," +
+				"\"{\"token\":\"188627880\",\"hostname\":\"ec2-54-237-143-4.compute-1.amazonaws.com\",\"port\":\"11212\",\"dc\":\"florida\",\"ip\":\"50.17.65.2\",\"zone\":\"us-east-1d\",\"location\":\"us-east-1\"},\"" +
+				"\"{\"token\":\"2019187467\",\"hostname\":\"ec2-54-237-143-4.compute-1.amazonaws.com\",\"port\":\"11213\",\"dc\":\"florida-v001\",\"ip\":\"54.83.87.174\",\"zone\":\"us-east-1c\",\"location\":\"us-east-1\"},\"" +
+				"\"{\"token\":\"3450843231\",\"hostname\":\"ec2-54-237-143-4.compute-1.amazonaws.com\",\"port\":\"11214\",\"dc\":\"florida-v001\",\"ip\":\"54.81.138.73\",\"zone\":\"us-east-1c\",\"location\":\"us-east-1\"},\""+
+				"\"{\"token\":\"587531700\",\"hostname\":\"ec2-54-82-176-215.compute-1.amazonaws.com\",\"port\":\"11215\",\"dc\":\"florida-v001\",\"ip\":\"54.82.176.215\",\"zone\":\"us-east-1c\",\"location\":\"us-east-1\"},\"" +
+				"\"{\"token\":\"3101134286\",\"hostname\":\"ec2-54-82-83-115.compute-1.amazonaws.com\",\"port\":\"11216\",\"dc\":\"florida-v000\",\"ip\":\"54.82.83.115\",\"zone\":\"us-east-1e\",\"location\":\"us-east-1\"},\"" +
+				"\"{\"token\":\"237822755\",\"hostname\":\"ec2-54-211-220-55.compute-1.amazonaws.com\",\"port\":\"11217\",\"dc\":\"florida-v000\",\"ip\":\"54.211.220.55\",\"zone\":\"us-east-1e\",\"location\":\"us-east-1\"},\"" +
+				"\"{\"token\":\"1669478519\",\"hostname\":\"ec2-54-80-65-203.compute-1.amazonaws.com\",\"port\":\"11218\",\"dc\":\"florida-v000\",\"ip\":\"54.80.65.203\",\"zone\":\"us-east-1e\",\"location\":\"us-east-1\"}]\"";
+
+		List<Host> hostList = new ArrayList<Host>();
+
+		hostList.add(new Host("ec2-54-237-143-4.compute-1.amazonaws.com", 11211, "us-east-1d", Status.Up));
+		hostList.add(new Host("ec2-54-237-143-4.compute-1.amazonaws.com", 11212, "us-east-1d", Status.Up));
+		hostList.add(new Host("ec2-54-237-143-4.compute-1.amazonaws.com", 11213, "us-east-1c", Status.Up));
+		hostList.add(new Host("ec2-54-237-143-4.compute-1.amazonaws.com", 11214, "us-east-1c", Status.Up));
+		hostList.add(new Host("ec2-54-82-176-215.compute-1.amazonaws.com", 11215, "us-east-1c", Status.Up));
+		hostList.add(new Host("ec2-54-82-83-115.compute-1.amazonaws.com", 11216, "us-east-1e", Status.Up));
+		hostList.add(new Host("ec2-54-211-220-55.compute-1.amazonaws.com", 11217, "us-east-1e", Status.Up));
+		hostList.add(new Host("ec2-54-80-65-203.compute-1.amazonaws.com", 11218, "us-east-1e", Status.Up));
+
+        HttpEndpointBasedTokenMapSupplier tokenSupplier = new HttpEndpointBasedTokenMapSupplier("us-east-1d", 11211);
+
+		List<HostToken> hTokens = tokenSupplier.parseTokenListFromJson(json);
+
+		Assert.assertTrue(hTokens.get(0).getToken().equals(3051939411L));
+		Assert.assertTrue(hTokens.get(0).getHost().getHostAddress().equals("ec2-54-237-143-4.compute-1.amazonaws.com"));
+		Assert.assertEquals(hTokens.get(0).getHost().getPort(), 11211);
+		
+		Assert.assertTrue(hTokens.get(1).getToken().equals(188627880L));
+		Assert.assertTrue(hTokens.get(1).getHost().getHostAddress().equals("ec2-54-237-143-4.compute-1.amazonaws.com"));
+		Assert.assertEquals(hTokens.get(1).getHost().getPort(), 11212);
+		
+		Assert.assertTrue(hTokens.get(2).getToken().equals(2019187467L));
+		Assert.assertTrue(hTokens.get(2).getHost().getHostAddress().equals("ec2-54-237-143-4.compute-1.amazonaws.com"));
+		Assert.assertEquals(hTokens.get(2).getHost().getPort(), 11213);
+		
+		Assert.assertTrue(hTokens.get(3).getToken().equals(3450843231L));
+		Assert.assertTrue(hTokens.get(3).getHost().getHostAddress().equals("ec2-54-237-143-4.compute-1.amazonaws.com"));
+		Assert.assertEquals(hTokens.get(3).getHost().getPort(), 11214);
+		
+		Assert.assertTrue(hTokens.get(4).getToken().equals(587531700L));
+		Assert.assertTrue(hTokens.get(4).getHost().getHostAddress().equals("ec2-54-82-176-215.compute-1.amazonaws.com"));
+		Assert.assertEquals(hTokens.get(4).getHost().getPort(), 11215);
+		
+		Assert.assertTrue(hTokens.get(5).getToken().equals(3101134286L));
+		Assert.assertTrue(hTokens.get(5).getHost().getHostAddress().equals("ec2-54-82-83-115.compute-1.amazonaws.com"));
+		Assert.assertEquals(hTokens.get(5).getHost().getPort(), 11216);
+		
+		Assert.assertTrue(hTokens.get(6).getToken().equals(237822755L));
+		Assert.assertTrue(hTokens.get(6).getHost().getHostAddress().equals("ec2-54-211-220-55.compute-1.amazonaws.com"));
+		Assert.assertEquals(hTokens.get(6).getHost().getPort(), 11217);
+		
+		Assert.assertTrue(hTokens.get(7).getToken().equals(1669478519L));
+		Assert.assertTrue(hTokens.get(7).getHost().getHostAddress().equals("ec2-54-80-65-203.compute-1.amazonaws.com"));
+		Assert.assertEquals(hTokens.get(7).getHost().getPort(), 11218);
 	}
 }

--- a/dyno-demo/src/main/java/com/netflix/dyno/demo/redis/CustomTokenSupplierExample.java
+++ b/dyno-demo/src/main/java/com/netflix/dyno/demo/redis/CustomTokenSupplierExample.java
@@ -49,7 +49,7 @@ public class CustomTokenSupplierExample {
 
         final int port = 6379;
 
-        final Host localHost = new Host("localhost", port, Host.Status.Up);
+        final Host localHost = new Host("localhost", port, "localrack", Host.Status.Up);
 
         final HostSupplier localHostSupplier = new HostSupplier() {
 
@@ -81,7 +81,6 @@ public class CustomTokenSupplierExample {
                 .withHostSupplier(localHostSupplier)
                 .withCPConfig(new ConnectionPoolConfigurationImpl("tokenSupplierExample")
                         .withTokenSupplier(supplier))
-                .withPort(port)
                 .build();
 
     }

--- a/dyno-demo/src/main/java/com/netflix/dyno/demo/redis/DynoJedisDemo.java
+++ b/dyno-demo/src/main/java/com/netflix/dyno/demo/redis/DynoJedisDemo.java
@@ -66,7 +66,7 @@ public class DynoJedisDemo {
 
 		final int port = 6379; 
 		
-		final Host localHost = new Host("localhost", port, Status.Up);
+		final Host localHost = new Host("localhost", port, "localrack", Status.Up);
 
 		final HostSupplier localHostSupplier = new HostSupplier() {
 
@@ -126,7 +126,6 @@ public class DynoJedisDemo {
                         //.setCompressionThreshold(2)
                         //.setLocalRack(this.localRack)
 //      )
-		.withPort(port)
 		.build();
 	}
 
@@ -396,7 +395,7 @@ public class DynoJedisDemo {
 				if (parts.length != 2) {
 					throw new RuntimeException("Bad data format in file:" + line);
 				}
-				Host host = new Host(parts[0].trim(), port, Status.Up).setRack(parts[1].trim());
+				Host host = new Host(parts[0].trim(), port, parts[1].trim(), Status.Up);
 				hosts.add(host);
 			}
 		} finally {
@@ -583,10 +582,10 @@ public class DynoJedisDemo {
 			
 			for (Map<String, String> map : handler.getList()) {
 				
-				Host host = new Host(map.get("public-hostname"), 8102);
-				host.setRack(map.get("availability-zone"));
-				host.setStatus(map.get("status").equalsIgnoreCase("UP") ? Status.Up : Status.Down);
-				
+
+				String rack = map.get("availability-zone");
+				Status status = map.get("status").equalsIgnoreCase("UP") ? Status.Up : Status.Down;
+                Host host = new Host(map.get("public-hostname"), 8102, rack, status);
 				hosts.add(host);
 				System.out.println("Host: " + host);
 			}

--- a/dyno-jedis/src/main/java/com/netflix/dyno/jedis/DynoJedisClient.java
+++ b/dyno-jedis/src/main/java/com/netflix/dyno/jedis/DynoJedisClient.java
@@ -3231,7 +3231,6 @@ public class DynoJedisClient implements JedisCommands, BinaryJedisCommands, Mult
 
         private String appName;
         private String clusterName;
-        private int port = -1;
         private ConnectionPoolConfigurationImpl cpConfig;
         private HostSupplier hostSupplier;
         private DiscoveryClient discoveryClient;
@@ -3262,10 +3261,6 @@ public class DynoJedisClient implements JedisCommands, BinaryJedisCommands, Mult
             return this;
         }
 
-        public Builder withPort(int suppliedPort) {
-            port = suppliedPort;
-            return this;
-        }
 
         public Builder withDiscoveryClient(DiscoveryClient client) {
             discoveryClient = client;
@@ -3310,9 +3305,7 @@ public class DynoJedisClient implements JedisCommands, BinaryJedisCommands, Mult
             // Ensure that if the shadow cluster is down it will not block client application startup
             shadowConfig.setFailOnStartupIfNoHosts(false);
 
-            if (port != -1) {
-                shadowConfig.setPort(port);
-            }
+           
 
             HostSupplier shadowSupplier = null;
             if (discoveryClient != null) {
@@ -3352,9 +3345,6 @@ public class DynoJedisClient implements JedisCommands, BinaryJedisCommands, Mult
 
 
         private DynoJedisClient buildDynoJedisClient() {
-            if (port != -1) {
-                cpConfig.setPort(port);
-            }
 
             if (hostSupplier == null) {
                 if (discoveryClient == null) {
@@ -3415,7 +3405,7 @@ public class DynoJedisClient implements JedisCommands, BinaryJedisCommands, Mult
             if (ConnectionPoolConfiguration.LoadBalancingStrategy.TokenAware == config.getLoadBalancingStrategy()) {
                 if (config.getTokenSupplier() == null) {
                     Logger.warn("TOKEN AWARE selected and no token supplier found, using default HttpEndpointBasedTokenMapSupplier()");
-                    config.withTokenSupplier(new HttpEndpointBasedTokenMapSupplier(port));
+                    config.withTokenSupplier(new HttpEndpointBasedTokenMapSupplier());
                 }
 
                 if (config.getLocalRack() == null && config.localZoneAffinity()) {


### PR DESCRIPTION
Initial pull request to get some input on these changes.  I'll get the build.gradle backed out shortly, those changes were handy to get them into my local repo for an sbt project.

Changes:
* The host object is now mostly immutable, allowing only the status to be changed and I'm not 100% sure its used so we might be able to remove that.
* The host object's equals, hashcode, and comparable take hostName, port, and rack into consideration.
* Ports can only be set on the host objects in their constructors. 
* The HttpTokenSupplier has an option to supply a default port if they are not specified in the json for compatibility with configurations that don't have ports and all use the same port as it was originally done.

* This patch will take a few minor code changes for clients that take them, but not much different than the 1.4.5 to 1.4.6 changes from what I've seen.

* Added unit tests to check selection with different ports as well as with the current way of doing things. All tests passing, though on of the rate limit ones is a little flakey.

* Also running in one our production environment and seems to be doing well with 3x servers with 10x dynomite and 10x redis running on each. Load seems evenly spread among all of the instances.

* Tried to finish up some of the renaming work that seems to be in progress for zone vs rack vs dc.

* I need to find the code style that's supposed to get used in this repo. I'll get these files formatted like that shortly. The code all in is kind of all over the place.