### PR TITLE
Allow passing customer ConnectionPoolMonitor's that implements them.

### DIFF
--- a/dyno-jedis/src/main/java/com/netflix/dyno/jedis/DynoDualWriterClient.java
+++ b/dyno-jedis/src/main/java/com/netflix/dyno/jedis/DynoDualWriterClient.java
@@ -16,6 +16,7 @@
 package com.netflix.dyno.jedis;
 
 import com.netflix.dyno.connectionpool.ConnectionPool;
+import com.netflix.dyno.connectionpool.ConnectionPoolMonitor;
 import com.netflix.dyno.connectionpool.OperationResult;
 import com.netflix.dyno.contrib.DynoOPMonitor;
 import org.slf4j.Logger;
@@ -54,18 +55,20 @@ public class DynoDualWriterClient extends DynoJedisClient {
     public DynoDualWriterClient(String name, String clusterName,
                                 ConnectionPool<Jedis> pool,
                                 DynoOPMonitor operationMonitor,
+                                ConnectionPoolMonitor connectionPoolMonitor,
                                 DynoJedisClient shadowClient) {
 
-        this(name, clusterName, pool, operationMonitor, shadowClient,
+        this(name, clusterName, pool, operationMonitor, connectionPoolMonitor, shadowClient,
                 new TimestampDial(pool.getConfiguration().getDualWritePercentage()));
     }
 
     public DynoDualWriterClient(String name, String clusterName,
                                 ConnectionPool<Jedis> pool,
                                 DynoOPMonitor operationMonitor,
+                                ConnectionPoolMonitor connectionPoolMonitor,
                                 DynoJedisClient shadowClient,
                                 Dial dial) {
-        super(name, clusterName, pool, operationMonitor);
+        super(name, clusterName, pool, operationMonitor, connectionPoolMonitor);
         this.shadowClient = shadowClient;
         this.dial = dial;
     }

--- a/dyno-jedis/src/main/java/com/netflix/dyno/jedis/DynoJedisClient.java
+++ b/dyno-jedis/src/main/java/com/netflix/dyno/jedis/DynoJedisClient.java
@@ -3325,16 +3325,18 @@ public class DynoJedisClient implements JedisCommands, BinaryJedisCommands, Mult
 
             // Construct an instance of our DualWriter client
             DynoOPMonitor opMonitor = new DynoOPMonitor(appName);
-            final ConnectionPoolImpl<Jedis> pool = createConnectionPool(appName, opMonitor, null);
+            ConnectionPoolMonitor cpMonitor = (this.cpMonitor == null) ? new DynoCPMonitor(appName) : this.cpMonitor;
+
+            final ConnectionPoolImpl<Jedis> pool = createConnectionPool(appName, opMonitor, cpMonitor);
 
             if (dualWriteDial != null) {
                 if (shadowConfig.getDualWritePercentage() > 0) {
                     dualWriteDial.setRange(shadowConfig.getDualWritePercentage());
                 }
 
-                return new DynoDualWriterClient(appName, clusterName, pool, opMonitor, shadowClient, dualWriteDial);
+                return new DynoDualWriterClient(appName, clusterName, pool, opMonitor, cpMonitor, shadowClient, dualWriteDial);
             } else {
-                return new DynoDualWriterClient(appName, clusterName, pool, opMonitor, shadowClient);
+                return new DynoDualWriterClient(appName, clusterName, pool, opMonitor, cpMonitor, shadowClient);
             }
         }
 

--- a/dyno-jedis/src/main/java/com/netflix/dyno/jedis/DynoJedisClient.java
+++ b/dyno-jedis/src/main/java/com/netflix/dyno/jedis/DynoJedisClient.java
@@ -3365,22 +3365,11 @@ public class DynoJedisClient implements JedisCommands, BinaryJedisCommands, Mult
 
             setLoadBalancingStrategy(cpConfig);
 
-<<<<<<< HEAD
             ConnectionPoolMonitor cpMonitor = (this.cpMonitor == null) ? new DynoCPMonitor(appName) : this.cpMonitor;
-
-            DynoOPMonitor opMonitor = new DynoOPMonitor(appName);
-=======
-            DynoCPMonitor cpMonitor = new DynoCPMonitor(appName);
->>>>>>> Netflix/master
-
 
             JedisConnectionFactory connFactory = new JedisConnectionFactory(opMonitor);
 
-<<<<<<< HEAD
-            return new DynoJedisClient(appName, clusterName, pool, opMonitor, cpMonitor);
-=======
             return startConnectionPool(appName, connFactory, cpConfig, cpMonitor);
->>>>>>> Netflix/master
         }
 
         private ConnectionPoolImpl<Jedis> startConnectionPool(String appName, JedisConnectionFactory connFactory,


### PR DESCRIPTION
DynoJedisClient constructor and also builder does not allow customer ConnectionPoolMonitor's that implements ConnectionPoolMonitor interface. By default it is using DynoCPMonitor. However my use case is that we want to use statsd or graphite for storing the metrics and so the custom implementation is now added. 