### PR TITLE
Tokens for local Datacenter

### DIFF
--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/ConnectionPool.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/ConnectionPool.java
@@ -17,11 +17,9 @@ package com.netflix.dyno.connectionpool;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.Future;
 
 import com.netflix.dyno.connectionpool.exception.DynoException;
-import com.netflix.dyno.connectionpool.impl.lb.HostSelectionWithFallback;
 
 /**
  * Base interface for a pool of connections. A concrete connection pool will

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/Host.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/Host.java
@@ -74,6 +74,11 @@ public class Host {
 		return hostname;
 	}
 	
+	public String getHostName() {
+	    return hostname;
+	}
+
+	
 	public String getIpAddress() {
 		return ipAddress;
 	}

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/Host.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/Host.java
@@ -31,6 +31,7 @@ public class Host {
 	private InetSocketAddress socketAddress = null;
 	
 	private String rack; 
+	private String datacenter;
 	
 	public static enum Status {
 		Up, Down;
@@ -97,7 +98,20 @@ public class Host {
 	
 	public Host setRack(String rack) {
 		this.rack = rack;
+        setDatacenter(rack);
 		return this;
+	}
+	
+	public String getDatacenter() {
+		return datacenter;
+	}
+	
+	/** 
+	 * Datacenter format us-east-x, us-west-x etc.
+	 * 
+	 */
+	private void setDatacenter(String rack) {
+		this.datacenter = rack.substring(0, rack.length() - 1);
 	}
 	
 	public Host setStatus(Status condition) {
@@ -142,6 +156,6 @@ public class Host {
 
 	@Override
 	public String toString() {
-		return "Host [hostname=" + hostname + ", ipAddress=" + ipAddress + ", port=" + port + ", rack: " + rack + ", status: " + status.name() + "]";
+		return "Host [hostname=" + hostname + ", ipAddress=" + ipAddress + ", port=" + port + ", rack: " + rack + ", datacenter: " + datacenter + ", status: " + status.name() + "]";
 	}
 }

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/Host.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/Host.java
@@ -17,150 +17,153 @@ package com.netflix.dyno.connectionpool;
 
 import java.net.InetSocketAddress;
 
+import com.netflix.dyno.connectionpool.impl.utils.ConfigUtils;
+
 /**
  * Class encapsulating information about a host.
+ * 
  * @author poberai
+ * @author ipapapanagiotou
  *
  */
 public class Host {
 
-	private final String hostname;
-	private final String ipAddress;
-	private int port;
-	private Status status = Status.Down;
-	private InetSocketAddress socketAddress = null;
-	
-	private String rack; 
-	private String datacenter;
-	
-	public static enum Status {
-		Up, Down;
-	}
-	
-	public Host(String hostname, int port) {
-		this(hostname, null, port, Status.Down);
-	}
-	
-	public Host(String hostname, Status status) {
-		this(hostname, null, -1, status);
-	}
-	
-	public Host(String hostname, int port, Status status) {
-		this(hostname, null, port, status);
-	}
-	
-	public Host(String hostname, String ipAddress, int port) {
-		this(hostname, ipAddress, port, Status.Down);
-	}
-	
-	public Host(String hostname, String ipAddress, Status status) {
-		this(hostname, ipAddress, -1, status);
-	}
+    private final String hostname;
+    private final String ipAddress;
+    private int port;
+    private Status status = Status.Down;
+    private InetSocketAddress socketAddress = null;
 
-	public Host(String name, String ipAddress, int port, Status status) {
-		this.hostname = name;
-		this.ipAddress = ipAddress;
-		this.port = port;
-		this.status = status;
-		if (port != -1) {
-			this.socketAddress = new InetSocketAddress(name, port);
-		}
-	}
+    private String rack;
+    private String datacenter;
 
-	public String getHostAddress() {
-		if (this.ipAddress != null) {
-			return ipAddress;
-		}
-		return hostname;
-	}
-	
-	public String getHostName() {
-	    return hostname;
-	}
+    public static enum Status {
+	Up, Down;
+    }
 
-	
-	public String getIpAddress() {
-		return ipAddress;
-	}
-	
-	public int getPort() {
-		return port;
-	}
-	
-	public Host setPort(int p) {
-		this.port = p;
-		this.socketAddress = new InetSocketAddress(hostname, port);
-		return this;
-	}
+    public Host(String hostname, int port) {
+	this(hostname, null, port, Status.Down);
+    }
 
-	public Status getStatus() {
-		return status;
-	}
+    public Host(String hostname, Status status) {
+	this(hostname, null, -1, status);
+    }
 
-	public String getRack() {
-		return rack;
-	}
-	
-	public Host setRack(String rack) {
-		this.rack = rack;
-        setDatacenter(rack);
-		return this;
-	}
-	
-	public String getDatacenter() {
-		return datacenter;
-	}
-	
-	/** 
-	 * Datacenter format us-east-x, us-west-x etc.
-	 * 
-	 */
-	private void setDatacenter(String rack) {
-		this.datacenter = rack.substring(0, rack.length() - 1);
-	}
-	
-	public Host setStatus(Status condition) {
-		status = condition;
-		return this;
-	}
-	
-	public boolean isUp() {
-		return status == Status.Up;
-	}
-	
-	public InetSocketAddress getSocketAddress() {
-		return socketAddress;
-	}
-	
-	public static final Host NO_HOST = new Host("UNKNOWN", "UNKNOWN", 0);
+    public Host(String hostname, int port, Status status) {
+	this(hostname, null, port, status);
+    }
 
-	@Override
-	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + ((hostname == null) ? 0 : hostname.hashCode());
-		result = prime * result + ((rack == null) ? 0 : rack.hashCode());
-		return result;
-	}
+    public Host(String hostname, String ipAddress, int port) {
+	this(hostname, ipAddress, port, Status.Down);
+    }
 
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj) return true;
-		if (obj == null) return false;
-		
-		if (getClass() != obj.getClass()) return false;
-		
-		Host other = (Host) obj;
-		boolean equals = true;
-		
-		equals &= (hostname != null) ? hostname.equals(other.hostname) : other.hostname == null;
-		equals &= (rack != null) ? rack.equals(other.rack) : other.rack == null;
-		
-		return equals;
-	}
+    public Host(String hostname, String ipAddress, Status status) {
+	this(hostname, ipAddress, -1, status);
+    }
 
