### PR TITLE
Fix maven generated POM compile scopes.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,8 @@ subprojects {
     apply plugin: 'nebula.netflixoss'
     apply plugin: 'java'
     apply plugin: 'idea'
-    apply plugin: 'eclipse'    
+    apply plugin: 'eclipse'
+    apply plugin: 'nebula.compile-api'
 
     sourceCompatibility = 1.7
     targetCompatibility = 1.7
@@ -24,12 +25,12 @@ subprojects {
     group = "com.netflix.${githubProjectName}"
 
     dependencies {
-        compile "joda-time:joda-time:2.3"
-        compile "org.slf4j:slf4j-api:1.7.6"
-        compile "org.slf4j:slf4j-log4j12:1.7.21"
-        compile "com.googlecode.json-simple:json-simple:1.1"
-        compile "org.apache.httpcomponents:httpclient:4.2.1"
-        compile "com.sun.jersey:jersey-core:1.11"
+        compileApi "joda-time:joda-time:2.3"
+        compileApi "org.slf4j:slf4j-api:1.7.6"
+        compileApi "org.slf4j:slf4j-log4j12:1.7.21"
+        compileApi "com.googlecode.json-simple:json-simple:1.1"
+        compileApi "org.apache.httpcomponents:httpclient:4.2.1"
+        compileApi "com.sun.jersey:jersey-core:1.11"
         testCompile "junit:junit:4.11"
     }
 
@@ -46,9 +47,9 @@ project(':dyno-core') {
     apply plugin: 'project-report'
     
     dependencies {
-        compile "org.apache.commons:commons-math:2.2"
-        compile "commons-io:commons-io:2.4"
-        compile "org.mockito:mockito-all:1.9.5"
+        compileApi "org.apache.commons:commons-math:2.2"
+        compileApi "commons-io:commons-io:2.4"
+        compileApi "org.mockito:mockito-all:1.9.5"
         testCompile "junit:junit:4.11"
     }
 }
@@ -58,11 +59,11 @@ project(':dyno-contrib') {
     apply plugin: 'project-report'
     
     dependencies {
-        compile  project(':dyno-core')
-        compile "com.google.inject:guice:3.0"
-        compile "com.netflix.archaius:archaius-core:0.5.6"
-        compile "com.netflix.servo:servo-core:0.5.5"
-        compile 'com.netflix.eureka:eureka-client:1.1.110'
+        compileApi  project(':dyno-core')
+        compileApi "com.google.inject:guice:3.0"
+        compileApi "com.netflix.archaius:archaius-core:0.5.6"
+        compileApi "com.netflix.servo:servo-core:0.5.5"
+        compileApi 'com.netflix.eureka:eureka-client:1.1.110'
     }
 }
 
@@ -71,9 +72,9 @@ project(':dyno-memcache') {
     apply plugin: 'project-report'
 
     dependencies {
-        compile  project(':dyno-core')
-        compile  project(':dyno-contrib')
-//        compile "net.spy:spymemcached:2.10.2+"
+        compileApi  project(':dyno-core')
+        compileApi  project(':dyno-contrib')
+//        compileApi "net.spy:spymemcached:2.10.2+"
     }
 }
 
@@ -82,9 +83,9 @@ project(':dyno-jedis') {
     apply plugin: 'project-report'
 
     dependencies {
-        compile  project(':dyno-core')
-        compile  project(':dyno-contrib')
-        compile "redis.clients:jedis:2.8.1"
+        compileApi  project(':dyno-core')
+        compileApi  project(':dyno-contrib')
+        compileApi "redis.clients:jedis:2.8.1"
     }
 }
 
@@ -93,9 +94,9 @@ project(':dyno-redisson') {
     apply plugin: 'project-report'
 
     dependencies {
-        compile  project(':dyno-core')
-        compile  project(':dyno-contrib')
-        compile "org.redisson:redisson:1.1.0"
+        compileApi  project(':dyno-core')
+        compileApi  project(':dyno-contrib')
+        compileApi "org.redisson:redisson:1.1.0"
     }
 }
 
@@ -104,11 +105,11 @@ project(':dyno-demo') {
     apply plugin: 'project-report'
 
     dependencies {
-        compile  project(':dyno-core')
-        compile  project(':dyno-contrib')
-        compile  project(':dyno-memcache')
-        compile  project(':dyno-jedis')
-        compile  project(':dyno-recipes')
+        compileApi  project(':dyno-core')
+        compileApi  project(':dyno-contrib')
+        compileApi  project(':dyno-memcache')
+        compileApi  project(':dyno-jedis')
+        compileApi  project(':dyno-recipes')
     }
 }
 
@@ -117,7 +118,7 @@ project(':dyno-recipes') {
     apply plugin: 'project-report'
 
     dependencies {
-        compile project(':dyno-core')
-        compile project(':dyno-jedis')
+        compileApi project(':dyno-core')
+        compileApi project(':dyno-jedis')
     }
 }


### PR DESCRIPTION
Fix generated POMs to mark dependencies scope as gradle defined 'compile', not 'runtime'. Adding 'nebula' 'compileApi' scope.