-	@Override
-	public String toString() {
-		return "Host [hostname=" + hostname + ", ipAddress=" + ipAddress + ", port=" + port + ", rack: " + rack + ", datacenter: " + datacenter + ", status: " + status.name() + "]";
+    public Host(String name, String ipAddress, int port, Status status) {
+	this.hostname = name;
+	this.ipAddress = ipAddress;
+	this.port = port;
+	this.status = status;
+	if (port != -1) {
+	    this.socketAddress = new InetSocketAddress(name, port);
 	}
+    }
+
+    public String getHostAddress() {
+	if (this.ipAddress != null) {
+	    return ipAddress;
+	}
+	return hostname;
+    }
+
+    public String getHostName() {
+	return hostname;
+    }
+
+    public String getIpAddress() {
+	return ipAddress;
+    }
+
+    public int getPort() {
+	return port;
+    }
+
+    public Host setPort(int p) {
+	this.port = p;
+	this.socketAddress = new InetSocketAddress(hostname, port);
+	return this;
+    }
+
+    public Status getStatus() {
+	return status;
+    }
+
+    public String getRack() {
+	return rack;
+    }
+
+    public Host setRack(String rack) {
+	this.rack = rack;
+	setDatacenter(rack);
+	return this;
+    }
+
+    public String getDatacenter() {
+	return datacenter;
+    }
+
+    private void setDatacenter(String rack) {
+	this.datacenter = ConfigUtils.getDataCenter(rack);
+    }
+
+    public Host setStatus(Status condition) {
+	status = condition;
+	return this;
+    }
+
+    public boolean isUp() {
+	return status == Status.Up;
+    }
+
+    public InetSocketAddress getSocketAddress() {
+	return socketAddress;
+    }
+
+    public static final Host NO_HOST = new Host("UNKNOWN", "UNKNOWN", 0);
+
+    @Override
+    public int hashCode() {
+	final int prime = 31;
+	int result = 1;
+	result = prime * result + ((hostname == null) ? 0 : hostname.hashCode());
+	result = prime * result + ((rack == null) ? 0 : rack.hashCode());
+	return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+	if (this == obj)
+	    return true;
+	if (obj == null)
+	    return false;
+
+	if (getClass() != obj.getClass())
+	    return false;
+
+	Host other = (Host) obj;
+	boolean equals = true;
+
+	equals &= (hostname != null) ? hostname.equals(other.hostname) : other.hostname == null;
+	equals &= (rack != null) ? rack.equals(other.rack) : other.rack == null;
+
+	return equals;
+    }
+
+    @Override
+    public String toString() {
+	return "Host [hostname=" + hostname + ", ipAddress=" + ipAddress + ", port=" + port + ", rack: " + rack
+		+ ", datacenter: " + datacenter + ", status: " + status.name() + "]";
+    }
 }

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/TokenMapSupplier.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/TokenMapSupplier.java
@@ -15,28 +15,29 @@
  ******************************************************************************/
 package com.netflix.dyno.connectionpool;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
 import com.netflix.dyno.connectionpool.impl.lb.HostToken;
 
 /**
- * Interface for supplying the list of {@link HostToken} that represent the dynomite server topology
+ * Interface for supplying the list of {@link HostToken} that represent the
+ * dynomite server topology
+ * 
  * @author poberai
  *
  */
 public interface TokenMapSupplier {
 
-	/**
-	 * @return List<HostToken>
-	 */
-	public List<HostToken> getTokens(Set<Host> activeHosts);
-	
-	/**
-	 * 
-	 * @param host
-	 * @return
-	 */
-	public HostToken getTokenForHost(final Host host, final Set<Host> activeHosts);
+    /**
+     * @return List<HostToken>
+     */
+    public List<HostToken> getTokens(Set<Host> activeHosts);
+
+    /**
+     * 
+     * @param host
+     * @return
+     */
+    public HostToken getTokenForHost(final Host host, final Set<Host> activeHosts);
 }

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolImpl.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolImpl.java
@@ -41,27 +41,35 @@ import com.netflix.dyno.connectionpool.impl.utils.CollectionUtils.Predicate;
 import javax.management.*;
 
 /**
- * Main implementation class for {@link ConnectionPool}
- * The pool deals with a bunch of other components and brings together all the functionality for Dyno. Hence this is where all the action happens. 
+ * Main implementation class for {@link ConnectionPool} The pool deals with a
+ * bunch of other components and brings together all the functionality for Dyno.
+ * Hence this is where all the action happens.
  * 
- * Here are the top salient features of this class. 
+ * Here are the top salient features of this class.
  * 
- *     1. Manages a collection of {@link HostConnectionPool}s for all the {@link Host}s that it receives from the {@link HostSupplier}
+ * 1. Manages a collection of {@link HostConnectionPool}s for all the
+ * {@link Host}s that it receives from the {@link HostSupplier}
  * 
- *     2. Manages adding and removing hosts as dictated by the HostSupplier.
- *  
- *     3. Enables execution of {@link Operation} using a {@link Connection} borrowed from the {@link HostConnectionPool}s
+ * 2. Manages adding and removing hosts as dictated by the HostSupplier.
  * 
- *     4. Employs a {@link HostSelectionStrategy} (basically Round Robin or Token Aware) when executing operations
+ * 3. Enables execution of {@link Operation} using a {@link Connection} borrowed
+ * from the {@link HostConnectionPool}s
  * 
- *     5. Uses a health check monitor for tracking error rates from the execution of operations. The health check monitor can then decide 
- *        to recycle a given HostConnectionPool, and execute requests using fallback HostConnectionPools for remote DCs.
- *        
- *     6. Uses {@link RetryPolicy} when executing operations for better resilience against transient failures.    
+ * 4. Employs a {@link HostSelectionStrategy} (basically Round Robin or Token
+ * Aware) when executing operations
+ * 
+ * 5. Uses a health check monitor for tracking error rates from the execution of
+ * operations. The health check monitor can then decide to recycle a given
+ * HostConnectionPool, and execute requests using fallback HostConnectionPools
+ * for remote DCs.
+ * 
+ * 6. Uses {@link RetryPolicy} when executing operations for better resilience
+ * against transient failures.
  * 
  * @see {@link HostSupplier} {@link Host} {@link HostSelectionStrategy}
- * @see {@link Connection} {@link ConnectionFactory} {@link ConnectionPoolConfiguration} {@link ConnectionPoolMonitor}
- * @see {@link ConnectionPoolHealthTracker} 
+ * @see {@link Connection} {@link ConnectionFactory}
+ *      {@link ConnectionPoolConfiguration} {@link ConnectionPoolMonitor}
+ * @see {@link ConnectionPoolHealthTracker}
  * 
  * @author poberai
  *
@@ -69,628 +77,639 @@ import javax.management.*;
  */
 public class ConnectionPoolImpl<CL> implements ConnectionPool<CL>, TopologyView {
 
-	private static final Logger Logger = LoggerFactory.getLogger(ConnectionPoolImpl.class);
+    private static final Logger Logger = LoggerFactory.getLogger(ConnectionPoolImpl.class);
 
-	private final ConcurrentHashMap<Host, HostConnectionPool<CL>> cpMap = new ConcurrentHashMap<Host, HostConnectionPool<CL>>();
-	private final ConnectionPoolHealthTracker<CL> cpHealthTracker;
-	
-	private final HostConnectionPoolFactory<CL> hostConnPoolFactory;
-	private final ConnectionFactory<CL> connFactory; 
-	private final ConnectionPoolConfiguration cpConfiguration; 
-	private final ConnectionPoolMonitor cpMonitor;
+    private final ConcurrentHashMap<Host, HostConnectionPool<CL>> cpMap = new ConcurrentHashMap<Host, HostConnectionPool<CL>>();
+    private final ConnectionPoolHealthTracker<CL> cpHealthTracker;
+
+    private final HostConnectionPoolFactory<CL> hostConnPoolFactory;
+    private final ConnectionFactory<CL> connFactory;
+    private final ConnectionPoolConfiguration cpConfiguration;
+    private final ConnectionPoolMonitor cpMonitor;
 
     private final ScheduledExecutorService idleThreadPool = Executors.newSingleThreadScheduledExecutor();
-	
-	private final HostsUpdater hostsUpdater;
-	private final ScheduledExecutorService connPoolThreadPool = Executors.newScheduledThreadPool(1);
-	
-	private final AtomicBoolean started = new AtomicBoolean(false);
+
+    private final HostsUpdater hostsUpdater;
+    private final ScheduledExecutorService connPoolThreadPool = Executors.newScheduledThreadPool(1);
+
+    private final AtomicBoolean started = new AtomicBoolean(false);
     private final AtomicBoolean idling = new AtomicBoolean(false);
 
     private HostSelectionWithFallback<CL> selectionStrategy;
-	
-	private Type poolType;
 
-	public ConnectionPoolImpl(ConnectionFactory<CL> cFactory, ConnectionPoolConfiguration cpConfig, ConnectionPoolMonitor cpMon) {
-		this(cFactory, cpConfig, cpMon, Type.Sync);
+    private Type poolType;
+
+    public ConnectionPoolImpl(ConnectionFactory<CL> cFactory, ConnectionPoolConfiguration cpConfig,
+	    ConnectionPoolMonitor cpMon) {
+	this(cFactory, cpConfig, cpMon, Type.Sync);
+    }
+
+    public ConnectionPoolImpl(ConnectionFactory<CL> cFactory, ConnectionPoolConfiguration cpConfig,
+	    ConnectionPoolMonitor cpMon, Type type) {
+	this.connFactory = cFactory;
+	this.cpConfiguration = cpConfig;
+	this.cpMonitor = cpMon;
+	this.poolType = type;
+
+	this.cpHealthTracker = new ConnectionPoolHealthTracker<CL>(cpConfiguration, connPoolThreadPool);
+
+	switch (type) {
+	case Sync:
+	    hostConnPoolFactory = new SyncHostConnectionPoolFactory();
+	    break;
+	case Async:
+	    hostConnPoolFactory = new AsyncHostConnectionPoolFactory();
+	    break;
+	default:
+	    throw new RuntimeException("unknown type");
 	}
+	;
 
-    public ConnectionPoolImpl(ConnectionFactory<CL> cFactory, ConnectionPoolConfiguration cpConfig, ConnectionPoolMonitor cpMon, Type type) {
-        this.connFactory = cFactory;
-        this.cpConfiguration = cpConfig;
-        this.cpMonitor = cpMon;
-        this.poolType = type;
-
-        this.cpHealthTracker = new ConnectionPoolHealthTracker<CL>(cpConfiguration, connPoolThreadPool);
-
-        switch (type) {
-            case Sync:
-                hostConnPoolFactory = new SyncHostConnectionPoolFactory();
-                break;
-            case Async:
-                hostConnPoolFactory = new AsyncHostConnectionPoolFactory();
-                break;
-            default:
-                throw new RuntimeException("unknown type");
-        };
-
-        this.hostsUpdater = new HostsUpdater(cpConfiguration.getHostSupplier());
+	this.hostsUpdater = new HostsUpdater(cpConfiguration.getHostSupplier());
 
     }
 
-	public String getName() {
-		return cpConfiguration.getName();
+    public String getName() {
+	return cpConfiguration.getName();
+    }
+
+    public ConnectionPoolMonitor getMonitor() {
+	return cpMonitor;
+    }
+
+    public ConnectionPoolHealthTracker<CL> getHealthTracker() {
+	return cpHealthTracker;
+    }
+
+    @Override
+    public boolean isIdle() {
+	return idling.get();
+    }
+
+    @Override
+    public boolean addHost(Host host) {
+	return addHost(host, true);
+    }
+
+    public boolean addHost(Host host, boolean refreshLoadBalancer) {
+
+	host.setPort(cpConfiguration.getPort());
+
+	HostConnectionPool<CL> connPool = cpMap.get(host);
+
+	if (connPool != null) {
+	    if (Logger.isDebugEnabled()) {
+		Logger.debug("HostConnectionPool already exists for host: " + host + ", ignoring addHost");
+	    }
+	    return false;
 	}
-	
-	public ConnectionPoolMonitor getMonitor() {
-		return cpMonitor;
-	}
-	
-	public ConnectionPoolHealthTracker<CL> getHealthTracker() {
-		return cpHealthTracker;
-	}
 
-	@Override
-	public boolean isIdle() {
-		return idling.get();
-	}
+	final HostConnectionPool<CL> hostPool = hostConnPoolFactory.createHostConnectionPool(host, this);
 
-	@Override
-	public boolean addHost(Host host) {
-		return addHost(host, true);
-	}
+	HostConnectionPool<CL> prevPool = cpMap.putIfAbsent(host, hostPool);
+	if (prevPool == null) {
+	    // This is the first time we are adding this pool.
+	    Logger.info("Adding host connection pool for host: " + host);
 
-	public boolean addHost(Host host, boolean refreshLoadBalancer) {
-		
-		host.setPort(cpConfiguration.getPort());
+	    try {
+		int primed = hostPool.primeConnections();
+		Logger.info("Successfully primed " + primed + " of " + cpConfiguration.getMaxConnsPerHost() + " to "
+			+ host);
 
-		HostConnectionPool<CL> connPool = cpMap.get(host);
-		
-		if (connPool != null) {
-			if (Logger.isDebugEnabled()) {
-				Logger.debug("HostConnectionPool already exists for host: " + host + ", ignoring addHost");
-			}
-			return false;
-		}
-		
-		final HostConnectionPool<CL> hostPool = hostConnPoolFactory.createHostConnectionPool(host, this);
-		
-		HostConnectionPool<CL> prevPool = cpMap.putIfAbsent(host, hostPool);
-		if (prevPool == null) {
-			// This is the first time we are adding this pool. 
-			Logger.info("Adding host connection pool for host: " + host);
-			
-			try {
-				int primed = hostPool.primeConnections();
-                Logger.info("Successfully primed " + primed + " of " + cpConfiguration.getMaxConnsPerHost() + " to " + host);
+		if (hostPool.isActive()) {
+		    if (refreshLoadBalancer) {
+			selectionStrategy.addHost(host, hostPool);
+		    }
 
-                if (hostPool.isActive()) {
-                    if (refreshLoadBalancer) {
-                        selectionStrategy.addHost(host, hostPool);
-                    }
+		    cpHealthTracker.initializePingHealthchecksForPool(hostPool);
 
-					cpHealthTracker.initializePingHealthchecksForPool(hostPool);
+		    cpMonitor.hostAdded(host, hostPool);
 
-                    cpMonitor.hostAdded(host, hostPool);
-
-                } else {
-                    Logger.info("Failed to prime enough connections to host " + host + " for it take traffic; will retry");
-                    cpMap.remove(host);
-                }
-
-                return primed > 0;
-			} catch (DynoException e) {
-				Logger.info("Failed to init host pool for host: " + host, e);
-				cpMap.remove(host);
-				return false;
-			}
 		} else {
-			return false;
+		    Logger.info(
+			    "Failed to prime enough connections to host " + host + " for it take traffic; will retry");
+		    cpMap.remove(host);
 		}
+
+		return primed > 0;
+	    } catch (DynoException e) {
+		Logger.info("Failed to init host pool for host: " + host, e);
+		cpMap.remove(host);
+		return false;
+	    }
+	} else {
+	    return false;
 	}
-	
-	@Override
-	public boolean removeHost(Host host) {
-		HostConnectionPool<CL> hostPool = cpMap.remove(host);
-		if (hostPool != null) {
-			selectionStrategy.removeHost(host, hostPool);
-			cpHealthTracker.removeHost(host);
-			cpMonitor.hostRemoved(host);
-			hostPool.shutdown();
-            Logger.info(String.format("Remove host: Successfully removed host %s from connection pool", host.getHostAddress()));
-            return true;
+    }
+
+    @Override
+    public boolean removeHost(Host host) {
+	HostConnectionPool<CL> hostPool = cpMap.remove(host);
+	if (hostPool != null) {
+	    selectionStrategy.removeHost(host, hostPool);
+	    cpHealthTracker.removeHost(host);
+	    cpMonitor.hostRemoved(host);
+	    hostPool.shutdown();
+	    Logger.info(String.format("Remove host: Successfully removed host %s from connection pool",
+		    host.getHostAddress()));
+	    return true;
+	} else {
+	    Logger.info(String.format("Remove host: Host %s NOT FOUND in the connection pool", host.getHostAddress()));
+	    return false;
+	}
+    }
+
+    @Override
+    public boolean isHostUp(Host host) {
+	HostConnectionPool<CL> hostPool = cpMap.get(host);
+	return (hostPool != null) ? hostPool.isActive() : false;
+    }
+
+    @Override
+    public boolean hasHost(Host host) {
+	return cpMap.get(host) != null;
+    }
+
+    @Override
+    public List<HostConnectionPool<CL>> getActivePools() {
+
+	return new ArrayList<HostConnectionPool<CL>>(
+		CollectionUtils.filter(getPools(), new Predicate<HostConnectionPool<CL>>() {
+
+		    @Override
+		    public boolean apply(HostConnectionPool<CL> hostPool) {
+			if (hostPool == null) {
+			    return false;
+			}
+			return hostPool.isActive();
+		    }
+		}));
+    }
+
+    @Override
+    public List<HostConnectionPool<CL>> getPools() {
+	return new ArrayList<HostConnectionPool<CL>>(cpMap.values());
+    }
+
+    @Override
+    public Future<Boolean> updateHosts(Collection<Host> hostsUp, Collection<Host> hostsDown) {
+	Logger.debug(String.format("Updating hosts: UP=%s, DOWN=%s", hostsUp, hostsDown));
+	boolean condition = false;
+	if (hostsUp != null && !hostsUp.isEmpty()) {
+	    for (Host hostUp : hostsUp) {
+		condition |= addHost(hostUp);
+	    }
+	}
+	if (hostsDown != null && !hostsDown.isEmpty()) {
+	    for (Host hostDown : hostsDown) {
+		condition |= removeHost(hostDown);
+	    }
+	}
+	return getEmptyFutureTask(condition);
+    }
+
+    @Override
+    public HostConnectionPool<CL> getHostPool(Host host) {
+	return cpMap.get(host);
+    }
+
+    @Override
+    public <R> OperationResult<R> executeWithFailover(Operation<CL, R> op) throws DynoException {
+
+	// Start recording the operation
+	long startTime = System.currentTimeMillis();
+
+	RetryPolicy retry = cpConfiguration.getRetryPolicyFactory().getRetryPolicy();
+	retry.begin();
+
+	DynoException lastException = null;
+
+	do {
+	    Connection<CL> connection = null;
+
+	    try {
+		connection = selectionStrategy.getConnectionUsingRetryPolicy(op,
+			cpConfiguration.getMaxTimeoutWhenExhausted(), TimeUnit.MILLISECONDS, retry);
+
+		OperationResult<R> result = connection.execute(op);
+
+		// Add context to the result from the successful execution
+		result.setNode(connection.getHost()).addMetadata(connection.getContext().getAll());
+
+		retry.success();
+		cpMonitor.incOperationSuccess(connection.getHost(), System.currentTimeMillis() - startTime);
+
+		return result;
+
+	    } catch (NoAvailableHostsException e) {
+		cpMonitor.incOperationFailure(null, e);
+
+		throw e;
+	    } catch (PoolExhaustedException e) {
+		Logger.warn("Pool exhausted: " + e.getMessage());
+		cpMonitor.incOperationFailure(null, e);
+		cpHealthTracker.trackConnectionError(e.getHostConnectionPool(), e);
+	    } catch (DynoException e) {
+
+		retry.failure(e);
+		lastException = e;
+
+		if (connection != null) {
+		    cpMonitor.incOperationFailure(connection.getHost(), e);
+
+		    if (retry.allowRetry()) {
+			cpMonitor.incFailover(connection.getHost(), e);
+		    }
+
+		    // Track the connection health so that the pool can be
+		    // purged at a later point
+		    cpHealthTracker.trackConnectionError(connection.getParentConnectionPool(), lastException);
 		} else {
-            Logger.info(String.format("Remove host: Host %s NOT FOUND in the connection pool", host.getHostAddress()));
-			return false;
+		    cpMonitor.incOperationFailure(null, e);
 		}
-	}
-	
-	@Override
-	public boolean isHostUp(Host host) {
-		HostConnectionPool<CL> hostPool = cpMap.get(host);
-		return (hostPool != null) ? hostPool.isActive() : false;
-	}
 
-	@Override
-	public boolean hasHost(Host host) {
-		return cpMap.get(host) != null;
-	}
-
-	@Override
-	public List<HostConnectionPool<CL>> getActivePools() {
-		
-		return new ArrayList<HostConnectionPool<CL>>(CollectionUtils.filter(getPools(), new Predicate<HostConnectionPool<CL>>() {
-
-            @Override
-            public boolean apply(HostConnectionPool<CL> hostPool) {
-                if (hostPool == null) {
-                    return false;
-                }
-                return hostPool.isActive();
-            }
-        }));
-	}
-
-	@Override
-	public List<HostConnectionPool<CL>> getPools() {
-		return new ArrayList<HostConnectionPool<CL>>(cpMap.values());
-	}
-
-	@Override
-	public Future<Boolean> updateHosts(Collection<Host> hostsUp, Collection<Host> hostsDown) {
-		Logger.debug(String.format("Updating hosts: UP=%s, DOWN=%s", hostsUp, hostsDown));
-		boolean condition = false;
-		if (hostsUp != null && !hostsUp.isEmpty()) {
-			for (Host hostUp : hostsUp) {
-				condition |= addHost(hostUp);
-			}
+	    } catch (Throwable t) {
+		throw new RuntimeException(t);
+	    } finally {
+		if (connection != null) {
+		    if (connection.getLastException() != null
+			    && connection.getLastException() instanceof FatalConnectionException) {
+			Logger.warn("Received FatalConnectionException; closing connection "
+				+ connection.getContext().getAll() + " to host "
+				+ connection.getParentConnectionPool().getHost());
+			connection.getParentConnectionPool().closeConnection(connection);
+			// note - don't increment connection closed metric here;
+			// it's done in closeConnection
+		    } else {
+			connection.getContext().reset();
+			connection.getParentConnectionPool().returnConnection(connection);
+		    }
 		}
-		if (hostsDown != null && !hostsDown.isEmpty()) {
-			for (Host hostDown : hostsDown) {
-				condition |= removeHost(hostDown);
-			}
-		}
-		return getEmptyFutureTask(condition);
-	}
+	    }
 
-	@Override
-	public HostConnectionPool<CL> getHostPool(Host host) {
-		return cpMap.get(host);
-	}
+	} while (retry.allowRetry());
 
-	@Override
-	public <R> OperationResult<R> executeWithFailover(Operation<CL, R> op) throws DynoException {
-		
-		// Start recording the operation
-		long startTime = System.currentTimeMillis();
-		
+	throw lastException;
+    }
+
+    @Override
+    public <R> Collection<OperationResult<R>> executeWithRing(Operation<CL, R> op) throws DynoException {
+
+	// Start recording the operation
+	long startTime = System.currentTimeMillis();
+
+	Collection<Connection<CL>> connections = selectionStrategy
+		.getConnectionsToRing(cpConfiguration.getMaxTimeoutWhenExhausted(), TimeUnit.MILLISECONDS);
+
+	LinkedBlockingQueue<Connection<CL>> connQueue = new LinkedBlockingQueue<Connection<CL>>();
+	connQueue.addAll(connections);
+
+	List<OperationResult<R>> results = new ArrayList<OperationResult<R>>();
+
+	DynoException lastException = null;
+
+	try {
+	    while (!connQueue.isEmpty()) {
+
+		Connection<CL> connection = connQueue.poll();
+
 		RetryPolicy retry = cpConfiguration.getRetryPolicyFactory().getRetryPolicy();
 		retry.begin();
-		
-		DynoException lastException = null;
-		
-		do  {
-			Connection<CL> connection = null;
-			
-			try {
-					connection =
-                            selectionStrategy.getConnectionUsingRetryPolicy(
-                                    op,
-                                    cpConfiguration.getMaxTimeoutWhenExhausted(),
-                                    TimeUnit.MILLISECONDS,
-                                    retry
-                            );
 
-				OperationResult<R> result = connection.execute(op);
-				
-				// Add context to the result from the successful execution
-				result.setNode(connection.getHost())
-					  .addMetadata(connection.getContext().getAll());
+		do {
+		    try {
+			connection.getContext().setMetadata("host", connection.getHost().getHostAddress());
+			OperationResult<R> result = connection.execute(op);
 
-				retry.success();
-				cpMonitor.incOperationSuccess(connection.getHost(), System.currentTimeMillis()-startTime);
-				
-				return result; 
-				
-			} catch(NoAvailableHostsException e) {
-				cpMonitor.incOperationFailure(null, e);
+			// Add context to the result from the successful
+			// execution
+			result.setNode(connection.getHost()).addMetadata(connection.getContext().getAll());
 
-				throw e;
-			} catch (PoolExhaustedException e) {
-                Logger.warn("Pool exhausted: " + e.getMessage());
-                cpMonitor.incOperationFailure(null, e);
-                cpHealthTracker.trackConnectionError(e.getHostConnectionPool(), e);
-			} catch(DynoException e) {
-				
-				retry.failure(e);
-				lastException = e;
+			retry.success();
+			cpMonitor.incOperationSuccess(connection.getHost(), System.currentTimeMillis() - startTime);
 
-                if (connection != null) {
-                    cpMonitor.incOperationFailure(connection.getHost(), e);
+			results.add(result);
 
-                    if (retry.allowRetry()) {
-                        cpMonitor.incFailover(connection.getHost(), e);
-                    }
+		    } catch (NoAvailableHostsException e) {
+			cpMonitor.incOperationFailure(null, e);
 
-                    // Track the connection health so that the pool can be purged at a later point
-                    cpHealthTracker.trackConnectionError(connection.getParentConnectionPool(), lastException);
-                } else {
-                    cpMonitor.incOperationFailure(null, e);
-                }
+			throw e;
+		    } catch (DynoException e) {
 
-			} catch(Throwable t) {
-				throw new RuntimeException(t);
-			} finally {
-                if (connection != null) {
-                    if (connection.getLastException() != null &&
-                            connection.getLastException() instanceof FatalConnectionException) {
-                        Logger.warn("Received FatalConnectionException; closing connection " +
-                                connection.getContext().getAll() + " to host " +
-                                connection.getParentConnectionPool().getHost());
-                        connection.getParentConnectionPool().closeConnection(connection);
-                        // note - don't increment connection closed metric here; it's done in closeConnection
-                    } else {
-                        connection.getContext().reset();
-                        connection.getParentConnectionPool().returnConnection(connection);
-                    }
-                }
+			retry.failure(e);
+			lastException = e;
+
+			cpMonitor.incOperationFailure(connection != null ? connection.getHost() : null, e);
+
+			// Track the connection health so that the pool can be
+			// purged at a later point
+			if (connection != null) {
+			    cpHealthTracker.trackConnectionError(connection.getParentConnectionPool(), lastException);
 			}
-			
-		} while(retry.allowRetry());
-		
-		throw lastException;
-	}
 
-	@Override
-	public <R> Collection<OperationResult<R>> executeWithRing(Operation<CL, R> op) throws DynoException {
+		    } catch (Throwable t) {
+			throw new RuntimeException(t);
+		    } finally {
+			connection.getContext().reset();
+			connection.getParentConnectionPool().returnConnection(connection);
+		    }
 
-		// Start recording the operation
-		long startTime = System.currentTimeMillis();
+		} while (retry.allowRetry());
+	    }
 
-		Collection<Connection<CL>> connections = selectionStrategy.getConnectionsToRing(cpConfiguration.getMaxTimeoutWhenExhausted(), TimeUnit.MILLISECONDS);
-
-		LinkedBlockingQueue<Connection<CL>> connQueue = new LinkedBlockingQueue<Connection<CL>>();
-		connQueue.addAll(connections);
-
-		List<OperationResult<R>> results = new ArrayList<OperationResult<R>>();
-
-		DynoException lastException = null;
-
-		try { 
-			while(!connQueue.isEmpty()) {
-
-				Connection<CL> connection = connQueue.poll();
-
-				RetryPolicy retry = cpConfiguration.getRetryPolicyFactory().getRetryPolicy();
-				retry.begin();
-
-				do {
-					try {
-                        connection.getContext().setMetadata("host", connection.getHost().getHostAddress());
-						OperationResult<R> result = connection.execute(op);
-
-						// Add context to the result from the successful execution
-						result.setNode(connection.getHost())
-						.addMetadata(connection.getContext().getAll());
-
-						retry.success();
-						cpMonitor.incOperationSuccess(connection.getHost(), System.currentTimeMillis()-startTime);
-
-						results.add(result); 
-
-					} catch(NoAvailableHostsException e) {
-						cpMonitor.incOperationFailure(null, e);
-
-						throw e;
-					} catch(DynoException e) {
-
-						retry.failure(e);
-						lastException = e;
-
-						cpMonitor.incOperationFailure(connection != null ? connection.getHost() : null, e);
-
-						// Track the connection health so that the pool can be purged at a later point
-						if (connection != null) {
-							cpHealthTracker.trackConnectionError(connection.getParentConnectionPool(), lastException);
-						}
-
-					} catch(Throwable t) {
-						throw new RuntimeException(t);
-					} finally {
-						connection.getContext().reset();
-						connection.getParentConnectionPool().returnConnection(connection);
-					}
-
-				} while(retry.allowRetry());
-			}
-			
-			// we fail the entire operation on a partial failure. hence need to clean up the rest of the pending connections
-		} finally {
-			List<Connection<CL>> remainingConns = new ArrayList<Connection<CL>>();
-			connQueue.drainTo(remainingConns);
-			for (Connection<CL> connectionToClose : remainingConns) {
-				try { 
-					connectionToClose.getContext().reset();
-					connectionToClose.getParentConnectionPool().returnConnection(connectionToClose);
-				} catch (Throwable t) {
-
-				}
-			}
-		}
-
-		if (lastException != null) {
-			throw lastException;
-		} else {
-			return results;
-		}
-	}
-	
-	/**
-	 * Use with EXTREME CAUTION. Connection that is borrowed must be returned, else we will have connection pool exhaustion
-	 * @param baseOperation
-	 * @return
-	 */
-	public <R> Connection<CL> getConnectionForOperation(BaseOperation<CL, R> baseOperation) {
-		return selectionStrategy.getConnection(baseOperation, cpConfiguration.getMaxTimeoutWhenExhausted(), TimeUnit.MILLISECONDS);
-	}
-	
-	@Override
-	public void shutdown() {
-
-        if (started.get()) {
-            for (Host host : cpMap.keySet()) {
-                removeHost(host);
-            }
-            cpHealthTracker.stop();
-            hostsUpdater.stop();
-            connPoolThreadPool.shutdownNow();
-            deregisterMonitorConsoleMBean();
-        }
-	}
-
-	@Override
-	public Future<Boolean> start() throws DynoException {
-		
-		if (started.get()) {
-			return getEmptyFutureTask(false);
-		}
-		
-		HostSupplier hostSupplier = cpConfiguration.getHostSupplier();
-		if (hostSupplier == null) {
-			throw new DynoException("Host supplier not configured!");
-		}
-
-		HostStatusTracker hostStatus = hostsUpdater.refreshHosts();
-		cpMonitor.setHostCount(hostStatus.getHostCount());
-		Collection<Host> hostsUp = hostStatus.getActiveHosts();
-		
-		if (hostsUp == null || hostsUp.isEmpty()) {
-			throw new NoAvailableHostsException("No available hosts when starting connection pool");
-		}
-
-		final ExecutorService threadPool = Executors.newFixedThreadPool(Math.max(10, hostsUp.size()));
-		final List<Future<Void>> futures = new ArrayList<Future<Void>>();
-		
-		for (final Host host : hostsUp) {
-			
-			// Add host connection pool, but don't init the load balancer yet
-            futures.add(threadPool.submit(new Callable<Void>() {
-
-                @Override
-                public Void call() throws Exception {
-                    addHost(host, false);
-                    return null;
-                }
-            }));
-		}
-
+	    // we fail the entire operation on a partial failure. hence need to
+	    // clean up the rest of the pending connections
+	} finally {
+	    List<Connection<CL>> remainingConns = new ArrayList<Connection<CL>>();
+	    connQueue.drainTo(remainingConns);
+	    for (Connection<CL> connectionToClose : remainingConns) {
 		try {
-			for (Future<Void> future : futures) {
-				try {
-					future.get();
-				} catch (InterruptedException e) {
-					// do nothing
-				} catch (ExecutionException e) {
-					throw new RuntimeException(e);
-				}
-			}
-		} finally {
-			threadPool.shutdownNow();
-		}
-		
-		boolean success = started.compareAndSet(false, true);
-		if (success) {
-            idling.set(false);
-            idleThreadPool.shutdownNow();
-			selectionStrategy = initSelectionStrategy();
-			cpHealthTracker.start();
-			
-			connPoolThreadPool.scheduleWithFixedDelay(new Runnable() {
-
-                @Override
-                public void run() {
-                    try {
-                        HostStatusTracker hostStatus = hostsUpdater.refreshHosts();
-                        cpMonitor.setHostCount(hostStatus.getHostCount());
-                        Logger.debug(hostStatus.toString());
-                        updateHosts(hostStatus.getActiveHosts(), hostStatus.getInactiveHosts());
-                    } catch (Throwable throwable) {
-                        Logger.error("Failed to update hosts cache", throwable);
-                    }
-                }
-
-            }, 15 * 1000, 30 * 1000, TimeUnit.MILLISECONDS);
-
-			MonitorConsole.getInstance().registerConnectionPool(this);
-
-            registerMonitorConsoleMBean(MonitorConsole.getInstance());
+		    connectionToClose.getContext().reset();
+		    connectionToClose.getParentConnectionPool().returnConnection(connectionToClose);
+		} catch (Throwable t) {
 
 		}
-		
-		return getEmptyFutureTask(true);
+	    }
 	}
+
+	if (lastException != null) {
+	    throw lastException;
+	} else {
+	    return results;
+	}
+    }
+
+    /**
+     * Use with EXTREME CAUTION. Connection that is borrowed must be returned,
+     * else we will have connection pool exhaustion
+     * 
+     * @param baseOperation
+     * @return
+     */
+    public <R> Connection<CL> getConnectionForOperation(BaseOperation<CL, R> baseOperation) {
+	return selectionStrategy.getConnection(baseOperation, cpConfiguration.getMaxTimeoutWhenExhausted(),
+		TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public void shutdown() {
+
+	if (started.get()) {
+	    for (Host host : cpMap.keySet()) {
+		removeHost(host);
+	    }
+	    cpHealthTracker.stop();
+	    hostsUpdater.stop();
+	    connPoolThreadPool.shutdownNow();
+	    deregisterMonitorConsoleMBean();
+	}
+    }
+
+    @Override
+    public Future<Boolean> start() throws DynoException {
+
+	if (started.get()) {
+	    return getEmptyFutureTask(false);
+	}
+
+	HostSupplier hostSupplier = cpConfiguration.getHostSupplier();
+	if (hostSupplier == null) {
+	    throw new DynoException("Host supplier not configured!");
+	}
+
+	HostStatusTracker hostStatus = hostsUpdater.refreshHosts();
+	cpMonitor.setHostCount(hostStatus.getHostCount());
+	Collection<Host> hostsUp = hostStatus.getActiveHosts();
+
+	if (hostsUp == null || hostsUp.isEmpty()) {
+	    throw new NoAvailableHostsException("No available hosts when starting connection pool");
+	}
+
+	final ExecutorService threadPool = Executors.newFixedThreadPool(Math.max(10, hostsUp.size()));
+	final List<Future<Void>> futures = new ArrayList<Future<Void>>();
+
+	for (final Host host : hostsUp) {
+
+	    // Add host connection pool, but don't init the load balancer yet
+	    futures.add(threadPool.submit(new Callable<Void>() {
+
+		@Override
+		public Void call() throws Exception {
+		    addHost(host, false);
+		    return null;
+		}
+	    }));
+	}
+
+	try {
+	    for (Future<Void> future : futures) {
+		try {
+		    future.get();
+		} catch (InterruptedException e) {
+		    // do nothing
+		} catch (ExecutionException e) {
+		    throw new RuntimeException(e);
+		}
+	    }
+	} finally {
+	    threadPool.shutdownNow();
+	}
+
+	boolean success = started.compareAndSet(false, true);
+	if (success) {
+	    idling.set(false);
+	    idleThreadPool.shutdownNow();
+	    selectionStrategy = initSelectionStrategy();
+	    cpHealthTracker.start();
+
+	    connPoolThreadPool.scheduleWithFixedDelay(new Runnable() {
+
+		@Override
+		public void run() {
+		    try {
+			HostStatusTracker hostStatus = hostsUpdater.refreshHosts();
+			cpMonitor.setHostCount(hostStatus.getHostCount());
+			Logger.debug(hostStatus.toString());
+			updateHosts(hostStatus.getActiveHosts(), hostStatus.getInactiveHosts());
+		    } catch (Throwable throwable) {
+			Logger.error("Failed to update hosts cache", throwable);
+		    }
+		}
+
+	    }, 15 * 1000, 30 * 1000, TimeUnit.MILLISECONDS);
+
+	    MonitorConsole.getInstance().registerConnectionPool(this);
+
+	    registerMonitorConsoleMBean(MonitorConsole.getInstance());
+
+	}
+
+	return getEmptyFutureTask(true);
+    }
 
     @Override
     public void idle() {
-        if (this.started.get()) {
-            throw new IllegalStateException("Cannot move from started to idle once the pool has been started");
-        }
+	if (this.started.get()) {
+	    throw new IllegalStateException("Cannot move from started to idle once the pool has been started");
+	}
 
-        if (idling.compareAndSet(false, true)) {
-            idleThreadPool.scheduleAtFixedRate(new Runnable() {
-                @Override
-                public void run() {
-                    if (!started.get()) {
-                        try {
-                            HostStatusTracker hostStatus = hostsUpdater.refreshHosts();
-                            cpMonitor.setHostCount(hostStatus.getHostCount());
-                            Collection<Host> hostsUp = hostStatus.getActiveHosts();
-                            if (hostsUp.size() > 0) {
-                                Logger.debug("Found hosts while IDLING; starting the connection pool");
-                                start().get();
-                            }
-                        } catch (NoAvailableHostsException nah) {
-                            Logger.debug("No hosts found, will continue IDLING");
-                        } catch (DynoException de) {
-                            Logger.warn("Attempt to start connection pool FAILED", de);
-                        } catch (Exception e) {
-                            Logger.warn("Attempt to start connection pool FAILED", e);
-                        }
-                    }
-                }
-            }, 30, 60, TimeUnit.SECONDS);
-        }
+	if (idling.compareAndSet(false, true)) {
+	    idleThreadPool.scheduleAtFixedRate(new Runnable() {
+		@Override
+		public void run() {
+		    if (!started.get()) {
+			try {
+			    HostStatusTracker hostStatus = hostsUpdater.refreshHosts();
+			    cpMonitor.setHostCount(hostStatus.getHostCount());
+			    Collection<Host> hostsUp = hostStatus.getActiveHosts();
+			    if (hostsUp.size() > 0) {
+				Logger.debug("Found hosts while IDLING; starting the connection pool");
+				start().get();
+			    }
+			} catch (NoAvailableHostsException nah) {
+			    Logger.debug("No hosts found, will continue IDLING");
+			} catch (DynoException de) {
+			    Logger.warn("Attempt to start connection pool FAILED", de);
+			} catch (Exception e) {
+			    Logger.warn("Attempt to start connection pool FAILED", e);
+			}
+		    }
+		}
+	    }, 30, 60, TimeUnit.SECONDS);
+	}
     }
 
     @Override
-	public ConnectionPoolConfiguration getConfiguration() {
-		return cpConfiguration;
-	}
+    public ConnectionPoolConfiguration getConfiguration() {
+	return cpConfiguration;
+    }
 
-	private void registerMonitorConsoleMBean(MonitorConsoleMBean bean) {
-        final MBeanServer server = ManagementFactory.getPlatformMBeanServer();
-        try {
-            ObjectName objectName = new ObjectName(MonitorConsole.OBJECT_NAME);
-            if (!server.isRegistered(objectName)) {
-                server.registerMBean(bean, objectName);
-                Logger.info("registered mbean " + objectName);
-            } else {
-                Logger.info("mbean " + objectName + " has already been registered !");
-            }
-        } catch (MalformedObjectNameException | InstanceAlreadyExistsException | MBeanRegistrationException | NotCompliantMBeanException ex) {
-            Logger.error("Unable to register MonitorConsole mbean ", ex);
-        }
+    private void registerMonitorConsoleMBean(MonitorConsoleMBean bean) {
+	final MBeanServer server = ManagementFactory.getPlatformMBeanServer();
+	try {
+	    ObjectName objectName = new ObjectName(MonitorConsole.OBJECT_NAME);
+	    if (!server.isRegistered(objectName)) {
+		server.registerMBean(bean, objectName);
+		Logger.info("registered mbean " + objectName);
+	    } else {
+		Logger.info("mbean " + objectName + " has already been registered !");
+	    }
+	} catch (MalformedObjectNameException | InstanceAlreadyExistsException | MBeanRegistrationException
+		| NotCompliantMBeanException ex) {
+	    Logger.error("Unable to register MonitorConsole mbean ", ex);
 	}
+    }
 
     private void deregisterMonitorConsoleMBean() {
-        final MBeanServer server = ManagementFactory.getPlatformMBeanServer();
-        try {
-            ObjectName objectName = new ObjectName(MonitorConsole.OBJECT_NAME);
-            if (server.isRegistered(objectName)) {
-                server.unregisterMBean(objectName);
-                Logger.info("deregistered mbean " + objectName);
-            }
-        } catch (MalformedObjectNameException | MBeanRegistrationException | InstanceNotFoundException ex) {
-            Logger.error("Unable to deregister MonitorConsole mbean ", ex);
-        }
-
-	}
-	
-	private HostSelectionWithFallback<CL> initSelectionStrategy() {
-		
-		if (cpConfiguration.getTokenSupplier() == null) {
-			throw new RuntimeException("TokenMapSupplier not configured");
-		}
-		HostSelectionWithFallback<CL> selection = new HostSelectionWithFallback<CL>(cpConfiguration, cpMonitor);
-		selection.initWithHosts(cpMap);
-		return selection;
+	final MBeanServer server = ManagementFactory.getPlatformMBeanServer();
+	try {
+	    ObjectName objectName = new ObjectName(MonitorConsole.OBJECT_NAME);
+	    if (server.isRegistered(objectName)) {
+		server.unregisterMBean(objectName);
+		Logger.info("deregistered mbean " + objectName);
+	    }
+	} catch (MalformedObjectNameException | MBeanRegistrationException | InstanceNotFoundException ex) {
+	    Logger.error("Unable to deregister MonitorConsole mbean ", ex);
 	}
 
-	private Future<Boolean> getEmptyFutureTask(final Boolean condition) {
-		
-		FutureTask<Boolean> future = new FutureTask<Boolean>(new Callable<Boolean>() {
-			@Override
-			public Boolean call() throws Exception {
-				return condition;
-			}
-		});
-		
-		future.run();
-		return future;
-	}
+    }
 
-	private class SyncHostConnectionPoolFactory implements HostConnectionPoolFactory<CL> {
+    private HostSelectionWithFallback<CL> initSelectionStrategy() {
 
-		@Override
-		public HostConnectionPool<CL> createHostConnectionPool(Host host, ConnectionPoolImpl<CL> parentPoolImpl) {
-			return new HostConnectionPoolImpl<CL>(host, connFactory, cpConfiguration, cpMonitor);
-		}
+	if (cpConfiguration.getTokenSupplier() == null) {
+	    throw new RuntimeException("TokenMapSupplier not configured");
 	}
-	
-	private class AsyncHostConnectionPoolFactory implements HostConnectionPoolFactory<CL> {
+	HostSelectionWithFallback<CL> selection = new HostSelectionWithFallback<CL>(cpConfiguration, cpMonitor);
+	selection.initWithHosts(cpMap);
+	return selection;
+    }
 
-		@Override
-		public HostConnectionPool<CL> createHostConnectionPool(Host host, ConnectionPoolImpl<CL> parentPoolImpl) {
-			return new SimpleAsyncConnectionPoolImpl<CL>(host, connFactory, cpConfiguration, cpMonitor);
-		}
-	}
-	
+    private Future<Boolean> getEmptyFutureTask(final Boolean condition) {
+
+	FutureTask<Boolean> future = new FutureTask<Boolean>(new Callable<Boolean>() {
+	    @Override
+	    public Boolean call() throws Exception {
+		return condition;
+	    }
+	});
+
+	future.run();
+	return future;
+    }
+
+    private class SyncHostConnectionPoolFactory implements HostConnectionPoolFactory<CL> {
+
 	@Override
-	public <R> ListenableFuture<OperationResult<R>> executeAsync(AsyncOperation<CL, R> op) throws DynoException {
-		
-		DynoException lastException = null;
-		Connection<CL> connection = null;
-		long startTime = System.currentTimeMillis();
-		
-		try { 
-			connection = 
-					selectionStrategy.getConnection(op, cpConfiguration.getMaxTimeoutWhenExhausted(), TimeUnit.MILLISECONDS);
-			
-			ListenableFuture<OperationResult<R>> futureResult = connection.executeAsync(op);
-			
-			cpMonitor.incOperationSuccess(connection.getHost(), System.currentTimeMillis()-startTime);
-		
-			return futureResult; 
-			
-		} catch(NoAvailableHostsException e) {
-			cpMonitor.incOperationFailure(null, e);
-			throw e;
-		} catch(DynoException e) {
-			
-			lastException = e;
-			cpMonitor.incOperationFailure(connection != null ? connection.getHost() : null, e);
-			
-			// Track the connection health so that the pool can be purged at a later point
-			if (connection != null) {
-				cpHealthTracker.trackConnectionError(connection.getParentConnectionPool(), lastException);
-			}
-			
-		} catch(Throwable t) {
-			t.printStackTrace();
-		} finally {
-			if (connection != null) {
-				connection.getParentConnectionPool().returnConnection(connection);
-			}
-		}
-		return null;
+	public HostConnectionPool<CL> createHostConnectionPool(Host host, ConnectionPoolImpl<CL> parentPoolImpl) {
+	    return new HostConnectionPoolImpl<CL>(host, connFactory, cpConfiguration, cpMonitor);
 	}
+    }
 
-	public TokenPoolTopology getTopology() {
-        return selectionStrategy.getTokenPoolTopology();
+    private class AsyncHostConnectionPoolFactory implements HostConnectionPoolFactory<CL> {
+
+	@Override
+	public HostConnectionPool<CL> createHostConnectionPool(Host host, ConnectionPoolImpl<CL> parentPoolImpl) {
+	    return new SimpleAsyncConnectionPoolImpl<CL>(host, connFactory, cpConfiguration, cpMonitor);
+	}
+    }
+
+    @Override
+    public <R> ListenableFuture<OperationResult<R>> executeAsync(AsyncOperation<CL, R> op) throws DynoException {
+
+	DynoException lastException = null;
+	Connection<CL> connection = null;
+	long startTime = System.currentTimeMillis();
+
+	try {
+	    connection = selectionStrategy.getConnection(op, cpConfiguration.getMaxTimeoutWhenExhausted(),
+		    TimeUnit.MILLISECONDS);
+
+	    ListenableFuture<OperationResult<R>> futureResult = connection.executeAsync(op);
+
+	    cpMonitor.incOperationSuccess(connection.getHost(), System.currentTimeMillis() - startTime);
+
+	    return futureResult;
+
+	} catch (NoAvailableHostsException e) {
+	    cpMonitor.incOperationFailure(null, e);
+	    throw e;
+	} catch (DynoException e) {
+
+	    lastException = e;
+	    cpMonitor.incOperationFailure(connection != null ? connection.getHost() : null, e);
+
+	    // Track the connection health so that the pool can be purged at a
+	    // later point
+	    if (connection != null) {
+		cpHealthTracker.trackConnectionError(connection.getParentConnectionPool(), lastException);
+	    }
+
+	} catch (Throwable t) {
+	    t.printStackTrace();
+	} finally {
+	    if (connection != null) {
+		connection.getParentConnectionPool().returnConnection(connection);
+	    }
+	}
+	return null;
+    }
+
+    public TokenPoolTopology getTopology() {
+	return selectionStrategy.getTokenPoolTopology();
     }
 
     @Override
     public Map<String, List<TokenPoolTopology.TokenStatus>> getTopologySnapshot() {
-        return Collections.unmodifiableMap(selectionStrategy.getTokenPoolTopology().getAllTokens());
+	return Collections.unmodifiableMap(selectionStrategy.getTokenPoolTopology().getAllTokens());
     }
 
     @Override
     public Long getTokenForKey(String key) {
-        if (cpConfiguration.getLoadBalancingStrategy() ==
-                ConnectionPoolConfiguration.LoadBalancingStrategy.TokenAware) {
-            return selectionStrategy.getTokenForKey(key);
-        }
+	if (cpConfiguration
+		.getLoadBalancingStrategy() == ConnectionPoolConfiguration.LoadBalancingStrategy.TokenAware) {
+	    return selectionStrategy.getTokenForKey(key);
+	}
 
-        return null;
+	return null;
     }
 }

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/lb/AbstractTokenMapSupplier.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/lb/AbstractTokenMapSupplier.java
@@ -37,143 +37,158 @@ import com.netflix.dyno.connectionpool.impl.utils.CollectionUtils;
 import com.netflix.dyno.connectionpool.impl.utils.CollectionUtils.Predicate;
 
 /**
- * An Example of the JSON payload that we get from a dynomite server
- * [
- *   {"token":"3051939411","hostname":"ec2-54-237-143-4.compute-1.amazonaws.com" ,"dc":"florida","ip":"54.237.143.4",      "zone":"us-east-1d", "location":"us-east-1"},
- *   {"token":"188627880"," hostname":"ec2-50-17-65-2.compute-1.amazonaws.com"   ,"dc":"florida","ip":"50.17.65.2",        "zone":"us-east-1d", "location":"us-east-1"},
- *   {"token":"2019187467","hostname":"ec2-54-83-87-174.compute-1.amazonaws.com" ,"dc":"florida-v001","ip":"54.83.87.174", "zone":"us-east-1c", "location":"us-east-1"},
- *   {"token":"3450843231","hostname":"ec2-54-81-138-73.compute-1.amazonaws.com" ,"dc":"florida-v001","ip":"54.81.138.73", "zone":"us-east-1c", "location":"us-east-1"},
- *   {"token":"587531700"," hostname":"ec2-54-82-176-215.compute-1.amazonaws.com","dc":"florida-v001","ip":"54.82.176.215","zone":"us-east-1c", "location":"us-east-1"},
- *   {"token":"3101134286","hostname":"ec2-54-82-83-115.compute-1.amazonaws.com" ,"dc":"florida-v000","ip":"54.82.83.115", "zone":"us-east-1e", "location":"us-east-1"},
- *   {"token":"237822755"," hostname":"ec2-54-211-220-55.compute-1.amazonaws.com","dc":"florida-v000","ip":"54.211.220.55","zone":"us-east-1e", "location":"us-east-1"},
- *   {"token":"1669478519","hostname":"ec2-54-80-65-203.compute-1.amazonaws.com" ,"dc":"florida-v000","ip":"54.80.65.203", "zone":"us-east-1e", "location":"us-east-1"}
- * ]
+ * An Example of the JSON payload that we get from a dynomite server [
+ * {"token":"3051939411","hostname":"ec2-54-237-143-4.compute-1.amazonaws.com"
+ * ,"dc":"florida","ip":"54.237.143.4", "zone":"us-east-1d",
+ * "location":"us-east-1"}, {"token":"188627880","
+ * hostname":"ec2-50-17-65-2.compute-1.amazonaws.com"
+ * ,"dc":"florida","ip":"50.17.65.2", "zone":"us-east-1d",
+ * "location":"us-east-1"},
+ * {"token":"2019187467","hostname":"ec2-54-83-87-174.compute-1.amazonaws.com"
+ * ,"dc":"florida-v001","ip":"54.83.87.174", "zone":"us-east-1c",
+ * "location":"us-east-1"},
+ * {"token":"3450843231","hostname":"ec2-54-81-138-73.compute-1.amazonaws.com"
+ * ,"dc":"florida-v001","ip":"54.81.138.73", "zone":"us-east-1c",
+ * "location":"us-east-1"}, {"token":"587531700","
+ * hostname":"ec2-54-82-176-215.compute-1.amazonaws.com","dc":"florida-v001","ip":"54.82.176.215","zone":"us-east-1c",
+ * "location":"us-east-1"},
+ * {"token":"3101134286","hostname":"ec2-54-82-83-115.compute-1.amazonaws.com"
+ * ,"dc":"florida-v000","ip":"54.82.83.115", "zone":"us-east-1e",
+ * "location":"us-east-1"}, {"token":"237822755","
+ * hostname":"ec2-54-211-220-55.compute-1.amazonaws.com","dc":"florida-v000","ip":"54.211.220.55","zone":"us-east-1e",
+ * "location":"us-east-1"},
+ * {"token":"1669478519","hostname":"ec2-54-80-65-203.compute-1.amazonaws.com"
+ * ,"dc":"florida-v000","ip":"54.80.65.203", "zone":"us-east-1e",
+ * "location":"us-east-1"} ]
  * 
  * @author poberai
  *
  */
 public abstract class AbstractTokenMapSupplier implements TokenMapSupplier {
 
-	private static final Logger Logger = LoggerFactory.getLogger(AbstractTokenMapSupplier.class);
+    private static final Logger Logger = LoggerFactory.getLogger(AbstractTokenMapSupplier.class);
 
-	private final String localZone;
-	private final String localDatacenter;
-	protected final int port;
+    private final String localZone;
+    private final String localDatacenter;
+    protected final int port;
 
     public AbstractTokenMapSupplier() {
-        this(8080);
+	this(8080);
     }
 
-	public AbstractTokenMapSupplier(int port) {
-		localZone = ConfigUtils.getLocalZone();
-		localDatacenter = ConfigUtils.getDataCenter();
-		this.port = port;
-	}
+    public AbstractTokenMapSupplier(int port) {
+	localZone = ConfigUtils.getLocalZone();
+	localDatacenter = ConfigUtils.getDataCenter();
+	this.port = port;
+    }
 
-	public abstract String getTopologyJsonPayload(Set<Host> activeHosts);
-	
-	public abstract String getTopologyJsonPayload(String hostname);
-	
-	@Override
-	public List<HostToken> getTokens(Set<Host> activeHosts) {
+    public abstract String getTopologyJsonPayload(Set<Host> activeHosts);
 
-		// Doing this since not all tokens are received from an individual call to a dynomite server
-		// hence trying them all
-		Set<HostToken> allTokens = new HashSet<HostToken>();
-		
-		for (Host host : activeHosts) {
-			try {
-				List<HostToken> hostTokens = parseTokenListFromJson(getTopologyJsonPayload((host.getHostAddress())));
-				for (HostToken hToken : hostTokens) {
-					allTokens.add(hToken);
-				}
-			} catch (Exception e) {
-				Logger.warn("Could not get json response for token topology [" + e.getMessage() + "]");
-			}
+    public abstract String getTopologyJsonPayload(String hostname);
+
+    @Override
+    public List<HostToken> getTokens(Set<Host> activeHosts) {
+
+	// Doing this since not all tokens are received from an individual call
+	// to a dynomite server
+	// hence trying them all
+	Set<HostToken> allTokens = new HashSet<HostToken>();
+
+	for (Host host : activeHosts) {
+	    try {
+		List<HostToken> hostTokens = parseTokenListFromJson(getTopologyJsonPayload((host.getHostAddress())));
+		for (HostToken hToken : hostTokens) {
+		    allTokens.add(hToken);
 		}
-		return new ArrayList<HostToken>(allTokens);
+	    } catch (Exception e) {
+		Logger.warn("Could not get json response for token topology [" + e.getMessage() + "]");
+	    }
 	}
-	
-	@Override
-	public HostToken getTokenForHost(final Host host, final Set<Host> activeHosts) {
-        String jsonPayload;
-        if (activeHosts.size() == 0) {
-            jsonPayload = getTopologyJsonPayload(host.getHostAddress());
-        } else {
-            try {
-                jsonPayload = getTopologyJsonPayload(activeHosts);
-            } catch (TimeoutException ex) {
-                // Try using the host we just primed connections to. If that fails,
-                // let the exception bubble up to ConnectionPoolImpl which will remove
-                // the host from the host-mapping
-                jsonPayload = getTopologyJsonPayload(host.getHostAddress());
-            }
-        }
-		List<HostToken> hostTokens = parseTokenListFromJson(jsonPayload);
-		
-		return CollectionUtils.find(hostTokens, new Predicate<HostToken>() {
+	return new ArrayList<HostToken>(allTokens);
+    }
 
-			@Override
-			public boolean apply(HostToken x) {
-				return x.getHost().getHostAddress().equals(host.getHostAddress());
-			}
-		});
+    @Override
+    public HostToken getTokenForHost(final Host host, final Set<Host> activeHosts) {
+	String jsonPayload;
+	if (activeHosts.size() == 0) {
+	    jsonPayload = getTopologyJsonPayload(host.getHostAddress());
+	} else {
+	    try {
+		jsonPayload = getTopologyJsonPayload(activeHosts);
+	    } catch (TimeoutException ex) {
+		// Try using the host we just primed connections to. If that
+		// fails,
+		// let the exception bubble up to ConnectionPoolImpl which will
+		// remove
+		// the host from the host-mapping
+		jsonPayload = getTopologyJsonPayload(host.getHostAddress());
+	    }
 	}
-	
-	private boolean isLocalZoneHost(Host host) {
-		if (localZone == null || localZone.isEmpty()) {
-			Logger.warn("Local rack was not defined");
-			return true; // consider everything
-		}
-		return localZone.equalsIgnoreCase(host.getRack());
-	}
-	
-	private boolean isLocalDatacenterHost(Host host) {
-		
-		if (localDatacenter == null || localDatacenter.isEmpty()) {
-			Logger.warn("Local Datacenter was not defined");
-			return true;
-		}
+	List<HostToken> hostTokens = parseTokenListFromJson(jsonPayload);
 
-		return localDatacenter.equalsIgnoreCase(host.getDatacenter());
+	return CollectionUtils.find(hostTokens, new Predicate<HostToken>() {
+
+	    @Override
+	    public boolean apply(HostToken x) {
+		return x.getHost().getHostAddress().equals(host.getHostName());
+	    }
+	});
+    }
+
+    private boolean isLocalZoneHost(Host host) {
+	if (localZone == null || localZone.isEmpty()) {
+	    Logger.warn("Local rack was not defined");
+	    return true; // consider everything
 	}
+	return localZone.equalsIgnoreCase(host.getRack());
+    }
+
+    private boolean isLocalDatacenterHost(Host host) {
+
+	if (localDatacenter == null || localDatacenter.isEmpty()) {
+	    Logger.warn("Local Datacenter was not defined");
+	    return true;
+	}
+
+	return localDatacenter.equalsIgnoreCase(host.getDatacenter());
+    }
 
     // package-private for Test
-	List<HostToken> parseTokenListFromJson(String json) {
-		
-		List<HostToken> hostTokens = new ArrayList<HostToken>();
-		
-		JSONParser parser = new JSONParser();
-		try {
-			JSONArray arr = (JSONArray) parser.parse(json);
-			
-			Iterator<?> iter = arr.iterator();
-			while (iter.hasNext()) {
-				
-				Object item = iter.next();
-				if (!(item instanceof JSONObject)) {
-					continue;
-				}
-				JSONObject jItem = (JSONObject)item;
-				
-				Long token = Long.parseLong((String)jItem.get("token"));
-				String hostname = (String)jItem.get("hostname");
-				String zone = (String)jItem.get("zone");
-				
-				Host host = new Host(hostname, port, Status.Up);
-				host.setRack(zone);
-				
-				if(isLocalDatacenterHost(host)){				
-					HostToken hostToken = new HostToken(token, host);
-					hostTokens.add(hostToken);
-				}
-			}
-			
-		} catch (ParseException e) {
-			Logger.error("Failed to parse json response: " + json, e);
-			throw new RuntimeException(e);
-		}
+    List<HostToken> parseTokenListFromJson(String json) {
 
-		return hostTokens;
+	List<HostToken> hostTokens = new ArrayList<HostToken>();
+
+	JSONParser parser = new JSONParser();
+	try {
+	    JSONArray arr = (JSONArray) parser.parse(json);
+
+	    Iterator<?> iter = arr.iterator();
+	    while (iter.hasNext()) {
+
+		Object item = iter.next();
+		if (!(item instanceof JSONObject)) {
+		    continue;
+		}
+		JSONObject jItem = (JSONObject) item;
+
+		Long token = Long.parseLong((String) jItem.get("token"));
+		String hostname = (String) jItem.get("hostname");
+		String zone = (String) jItem.get("zone");
+
+		Host host = new Host(hostname, port, Status.Up);
+		host.setRack(zone);
+		
+		if (isLocalDatacenterHost(host)) {
+		    HostToken hostToken = new HostToken(token, host);
+		    hostTokens.add(hostToken);
+		}
+	    }
+
+	} catch (ParseException e) {
+	    Logger.error("Failed to parse json response: " + json, e);
+	    throw new RuntimeException(e);
 	}
+
+	return hostTokens;
+    }
 }

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/lb/HttpEndpointBasedTokenMapSupplier.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/lb/HttpEndpointBasedTokenMapSupplier.java
@@ -43,8 +43,8 @@ public class HttpEndpointBasedTokenMapSupplier extends AbstractTokenMapSupplier 
 
     private static final String DefaultServerUrl = "http://{hostname}:8080/REST/v1/admin/cluster_describe";
     private final String serverUrl;
-    private static final Integer NumRetriesSameNode = 2;
-    private static final Integer NumRetriesAcrossNodes = 2;
+    private static final Integer NUM_RETRIES_PER_NODE = 2;
+    private static final Integer NUM_RETRIER_ACROSS_NODES = 2;
 
     public HttpEndpointBasedTokenMapSupplier(int port) {
 	this(DefaultServerUrl, port);
@@ -60,7 +60,7 @@ public class HttpEndpointBasedTokenMapSupplier extends AbstractTokenMapSupplier 
      */
     @Override
     public String getTopologyJsonPayload(Set<Host> activeHosts) {
-	int count = NumRetriesAcrossNodes;
+	int count = NUM_RETRIER_ACROSS_NODES;
 	String response;
 	Exception lastEx = null;
 
@@ -110,7 +110,7 @@ public class HttpEndpointBasedTokenMapSupplier extends AbstractTokenMapSupplier 
 	client.getParams().setParameter(HttpConnectionParams.CONNECTION_TIMEOUT, 2000);
 	client.getParams().setParameter(HttpConnectionParams.SO_TIMEOUT, 5000);
 
-	DefaultHttpRequestRetryHandler retryhandler = new DefaultHttpRequestRetryHandler(NumRetriesAcrossNodes, true);
+	DefaultHttpRequestRetryHandler retryhandler = new DefaultHttpRequestRetryHandler(NUM_RETRIER_ACROSS_NODES, true);
 	client.setHttpRequestRetryHandler(retryhandler);
 
 	HttpGet get = new HttpGet(url);
@@ -163,7 +163,7 @@ public class HttpEndpointBasedTokenMapSupplier extends AbstractTokenMapSupplier 
      * @return the topology from cluster_describe
      */
     private String getTopologyWithNodeRetry(Set<Host> activeHosts) {
-	int count = NumRetriesSameNode;
+	int count = NUM_RETRIES_PER_NODE;
 	String nodeResponse;
 	Exception lastEx;
 	final String randomHost = getRandomHost(activeHosts);

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/lb/HttpEndpointBasedTokenMapSupplier.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/lb/HttpEndpointBasedTokenMapSupplier.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.Random;
 import java.util.Set;
 
-import com.netflix.dyno.connectionpool.exception.DynoConnectException;
 import com.netflix.dyno.connectionpool.exception.DynoException;
 import com.netflix.dyno.connectionpool.exception.TimeoutException;
 import org.apache.http.HttpResponse;
@@ -40,109 +39,160 @@ import com.netflix.dyno.connectionpool.impl.utils.IOUtilities;
 
 public class HttpEndpointBasedTokenMapSupplier extends AbstractTokenMapSupplier {
 
-	private static final Logger Logger = LoggerFactory.getLogger(HttpEndpointBasedTokenMapSupplier.class);
-	
-	private static final String DefaultServerUrl = "http://{hostname}:8080/REST/v1/admin/cluster_describe";
-	private final String serverUrl;
-	private static final Integer NumRetries = 2;
+    private static final Logger Logger = LoggerFactory.getLogger(HttpEndpointBasedTokenMapSupplier.class);
 
-	public HttpEndpointBasedTokenMapSupplier(int port) {
-		this(DefaultServerUrl, port);
-	}
+    private static final String DefaultServerUrl = "http://{hostname}:8080/REST/v1/admin/cluster_describe";
+    private final String serverUrl;
+    private static final Integer NumRetriesSameNode = 2;
+    private static final Integer NumRetriesAcrossNodes = 2;
 
-	public HttpEndpointBasedTokenMapSupplier(String url, int port) {
-        super(port);
-		serverUrl = url;
-	}
+    public HttpEndpointBasedTokenMapSupplier(int port) {
+	this(DefaultServerUrl, port);
+    }
 
-	@Override
-	public String getTopologyJsonPayload(Set<Host> activeHosts) {
-		
-		int count = NumRetries;
-		Exception lastEx = null;
+    public HttpEndpointBasedTokenMapSupplier(String url, int port) {
+	super(port);
+	serverUrl = url;
+    }
 
-		String response;
-        final String randomHost = getRandomHost(activeHosts);
-		do {
-			try {
-                response = getResponseViaHttp(randomHost);
-                if (response != null) {
-                    return response;
-                }
-            } catch (Exception e) {
-				lastEx = e;
-			} finally {
-				count--;
-			}
-		} while ((count > 0));
-		
-		if (lastEx != null) {
-            Logger.warn("Unable to obtain topology for Host " + randomHost + ", error = " + lastEx.getMessage());
-            if (lastEx instanceof ConnectTimeoutException) {
-                throw new TimeoutException("Unable to obtain topology", lastEx);
-            }
-			throw new DynoException(lastEx);
-		} else {
-			throw new DynoException("Could not contact dynomite for token map");
+    /**
+     * Tries to get topology information by randomly trying across nodes.
+     */
+    @Override
+    public String getTopologyJsonPayload(Set<Host> activeHosts) {
+	int count = NumRetriesAcrossNodes;
+	String response;
+	Exception lastEx = null;
+
+	do {
+	    try {
+		response = getTopologyWithNodeRetry(activeHosts);
+		if (response != null) {
+		    return response;
 		}
+	    } catch (Exception e) {
+		lastEx = e;
+	    } finally {
+		count--;
+	    }
+	} while ((count > 0));
+
+	if (lastEx != null) {
+	    if (lastEx instanceof ConnectTimeoutException) {
+		throw new TimeoutException("Unable to obtain topology", lastEx);
+	    }
+	    throw new DynoException(lastEx);
+	} else {
+	    throw new DynoException("Could not contact dynomite for token map");
 	}
 
-	@Override
-	public String getTopologyJsonPayload(String hostname) {
-		try { 
-			return getResponseViaHttp(hostname);
-		} catch (Exception e) {
-			throw new RuntimeException(e);
-		}
+    }
+
+    @Override
+    public String getTopologyJsonPayload(String hostname) {
+	try {
+	    return getResponseViaHttp(hostname);
+	} catch (Exception e) {
+	    throw new RuntimeException(e);
+	}
+    }
+
+    private String getResponseViaHttp(String hostname) throws Exception {
+
+	String url = serverUrl;
+	url = url.replace("{hostname}", hostname);
+
+	if (Logger.isDebugEnabled()) {
+	    Logger.debug("Making http call to url: " + url);
 	}
 
-	private String getResponseViaHttp(String hostname) throws Exception {
-		
-		String url = serverUrl;
-		url = url.replace("{hostname}", hostname);
+	DefaultHttpClient client = new DefaultHttpClient();
+	client.getParams().setParameter(HttpConnectionParams.CONNECTION_TIMEOUT, 2000);
+	client.getParams().setParameter(HttpConnectionParams.SO_TIMEOUT, 5000);
 
-		if (Logger.isDebugEnabled()) {
-			Logger.debug("Making http call to url: " + url);
-		}
-		
-		DefaultHttpClient client = new DefaultHttpClient();
-		client.getParams().setParameter(HttpConnectionParams.CONNECTION_TIMEOUT, 2000);
-		client.getParams().setParameter(HttpConnectionParams.SO_TIMEOUT, 5000);
-		
-		DefaultHttpRequestRetryHandler retryhandler = new DefaultHttpRequestRetryHandler(NumRetries, true);
-		client.setHttpRequestRetryHandler(retryhandler);
-		
-		HttpGet get = new HttpGet(url);
-		
-		HttpResponse response = client.execute(get);
-		int statusCode = response.getStatusLine().getStatusCode();
-		if (!(statusCode == 200)) {
-			Logger.error("Got non 200 status code from " + url);
-			return null;
-		}
-			
-		InputStream in = null;
-		try {
-			in = response.getEntity().getContent();
-			return IOUtilities.toString(in);
-		} finally {
-			if (in != null) {
-				in.close();
-			}
-		}
-	}
-	
-	private String getRandomHost(Set<Host> activeHosts) {
-		Random random = new Random();
-		
-		List<Host> hostsUp = new ArrayList<Host>(CollectionUtils.filter(activeHosts, new Predicate<Host>() {
+	DefaultHttpRequestRetryHandler retryhandler = new DefaultHttpRequestRetryHandler(NumRetriesAcrossNodes, true);
+	client.setHttpRequestRetryHandler(retryhandler);
 
-			@Override
-			public boolean apply(Host x) {
-				return x.isUp();
-			}
-		}));
-		
-		return hostsUp.get(random.nextInt(hostsUp.size())).getHostAddress();
+	HttpGet get = new HttpGet(url);
+
+	HttpResponse response = client.execute(get);
+	int statusCode = response.getStatusLine().getStatusCode();
+	if (!(statusCode == 200)) {
+	    Logger.error("Got non 200 status code from " + url);
+	    return null;
 	}
+
+	InputStream in = null;
+	try {
+	    in = response.getEntity().getContent();
+	    return IOUtilities.toString(in);
+	} finally {
+	    if (in != null) {
+		in.close();
+	    }
+	}
+    }
+
+    /**
+     * Finds a random host from the set of active hosts to perform
+     * cluster_describe
+     * 
+     * @param activeHosts
+     * @return a random host
+     */
+    private String getRandomHost(Set<Host> activeHosts) {
+	Random random = new Random();
+
+	List<Host> hostsUp = new ArrayList<Host>(CollectionUtils.filter(activeHosts, new Predicate<Host>() {
+
+	    @Override
+	    public boolean apply(Host x) {
+		return x.isUp();
+	    }
+	}));
+
+	return hostsUp.get(random.nextInt(hostsUp.size())).getHostAddress();
+    }
+
+    /**
+     * Tries multiple nodes, and it only bubbles up the last node's exception.
+     * We want to bubble up the exception in order for the last node to be
+     * removed from the connection pool.
+     * 
+     * @param activeHosts
+     * @return the topology from cluster_describe
+     */
+    private String getTopologyWithNodeRetry(Set<Host> activeHosts) {
+	int count = NumRetriesSameNode;
+	String nodeResponse;
+	Exception lastEx;
+	final String randomHost = getRandomHost(activeHosts);
+	do {
+	    try {
+		lastEx = null;
+		nodeResponse = getResponseViaHttp(randomHost);
+		if (nodeResponse != null) {
+
+		    Logger.info("Received topology from " + randomHost);
+		    return nodeResponse;
+		}
+	    } catch (Exception e) {
+		Logger.info("cannot get topology from : " + randomHost);
+		lastEx = e;
+	    } finally {
+		count--;
+	    }
+
+	} while ((count > 0));
+
+	if (lastEx != null) {
+	    if (lastEx instanceof ConnectTimeoutException) {
+		throw new TimeoutException("Unable to obtain topology", lastEx);
+	    }
+	    throw new DynoException(lastEx);
+	} else {
+	    throw new DynoException("Could not contact dynomite for token map");
+	}
+
+    }
 }

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/utils/ConfigUtils.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/utils/ConfigUtils.java
@@ -16,37 +16,56 @@
 package com.netflix.dyno.connectionpool.impl.utils;
 
 /**
- * Simple helper class that provides convenience methods for configuration related tasks.
+ * Simple helper class that provides convenience methods for configuration
+ * related tasks.
  *
  * @author jcacciatore
+ * @author ipapapanagiotou
  */
 public class ConfigUtils {
 
     public static String getLocalZone() {
-        String az = System.getenv("EC2_AVAILABILITY_ZONE");
+	String az = System.getenv("EC2_AVAILABILITY_ZONE");
 
-        if (az == null) {
-            az = System.getProperty("EC2_AVAILABILITY_ZONE");
-        }
+	if (az == null) {
+	    az = System.getProperty("EC2_AVAILABILITY_ZONE");
+	}
 
-        return az;
+	return az;
     }
 
+    /**
+     * 
+     * @return the datacenter that the client is in
+     */
     public static String getDataCenter() {
-        String dc = System.getenv("EC2_REGION");
+	// first try with getEnv
+	String dc = System.getenv("EC2_REGION");
 
-        if (dc == null) {
-            dc = System.getProperty("EC2_REGION");
-        }
+	if (dc == null) {
+	    // then try with getProperty
+	    dc = System.getProperty("EC2_REGION");
+	}
 
-        if (dc == null) {
-            String rack = getLocalZone();
-            if (rack != null) {
-                dc = rack.substring(0, rack.length() - 1);
-            }
-        }
+	if (dc == null) {
+	    return getDataCenter(getLocalZone());
+	} else {
+	    return dc;
+	}
 
-        return dc;
+    }
+
+    /**
+     * 
+     * Datacenter format us-east-x, us-west-x etc.
+     * @param rack
+     * @return the datacenter based on the provided rack
+     */
+    public static String getDataCenter(String rack) {
+	if (rack != null) {
+	    return rack.substring(0, rack.length() - 1);
+	}
+	return null;
     }
 
 }


### PR DESCRIPTION
The PR includes the following:
* Limits Dyno to obtain and keep track of tokens only for nodes in each local datacenter. It addresses a security issue of making HTTP calls for Dynomite-manager tokens across regions. The only negative implication is when we use the JMX `getTopologySnapshot` we will only see same Datacenter tokens. Hence, we need to check client nodes in all regions to make sure the token distribution is correct.
* Fixes the bug that the HostToken received from the JSON does not contain a private IP address, hence a node could not be added in the Host connection pool.
* Added extra reliability in the way we perform requests for the `cluster_describe`. Before it would try one node and if it failed it would propagate the exception to the connection pool. Now it tries multiple nodes (twice by default) and propagates the last node to the connection pool. 
* Fixing some white spaces and some Java convention.