### PR TITLE
Regression Bug Fix: Host object equality contract changed

### DIFF
--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/Host.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/Host.java
@@ -28,155 +28,144 @@ import com.netflix.dyno.connectionpool.impl.utils.ConfigUtils;
  * @author ipapapanagiotou
  *
  */
-
 public class Host implements Comparable<Host> {
-        public static final int DEFAULT_PORT = 8102; 
-        public static final Host NO_HOST = new Host("UNKNOWN", "UNKNOWN", 0, "UNKNOWN");
+
+    public static final int DEFAULT_PORT = 8102;
+    public static final Host NO_HOST = new Host("UNKNOWN", "UNKNOWN", 0, "UNKNOWN");
     
-	private final String hostname;
-	private final String ipAddress;
-	private final int port;
-	private final InetSocketAddress socketAddress;
-        private final String rack; 
-        private final String datacenter;
-	private Status status = Status.Down;
+    private final String hostname;
+    private final String ipAddress;
+    private final int port;
+    private final InetSocketAddress socketAddress;
+    private final String rack;
+    private final String datacenter;
+    private Status status = Status.Down;
 
-	
+    public enum Status {
+        Up, Down;
+    }
 
-	
-	public static enum Status {
-		Up, Down;
-	}
-	
-	public Host(String hostname, int port, String rack) {
-		this(hostname, null, port, rack, rack, Status.Down);
-	}
-	
-	public Host(String hostname, String rack, Status status) {
-		this(hostname, null, DEFAULT_PORT, rack, rack, status);
-	}
-	
-	public Host(String hostname, int port, String rack, Status status) {
-		this(hostname, null, port, rack, rack, status);
-	}
-	
-	public Host(String hostname, String ipAddress, int port, String rack) {
-		this(hostname, ipAddress, port, rack, rack, Status.Down);
-	}
-	
-	public Host(String hostname, String ipAddress, String rack, Status status) {
-		this(hostname, ipAddress, DEFAULT_PORT, rack, rack, status);
-	}
+    public Host(String hostname, int port, String rack) {
+        this(hostname, null, port, rack, ConfigUtils.getDataCenterFromRack(rack), Status.Down);
+    }
 
-	public Host(String name, String ipAddress, int port, String rack, String datacenter,  Status status) {
-		this.hostname = name;
-		this.ipAddress = ipAddress;
-		this.port = port;
-		this.rack = rack;
-		this.status = status;
-		
-		this.datacenter = ConfigUtils.getDataCenter(datacenter);
-		
-		// Used for the unit tests to prevent host name resolution
-		if(port != -1) {
-		    this.socketAddress = new InetSocketAddress(name, port);
-		} else { 
-		    this.socketAddress = null;
-		}
-		
+    public Host(String hostname, String rack, Status status) {
+        this(hostname, null, DEFAULT_PORT, rack, ConfigUtils.getDataCenterFromRack(rack), status);
+    }
 
-	}
+    public Host(String hostname, int port, String rack, Status status) {
+        this(hostname, null, port, rack, ConfigUtils.getDataCenterFromRack(rack), status);
+    }
 
-	public String getHostAddress() {
-		if (this.ipAddress != null) {
-			return ipAddress;
-		}
-		return hostname;
-	}
-	
-	public String getHostName() {
+    public Host(String hostname, String ipAddress, int port, String rack) {
+        this(hostname, ipAddress, port, rack, ConfigUtils.getDataCenterFromRack(rack), Status.Down);
+    }
+
+    public Host(String hostname, String ipAddress, String rack, Status status) {
+        this(hostname, ipAddress, DEFAULT_PORT, rack, ConfigUtils.getDataCenterFromRack(rack), status);
+    }
+
+    public Host(String name, String ipAddress, int port, String rack, String datacenter,  Status status) {
+        this.hostname = name;
+        this.ipAddress = ipAddress;
+        this.port = port;
+        this.rack = rack;
+        this.status = status;
+        this.datacenter = datacenter;
+
+        // Used for the unit tests to prevent host name resolution
+        if(port != -1) {
+            this.socketAddress = new InetSocketAddress(name, port);
+        } else {
+            this.socketAddress = null;
+        }
+    }
+
+    public String getHostAddress() {
+        if (this.ipAddress != null) {
+            return ipAddress;
+        }
+        return hostname;
+    }
+
+    public String getHostName() {
             return hostname;
-	}
-	
-	public String getIpAddress() {
-		return ipAddress;
-	}
-	
-	public int getPort() {
-		return port;
-	}
-	
+    }
 
-	public String getRack() {
-		return rack;
-	}
-	
-	
-	public Host setStatus(Status condition) {
-		status = condition;
-		return this;
-	}
-	
-	public boolean isUp() {
-		return status == Status.Up;
-	}
-	
-	public InetSocketAddress getSocketAddress() {
-		return socketAddress;
-	}
-	
+    public String getIpAddress() {
+        return ipAddress;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public String getDatacenter() {
+        return datacenter;
+    }
+
+    public String getRack() {
+        return rack;
+    }
 
 
-	@Override
-	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + ((hostname == null) ? 0 : hostname.hashCode());
-		result = prime * result + ((rack == null) ? 0 : rack.hashCode());
-		result = prime * result + port;
-		return result;
-	}
+    public Host setStatus(Status condition) {
+        status = condition;
+        return this;
+    }
 
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj) return true;
-		if (obj == null) return false;
-		
-		if (getClass() != obj.getClass()) return false;
-		
-		Host other = (Host) obj;
-		boolean equals = true;
-		
-		equals &= (hostname != null) ? hostname.equals(other.hostname) : other.hostname == null;
-		equals &= (rack != null) ? rack.equals(other.rack) : other.rack == null;
-		equals &= port == other.port;
-		
-		return equals;
-	}
+    public boolean isUp() {
+        return status == Status.Up;
+    }
+
+    public InetSocketAddress getSocketAddress() {
+        return socketAddress;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((hostname == null) ? 0 : hostname.hashCode());
+        result = prime * result + ((rack == null) ? 0 : rack.hashCode());
+        result = prime * result + port;
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (obj == null) return false;
+
+        if (getClass() != obj.getClass()) return false;
+
+        Host other = (Host) obj;
+        boolean equals = true;
+
+        equals &= (hostname != null) ? hostname.equals(other.hostname) : other.hostname == null;
+        equals &= (rack != null) ? rack.equals(other.rack) : other.rack == null;
+        equals &= port == other.port;
+
+        return equals;
+    }
 
 
-	@Override
-	public int compareTo(Host o) {
-	    int compared = this.hostname.compareTo(o.hostname);
-	    if( compared != 0) {
-		return compared;
-	    }
-	    compared = this.rack.compareTo(o.hostname);
-	    if( compared != 0) {
-		return compared;
-	    }
-	    return Integer.compare(this.port,o.port);
-	}
-
-        public String getDatacenter() {
-    	return datacenter;
+    @Override
+    public int compareTo(Host o) {
+        int compared = this.hostname.compareTo(o.hostname);
+        if(compared != 0) {
+            return compared;
         }
-    
-     
-    
-        @Override
-        public String toString() {
-    	return "Host [hostname=" + hostname + ", ipAddress=" + ipAddress + ", port=" + port + ", rack: " + rack
-    		+ ", datacenter: " + datacenter + ", status: " + status.name() + "]";
+        compared = this.rack.compareTo(o.hostname);
+        if(compared != 0) {
+            return compared;
         }
+        return Integer.compare(this.port,o.port);
+    }
+
+    @Override
+    public String toString() {
+        return "Host [hostname=" + hostname + ", ipAddress=" + ipAddress + ", port=" + port + ", rack: " + rack
+            + ", datacenter: " + datacenter + ", status: " + status.name() + "]";
+    }
 }

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/lb/AbstractTokenMapSupplier.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/lb/AbstractTokenMapSupplier.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2016 Netflix, Inc.
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -60,7 +60,7 @@ import com.netflix.dyno.connectionpool.impl.utils.CollectionUtils.Predicate;
  * {"token":"1669478519","hostname":"ec2-54-80-65-203.compute-1.amazonaws.com"
  * ,"dc":"florida-v000","ip":"54.80.65.203", "zone":"us-east-1e",
  * "location":"us-east-1"} ]
- * 
+ *
  * @author poberai
  *
  */
@@ -75,7 +75,8 @@ public abstract class AbstractTokenMapSupplier implements TokenMapSupplier {
         this.localZone = localRack;
         localDatacenter = ConfigUtils.getDataCenter();
     }
-    public AbstractTokenMapSupplier(String localRack, int port){
+
+    public AbstractTokenMapSupplier(String localRack, int port) {
         this.localZone = localRack;
         localDatacenter = ConfigUtils.getDataCenter();
         unsuppliedPort = port;
@@ -85,6 +86,7 @@ public abstract class AbstractTokenMapSupplier implements TokenMapSupplier {
         localZone = ConfigUtils.getLocalZone();
         localDatacenter = ConfigUtils.getDataCenter();
     }
+
     public AbstractTokenMapSupplier(int port) {
         localZone = ConfigUtils.getLocalZone();
         localDatacenter = ConfigUtils.getDataCenter();
@@ -98,110 +100,111 @@ public abstract class AbstractTokenMapSupplier implements TokenMapSupplier {
     @Override
     public List<HostToken> getTokens(Set<Host> activeHosts) {
 
-	// Doing this since not all tokens are received from an individual call
-	// to a dynomite server
-	// hence trying them all
-	Set<HostToken> allTokens = new HashSet<HostToken>();
+        // Doing this since not all tokens are received from an individual call
+        // to a dynomite server
+        // hence trying them all
+        Set<HostToken> allTokens = new HashSet<HostToken>();
 
-	for (Host host : activeHosts) {
-	    try {
-		List<HostToken> hostTokens = parseTokenListFromJson(getTopologyJsonPayload((host.getHostAddress())));
-		for (HostToken hToken : hostTokens) {
-		    allTokens.add(hToken);
-		}
-	    } catch (Exception e) {
-		Logger.warn("Could not get json response for token topology [" + e.getMessage() + "]");
-	    }
-	}
-	return new ArrayList<HostToken>(allTokens);
+        for (Host host : activeHosts) {
+            try {
+                List<HostToken> hostTokens = parseTokenListFromJson(getTopologyJsonPayload((host.getHostAddress())));
+                for (HostToken hToken : hostTokens) {
+                    allTokens.add(hToken);
+                }
+            } catch (Exception e) {
+                Logger.warn("Could not get json response for token topology [" + e.getMessage() + "]");
+            }
+        }
+        return new ArrayList<HostToken>(allTokens);
     }
 
     @Override
     public HostToken getTokenForHost(final Host host, final Set<Host> activeHosts) {
-	String jsonPayload;
-	if (activeHosts.size() == 0) {
-	    jsonPayload = getTopologyJsonPayload(host.getHostAddress());
-	} else {
-	    try {
-		jsonPayload = getTopologyJsonPayload(activeHosts);
-	    } catch (TimeoutException ex) {
-		// Try using the host we just primed connections to. If that
-		// fails,
-		// let the exception bubble up to ConnectionPoolImpl which will
-		// remove
-		// the host from the host-mapping
-		jsonPayload = getTopologyJsonPayload(host.getHostAddress());
-	    }
-	}
-	List<HostToken> hostTokens = parseTokenListFromJson(jsonPayload);
+        String jsonPayload;
+        if (activeHosts.size() == 0) {
+            jsonPayload = getTopologyJsonPayload(host.getHostAddress());
+        } else {
+            try {
+                jsonPayload = getTopologyJsonPayload(activeHosts);
+            } catch (TimeoutException ex) {
+                // Try using the host we just primed connections to. If that
+                // fails,
+                // let the exception bubble up to ConnectionPoolImpl which will
+                // remove
+                // the host from the host-mapping
+                jsonPayload = getTopologyJsonPayload(host.getHostAddress());
+            }
+        }
+        List<HostToken> hostTokens = parseTokenListFromJson(jsonPayload);
 
-	return CollectionUtils.find(hostTokens, new Predicate<HostToken>() {
+        return CollectionUtils.find(hostTokens, new Predicate<HostToken>() {
 
-	    @Override
-	    public boolean apply(HostToken x) {
-		return x.getHost().getHostAddress().equals(host.getHostName());
-	    }
-	});
+            @Override
+            public boolean apply(HostToken x) {
+                return x.getHost().getHostAddress().equals(host.getHostName());
+            }
+        });
     }
 
     private boolean isLocalZoneHost(Host host) {
-	if (localZone == null || localZone.isEmpty()) {
-	    Logger.warn("Local rack was not defined");
-	    return true; // consider everything
-	}
-	return localZone.equalsIgnoreCase(host.getRack());
+        if (localZone == null || localZone.isEmpty()) {
+            Logger.warn("Local rack was not defined");
+            return true; // consider everything
+        }
+        return localZone.equalsIgnoreCase(host.getRack());
     }
 
     private boolean isLocalDatacenterHost(Host host) {
 
-	if (localDatacenter == null || localDatacenter.isEmpty()) {
-	    Logger.warn("Local Datacenter was not defined");
-	    return true;
-	}
+        if (localDatacenter == null || localDatacenter.isEmpty()) {
+            Logger.warn("Local Datacenter was not defined");
+            return true;
+        }
 
-	return localDatacenter.equalsIgnoreCase(host.getDatacenter());
+        return localDatacenter.equalsIgnoreCase(host.getDatacenter());
     }
 
     // package-private for Test
     List<HostToken> parseTokenListFromJson(String json) {
 
-	List<HostToken> hostTokens = new ArrayList<HostToken>();
+        List<HostToken> hostTokens = new ArrayList<HostToken>();
 
-	JSONParser parser = new JSONParser();
-	try {
-	    JSONArray arr = (JSONArray) parser.parse(json);
+        JSONParser parser = new JSONParser();
+        try {
+            JSONArray arr = (JSONArray) parser.parse(json);
 
-	    Iterator<?> iter = arr.iterator();
-	    while (iter.hasNext()) {
+            Iterator<?> iter = arr.iterator();
+            while (iter.hasNext()) {
 
-		Object item = iter.next();
-		if (!(item instanceof JSONObject)) {
-		    continue;
-		}
-		JSONObject jItem = (JSONObject) item;
-
-		Long token = Long.parseLong((String) jItem.get("token"));
-		String hostname = (String) jItem.get("hostname");
-		String zone = (String) jItem.get("zone");
-		String portStr = (String) jItem.get("port");
-                int port = unsuppliedPort;
-                if(portStr != null){
+                Object item = iter.next();
+                if (!(item instanceof JSONObject)) {
+                    continue;
+                }
+                JSONObject jItem = (JSONObject) item;
+                Long token = Long.parseLong((String) jItem.get("token"));
+                String hostname = (String) jItem.get("hostname");
+                String ipAddress = (String) jItem.get("ip");
+                String zone = (String) jItem.get("zone");
+                String datacenter = (String) jItem.get("dc");
+                String portStr = (String) jItem.get("port");
+                int port = Host.DEFAULT_PORT;
+                if (portStr != null) {
                     port = Integer.valueOf(portStr);
                 }
 
-		Host host = new Host(hostname, port, zone,  Status.Up);
+                Host host = new Host(hostname, ipAddress, port, zone, datacenter, Status.Up);
 
-		if (isLocalDatacenterHost(host)) {
-		    HostToken hostToken = new HostToken(token, host);
-		    hostTokens.add(hostToken);
-		}
-	    }
+                if (isLocalDatacenterHost(host)) {
+                    HostToken hostToken = new HostToken(token, host);
+                    hostTokens.add(hostToken);
+                }
+            }
 
-	} catch (ParseException e) {
-	    Logger.error("Failed to parse json response: " + json, e);
-	    throw new RuntimeException(e);
-	}
+        } catch (ParseException e) {
+            Logger.error("Failed to parse json response: " + json, e);
+            throw new RuntimeException(e);
+        }
 
-	return hostTokens;
+        return hostTokens;
     }
 }

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/lb/AbstractTokenMapSupplier.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/lb/AbstractTokenMapSupplier.java
@@ -37,29 +37,60 @@ import com.netflix.dyno.connectionpool.impl.utils.CollectionUtils;
 import com.netflix.dyno.connectionpool.impl.utils.CollectionUtils.Predicate;
 
 /**
- * An Example of the JSON payload that we get from a dynomite server [
- * {"token":"3051939411","hostname":"ec2-54-237-143-4.compute-1.amazonaws.com"
- * ,"dc":"florida","ip":"54.237.143.4", "zone":"us-east-1d",
- * "location":"us-east-1"}, {"token":"188627880","
- * hostname":"ec2-50-17-65-2.compute-1.amazonaws.com"
- * ,"dc":"florida","ip":"50.17.65.2", "zone":"us-east-1d",
- * "location":"us-east-1"},
- * {"token":"2019187467","hostname":"ec2-54-83-87-174.compute-1.amazonaws.com"
- * ,"dc":"florida-v001","ip":"54.83.87.174", "zone":"us-east-1c",
- * "location":"us-east-1"},
- * {"token":"3450843231","hostname":"ec2-54-81-138-73.compute-1.amazonaws.com"
- * ,"dc":"florida-v001","ip":"54.81.138.73", "zone":"us-east-1c",
- * "location":"us-east-1"}, {"token":"587531700","
- * hostname":"ec2-54-82-176-215.compute-1.amazonaws.com","dc":"florida-v001","ip":"54.82.176.215","zone":"us-east-1c",
- * "location":"us-east-1"},
- * {"token":"3101134286","hostname":"ec2-54-82-83-115.compute-1.amazonaws.com"
- * ,"dc":"florida-v000","ip":"54.82.83.115", "zone":"us-east-1e",
- * "location":"us-east-1"}, {"token":"237822755","
- * hostname":"ec2-54-211-220-55.compute-1.amazonaws.com","dc":"florida-v000","ip":"54.211.220.55","zone":"us-east-1e",
- * "location":"us-east-1"},
- * {"token":"1669478519","hostname":"ec2-54-80-65-203.compute-1.amazonaws.com"
- * ,"dc":"florida-v000","ip":"54.80.65.203", "zone":"us-east-1e",
- * "location":"us-east-1"} ]
+ * An Example of the JSON payload that we get from dynomite-manager (this will eventually be changed so that the call
+ * is made directly to Dynomite)
+ * <pre>
+ * [
+ *  {
+ *      "dc": "eu-west-1",
+ *      "hostname": "ec2-52-208-92-24.eu-west-1.compute.amazonaws.com",
+ *      "ip": "52.208.92.24",
+ *      "rack": "dyno_sandbox--euwest1c",
+ *      "token": "1383429731",
+ *      "zone": "eu-west-1c"
+ *  },
+ *  {
+ *      "dc": "us-east-1",
+ *      "hostname": "ec2-52-90-147-135.compute-1.amazonaws.com",
+ *      "ip": "52.90.147.135",
+ *      "rack": "dyno_sandbox--useast1c",
+ *      "token": "1383429731",
+ *      "zone": "us-east-1c"
+ *  },
+ *  {
+ *      "dc": "us-east-1",
+ *      "hostname": "ec2-52-23-207-227.compute-1.amazonaws.com",
+ *      "ip": "52.23.207.227",
+ *      "rack": "dyno_sandbox--useast1e",
+ *      "token": "1383429731",
+ *      "zone": "us-east-1e"
+ *  },
+ *  {
+ *      "dc": "eu-west-1",
+ *      "hostname": "ec2-52-209-165-110.eu-west-1.compute.amazonaws.com",
+ *      "ip": "52.209.165.110",
+ *      "rack": "dyno_sandbox--euwest1a",
+ *      "token": "1383429731",
+ *      "zone": "eu-west-1a"
+ *  },
+ *  {
+ *      "dc": "eu-west-1",
+ *      "hostname": "ec2-52-16-89-77.eu-west-1.compute.amazonaws.com",
+ *      "ip": "52.16.89.77",
+ *      "rack": "dyno_sandbox--euwest1b",
+ *      "token": "1383429731",
+ *      "zone": "eu-west-1b"
+ *  },
+ *  {
+ *      "dc": "us-east-1",
+ *      "hostname": "ec2-54-208-235-30.compute-1.amazonaws.com",
+ *      "ip": "54.208.235.30",
+ *      "rack": "dyno_sandbox--useast1d",
+ *      "token": "1383429731",
+ *      "zone": "us-east-1d"
+ *  }
+ *]
+ * </pre>
  *
  * @author poberai
  *
@@ -115,7 +146,7 @@ public abstract class AbstractTokenMapSupplier implements TokenMapSupplier {
                 Logger.warn("Could not get json response for token topology [" + e.getMessage() + "]");
             }
         }
-        return new ArrayList<HostToken>(allTokens);
+        return new ArrayList<>(allTokens);
     }
 
     @Override

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/utils/ConfigUtils.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/utils/ConfigUtils.java
@@ -48,7 +48,7 @@ public class ConfigUtils {
 	}
 
 	if (dc == null) {
-	    return getDataCenter(getLocalZone());
+	    return getDataCenterFromRack(getLocalZone());
 	} else {
 	    return dc;
 	}
@@ -61,7 +61,7 @@ public class ConfigUtils {
      * @param rack
      * @return the datacenter based on the provided rack
      */
-    public static String getDataCenter(String rack) {
+    public static String getDataCenterFromRack(String rack) {
 	if (rack != null) {
 	    return rack.substring(0, rack.length() - 1);
 	}

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/lb/AbstractTokenMapSupplierTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/lb/AbstractTokenMapSupplierTest.java
@@ -53,16 +53,16 @@ public class AbstractTokenMapSupplierTest {
 
 		List<Host> hostList = new ArrayList<>();
 
-		hostList.add(new Host("ec2-54-237-143-4.compute-1.amazonaws.com", 11211,"us-east-1d",  Status.Up));
-		hostList.add(new Host("ec2-50-17-65-2.compute-1.amazonaws.com", 11211, "us-east-1d" , Status.Up));
-		hostList.add(new Host("ec2-54-83-87-174.compute-1.amazonaws.com", 11211, "us-east-1c", Status.Up));
-		hostList.add(new Host("ec2-54-81-138-73.compute-1.amazonaws.com", 11211, "us-east-1c", Status.Up));
-		hostList.add(new Host("ec2-54-82-176-215.compute-1.amazonaws.com", 11211, "us-east-1c", Status.Up));
-		hostList.add(new Host("ec2-54-82-83-115.compute-1.amazonaws.com", 11211, "us-east-1e", Status.Up));
-		hostList.add(new Host("ec2-54-211-220-55.compute-1.amazonaws.com", 11211, "us-east-1e", Status.Up));
-		hostList.add(new Host("ec2-54-80-65-203.compute-1.amazonaws.com", 11211, "us-east-1c", Status.Up));
+		hostList.add(new Host("ec2-54-237-143-4.compute-1.amazonaws.com", "rack",  Status.Up));
+		hostList.add(new Host("ec2-50-17-65-2.compute-1.amazonaws.com", "rack" , Status.Up));
+		hostList.add(new Host("ec2-54-83-87-174.compute-1.amazonaws.com", "rack", Status.Up));
+		hostList.add(new Host("ec2-54-81-138-73.compute-1.amazonaws.com", "rack", Status.Up));
+		hostList.add(new Host("ec2-54-82-176-215.compute-1.amazonaws.com", "rack", Status.Up));
+		hostList.add(new Host("ec2-54-82-83-115.compute-1.amazonaws.com", "rack", Status.Up));
+		hostList.add(new Host("ec2-54-211-220-55.compute-1.amazonaws.com", "rack", Status.Up));
+		hostList.add(new Host("ec2-54-80-65-203.compute-1.amazonaws.com", "rack", Status.Up));
 
-		List<HostToken> hTokens = testTokenMapSupplier.getTokens(new HashSet<Host>(hostList));
+		List<HostToken> hTokens = testTokenMapSupplier.getTokens(new HashSet<>(hostList));
 		Collections.sort(hTokens, new Comparator<HostToken>() {
 			@Override
 			public int compare(HostToken o1, HostToken o2) {

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/lb/AbstractTokenMapSupplierTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/lb/AbstractTokenMapSupplierTest.java
@@ -26,14 +26,14 @@ import com.netflix.dyno.connectionpool.Host.Status;
 
 public class AbstractTokenMapSupplierTest {
 
-	final String json = "[{\"token\":\"3051939411\",\"hostname\":\"ec2-54-237-143-4.compute-1.amazonaws.com\",\"port\":\"11211\",\"dc\":\"florida\",\"ip\":\"54.237.143.4\",\"zone\":\"us-east-1d\",\"location\":\"us-east-1\"}\"," +
-			"\"{\"token\":\"188627880\",\"hostname\":\"ec2-50-17-65-2.compute-1.amazonaws.com\",\"port\":\"11211\",\"dc\":\"florida\",\"ip\":\"50.17.65.2\",\"zone\":\"us-east-1d\",\"location\":\"us-east-1\"},\"" +
-			"\"{\"token\":\"2019187467\",\"hostname\":\"ec2-54-83-87-174.compute-1.amazonaws.com\",\"port\":\"11211\",\"dc\":\"florida-v001\",\"ip\":\"54.83.87.174\",\"zone\":\"us-east-1c\",\"location\":\"us-east-1\"},\"" +
-			"\"{\"token\":\"3450843231\",\"hostname\":\"ec2-54-81-138-73.compute-1.amazonaws.com\",\"port\":\"11211\",\"dc\":\"florida-v001\",\"ip\":\"54.81.138.73\",\"zone\":\"us-east-1c\",\"location\":\"us-east-1\"},\""+
-			"\"{\"token\":\"587531700\",\"hostname\":\"ec2-54-82-176-215.compute-1.amazonaws.com\",\"port\":\"11211\",\"dc\":\"florida-v001\",\"ip\":\"54.82.176.215\",\"zone\":\"us-east-1c\",\"location\":\"us-east-1\"},\"" +
-			"\"{\"token\":\"3101134286\",\"hostname\":\"ec2-54-82-83-115.compute-1.amazonaws.com\",\"port\":\"11211\",\"dc\":\"florida-v000\",\"ip\":\"54.82.83.115\",\"zone\":\"us-east-1e\",\"location\":\"us-east-1\"},\"" +
-			"\"{\"token\":\"237822755\",\"hostname\":\"ec2-54-211-220-55.compute-1.amazonaws.com\",\"port\":\"11211\",\"dc\":\"florida-v000\",\"ip\":\"54.211.220.55\",\"zone\":\"us-east-1e\",\"location\":\"us-east-1\"},\"" +
-			"\"{\"token\":\"1669478519\",\"hostname\":\"ec2-54-80-65-203.compute-1.amazonaws.com\",\"port\":\"11211\",\"dc\":\"florida-v000\",\"ip\":\"54.80.65.203\",\"zone\":\"us-east-1e\",\"location\":\"us-east-1\"}]\"";
+	final String json = "[{\"token\":\"3051939411\",\"hostname\":\"ec2-54-237-143-4.compute-1.amazonaws.com\",\"port\":\"11211\",\"dc\":\"us-east-1\",\"ip\":\"54.237.143.4\",\"zone\":\"us-east-1d\"}\"," +
+			"\"{\"token\":\"188627880\",\"hostname\":\"ec2-50-17-65-2.compute-1.amazonaws.com\",\"port\":\"11211\",\"dc\":\"us-east-1\",\"ip\":\"50.17.65.2\",\"zone\":\"us-east-1d\"},\"" +
+			"\"{\"token\":\"2019187467\",\"hostname\":\"ec2-54-83-87-174.compute-1.amazonaws.com\",\"port\":\"11211\",\"dc\":\"us-east-1\",\"ip\":\"54.83.87.174\",\"zone\":\"us-east-1c\" },\"" +
+			"\"{\"token\":\"3450843231\",\"hostname\":\"ec2-54-81-138-73.compute-1.amazonaws.com\",\"port\":\"11211\",\"dc\":\"us-east-1\",\"ip\":\"54.81.138.73\",\"zone\":\"us-east-1c\"},\""+
+			"\"{\"token\":\"587531700\",\"hostname\":\"ec2-54-82-176-215.compute-1.amazonaws.com\",\"port\":\"11211\",\"dc\":\"us-east-1\",\"ip\":\"54.82.176.215\",\"zone\":\"us-east-1c\"},\"" +
+			"\"{\"token\":\"3101134286\",\"hostname\":\"ec2-54-82-83-115.compute-1.amazonaws.com\",\"port\":\"11211\",\"dc\":\"us-east-1\",\"ip\":\"54.82.83.115\",\"zone\":\"us-east-1e\"},\"" +
+			"\"{\"token\":\"237822755\",\"hostname\":\"ec2-54-211-220-55.compute-1.amazonaws.com\",\"port\":\"11211\",\"dc\":\"us-east-1\",\"ip\":\"54.211.220.55\",\"zone\":\"us-east-1e\"},\"" +
+			"\"{\"token\":\"1669478519\",\"hostname\":\"ec2-54-80-65-203.compute-1.amazonaws.com\",\"port\":\"11211\",\"dc\":\"us-east-1\",\"ip\":\"54.80.65.203\",\"zone\":\"us-east-1e\"}]\"";
 
 	private TokenMapSupplier testTokenMapSupplier = new AbstractTokenMapSupplier() {
 
@@ -51,7 +51,7 @@ public class AbstractTokenMapSupplierTest {
 	@Test
 	public void testParseJson() throws Exception {
 
-		List<Host> hostList = new ArrayList<Host>();
+		List<Host> hostList = new ArrayList<>();
 
 		hostList.add(new Host("ec2-54-237-143-4.compute-1.amazonaws.com", 11211,"us-east-1d",  Status.Up));
 		hostList.add(new Host("ec2-50-17-65-2.compute-1.amazonaws.com", 11211, "us-east-1d" , Status.Up));
@@ -59,7 +59,7 @@ public class AbstractTokenMapSupplierTest {
 		hostList.add(new Host("ec2-54-81-138-73.compute-1.amazonaws.com", 11211, "us-east-1c", Status.Up));
 		hostList.add(new Host("ec2-54-82-176-215.compute-1.amazonaws.com", 11211, "us-east-1c", Status.Up));
 		hostList.add(new Host("ec2-54-82-83-115.compute-1.amazonaws.com", 11211, "us-east-1e", Status.Up));
-		hostList.add(new Host("ec2-54-211-220-55.compute-1.amazonaws.com", 11211, "us-east-1c", Status.Up));
+		hostList.add(new Host("ec2-54-211-220-55.compute-1.amazonaws.com", 11211, "us-east-1e", Status.Up));
 		hostList.add(new Host("ec2-54-80-65-203.compute-1.amazonaws.com", 11211, "us-east-1c", Status.Up));
 
 		List<HostToken> hTokens = testTokenMapSupplier.getTokens(new HashSet<Host>(hostList));
@@ -70,21 +70,22 @@ public class AbstractTokenMapSupplierTest {
 			}
 		});
 
-		Assert.assertTrue(hTokens.get(0).getToken().equals(188627880L));
-		Assert.assertTrue(hTokens.get(0).getHost().getHostAddress().equals("ec2-50-17-65-2.compute-1.amazonaws.com"));
-		Assert.assertTrue(hTokens.get(1).getToken().equals(237822755L));
-		Assert.assertTrue(hTokens.get(1).getHost().getHostAddress().equals("ec2-54-211-220-55.compute-1.amazonaws.com"));
-		Assert.assertTrue(hTokens.get(2).getToken().equals(587531700L));
-		Assert.assertTrue(hTokens.get(2).getHost().getHostAddress().equals("ec2-54-82-176-215.compute-1.amazonaws.com"));
-		Assert.assertTrue(hTokens.get(3).getToken().equals(1669478519L));
-		Assert.assertTrue(hTokens.get(3).getHost().getHostAddress().equals("ec2-54-80-65-203.compute-1.amazonaws.com"));
-		Assert.assertTrue(hTokens.get(4).getToken().equals(2019187467L));
-		Assert.assertTrue(hTokens.get(4).getHost().getHostAddress().equals("ec2-54-83-87-174.compute-1.amazonaws.com"));
-		Assert.assertTrue(hTokens.get(5).getToken().equals(3051939411L));
-		Assert.assertTrue(hTokens.get(5).getHost().getHostAddress().equals("ec2-54-237-143-4.compute-1.amazonaws.com"));
-		Assert.assertTrue(hTokens.get(6).getToken().equals(3101134286L));
-		Assert.assertTrue(hTokens.get(6).getHost().getHostAddress().equals("ec2-54-82-83-115.compute-1.amazonaws.com"));
-		Assert.assertTrue(hTokens.get(7).getToken().equals(3450843231L));
-		Assert.assertTrue(hTokens.get(7).getHost().getHostAddress().equals("ec2-54-81-138-73.compute-1.amazonaws.com"));
-	}
+        Assert.assertTrue(validateHostToken(hTokens.get(0), 188627880L, "ec2-50-17-65-2.compute-1.amazonaws.com", "50.17.65.2", 11211, "us-east-1d", "us-east-1"));
+        Assert.assertTrue(validateHostToken(hTokens.get(1), 237822755L, "ec2-54-211-220-55.compute-1.amazonaws.com", "54.211.220.55", 11211, "us-east-1e", "us-east-1"));
+        Assert.assertTrue(validateHostToken(hTokens.get(2), 587531700L, "ec2-54-82-176-215.compute-1.amazonaws.com", "54.82.176.215", 11211, "us-east-1c", "us-east-1"));
+        Assert.assertTrue(validateHostToken(hTokens.get(3), 1669478519L, "ec2-54-80-65-203.compute-1.amazonaws.com", "54.80.65.203", 11211, "us-east-1e", "us-east-1"));
+        Assert.assertTrue(validateHostToken(hTokens.get(4), 2019187467L, "ec2-54-83-87-174.compute-1.amazonaws.com", "54.83.87.174", 11211, "us-east-1c", "us-east-1"));
+        Assert.assertTrue(validateHostToken(hTokens.get(5), 3051939411L, "ec2-54-237-143-4.compute-1.amazonaws.com", "54.237.143.4", 11211, "us-east-1d", "us-east-1"));
+        Assert.assertTrue(validateHostToken(hTokens.get(6), 3101134286L, "ec2-54-82-83-115.compute-1.amazonaws.com", "54.82.83.115", 11211, "us-east-1e", "us-east-1"));
+        Assert.assertTrue(validateHostToken(hTokens.get(7), 3450843231L, "ec2-54-81-138-73.compute-1.amazonaws.com", "54.81.138.73", 11211, "us-east-1c", "us-east-1"));
+    }
+
+    private boolean validateHostToken(HostToken hostToken, Long token, String hostname, String ipAddress, int port, String rack, String datacenter) {
+        return Objects.equals(hostToken.getToken(), token) &&
+                hostToken.getHost().getHostName().equals(hostname) &&
+                hostToken.getHost().getHostAddress().equals(ipAddress) &&
+                hostToken.getHost().getPort() == port &&
+                hostToken.getHost().getRack().equals(rack) &&
+                hostToken.getHost().getDatacenter().equals(datacenter);
+    }
 }

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/lb/TokenMapSupplierTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/lb/TokenMapSupplierTest.java
@@ -31,14 +31,14 @@ public class TokenMapSupplierTest {
 	public void testParseJson() throws Exception {
 
 
-		String json = "[{\"token\":\"3051939411\",\"hostname\":\"ec2-54-237-143-4.compute-1.amazonaws.com\",\"dc\":\"florida\",\"ip\":\"54.237.143.4\",\"zone\":\"us-east-1d\",\"location\":\"us-east-1\"}\"," +
-				"\"{\"token\":\"188627880\",\"hostname\":\"ec2-50-17-65-2.compute-1.amazonaws.com\",\"dc\":\"florida\",\"ip\":\"50.17.65.2\",\"zone\":\"us-east-1d\",\"location\":\"us-east-1\"},\"" +
-				"\"{\"token\":\"2019187467\",\"hostname\":\"ec2-54-83-87-174.compute-1.amazonaws.com\",\"dc\":\"florida-v001\",\"ip\":\"54.83.87.174\",\"zone\":\"us-east-1c\",\"location\":\"us-east-1\"},\"" +
-				"\"{\"token\":\"3450843231\",\"hostname\":\"ec2-54-81-138-73.compute-1.amazonaws.com\",\"dc\":\"florida-v001\",\"ip\":\"54.81.138.73\",\"zone\":\"us-east-1c\",\"location\":\"us-east-1\"},\""+
-				"\"{\"token\":\"587531700\",\"hostname\":\"ec2-54-82-176-215.compute-1.amazonaws.com\",\"dc\":\"florida-v001\",\"ip\":\"54.82.176.215\",\"zone\":\"us-east-1c\",\"location\":\"us-east-1\"},\"" +
-				"\"{\"token\":\"3101134286\",\"hostname\":\"ec2-54-82-83-115.compute-1.amazonaws.com\",\"dc\":\"florida-v000\",\"ip\":\"54.82.83.115\",\"zone\":\"us-east-1e\",\"location\":\"us-east-1\"},\"" +
-				"\"{\"token\":\"237822755\",\"hostname\":\"ec2-54-211-220-55.compute-1.amazonaws.com\",\"dc\":\"florida-v000\",\"ip\":\"54.211.220.55\",\"zone\":\"us-east-1e\",\"location\":\"us-east-1\"},\"" +
-				"\"{\"token\":\"1669478519\",\"hostname\":\"ec2-54-80-65-203.compute-1.amazonaws.com\",\"dc\":\"florida-v000\",\"ip\":\"54.80.65.203\",\"zone\":\"us-east-1e\",\"location\":\"us-east-1\"}]\"";
+		String json = "[{\"token\":\"3051939411\",\"hostname\":\"ec2-54-237-143-4.compute-1.amazonaws.com\",\"dc\":\"us-east-1\",\"ip\":\"54.237.143.4\",\"zone\":\"us-east-1d\",\"location\":\"us-east-1\"}\"," +
+				"\"{\"token\":\"188627880\",\"hostname\":\"ec2-50-17-65-2.compute-1.amazonaws.com\",\"dc\":\"us-east-1\",\"ip\":\"50.17.65.2\",\"zone\":\"us-east-1d\",\"location\":\"us-east-1\"},\"" +
+				"\"{\"token\":\"2019187467\",\"hostname\":\"ec2-54-83-87-174.compute-1.amazonaws.com\",\"dc\":\"us-east-1\",\"ip\":\"54.83.87.174\",\"zone\":\"us-east-1c\",\"location\":\"us-east-1\"},\"" +
+				"\"{\"token\":\"3450843231\",\"hostname\":\"ec2-54-81-138-73.compute-1.amazonaws.com\",\"dc\":\"us-east-1\",\"ip\":\"54.81.138.73\",\"zone\":\"us-east-1c\",\"location\":\"us-east-1\"},\""+
+				"\"{\"token\":\"587531700\",\"hostname\":\"ec2-54-82-176-215.compute-1.amazonaws.com\",\"dc\":\"us-east-1\",\"ip\":\"54.82.176.215\",\"zone\":\"us-east-1c\",\"location\":\"us-east-1\"},\"" +
+				"\"{\"token\":\"3101134286\",\"hostname\":\"ec2-54-82-83-115.compute-1.amazonaws.com\",\"dc\":\"us-east-1\",\"ip\":\"54.82.83.115\",\"zone\":\"us-east-1e\",\"location\":\"us-east-1\"},\"" +
+				"\"{\"token\":\"237822755\",\"hostname\":\"ec2-54-211-220-55.compute-1.amazonaws.com\",\"dc\":\"us-east-1\",\"ip\":\"54.211.220.55\",\"zone\":\"us-east-1e\",\"location\":\"us-east-1\"},\"" +
+				"\"{\"token\":\"1669478519\",\"hostname\":\"ec2-54-80-65-203.compute-1.amazonaws.com\",\"dc\":\"us-east-1\",\"ip\":\"54.80.65.203\",\"zone\":\"us-east-1e\",\"location\":\"us-east-1\"}]\"";
 
 		List<Host> hostList = new ArrayList<Host>();
 
@@ -56,21 +56,21 @@ public class TokenMapSupplierTest {
 		List<HostToken> hTokens = tokenSupplier.parseTokenListFromJson(json);
 
 		Assert.assertTrue(hTokens.get(0).getToken().equals(3051939411L));
-		Assert.assertTrue(hTokens.get(0).getHost().getHostAddress().equals("ec2-54-237-143-4.compute-1.amazonaws.com"));
+		Assert.assertTrue(hTokens.get(0).getHost().getHostName().equals("ec2-54-237-143-4.compute-1.amazonaws.com"));
 		Assert.assertTrue(hTokens.get(1).getToken().equals(188627880L));
-		Assert.assertTrue(hTokens.get(1).getHost().getHostAddress().equals("ec2-50-17-65-2.compute-1.amazonaws.com"));
+		Assert.assertTrue(hTokens.get(1).getHost().getHostName().equals("ec2-50-17-65-2.compute-1.amazonaws.com"));
 		Assert.assertTrue(hTokens.get(2).getToken().equals(2019187467L));
-		Assert.assertTrue(hTokens.get(2).getHost().getHostAddress().equals("ec2-54-83-87-174.compute-1.amazonaws.com"));
+		Assert.assertTrue(hTokens.get(2).getHost().getHostName().equals("ec2-54-83-87-174.compute-1.amazonaws.com"));
 		Assert.assertTrue(hTokens.get(3).getToken().equals(3450843231L));
-		Assert.assertTrue(hTokens.get(3).getHost().getHostAddress().equals("ec2-54-81-138-73.compute-1.amazonaws.com"));
+		Assert.assertTrue(hTokens.get(3).getHost().getHostName().equals("ec2-54-81-138-73.compute-1.amazonaws.com"));
 		Assert.assertTrue(hTokens.get(4).getToken().equals(587531700L));
-		Assert.assertTrue(hTokens.get(4).getHost().getHostAddress().equals("ec2-54-82-176-215.compute-1.amazonaws.com"));
+		Assert.assertTrue(hTokens.get(4).getHost().getHostName().equals("ec2-54-82-176-215.compute-1.amazonaws.com"));
 		Assert.assertTrue(hTokens.get(5).getToken().equals(3101134286L));
-		Assert.assertTrue(hTokens.get(5).getHost().getHostAddress().equals("ec2-54-82-83-115.compute-1.amazonaws.com"));
+		Assert.assertTrue(hTokens.get(5).getHost().getHostName().equals("ec2-54-82-83-115.compute-1.amazonaws.com"));
 		Assert.assertTrue(hTokens.get(6).getToken().equals(237822755L));
-		Assert.assertTrue(hTokens.get(6).getHost().getHostAddress().equals("ec2-54-211-220-55.compute-1.amazonaws.com"));
+		Assert.assertTrue(hTokens.get(6).getHost().getHostName().equals("ec2-54-211-220-55.compute-1.amazonaws.com"));
 		Assert.assertTrue(hTokens.get(7).getToken().equals(1669478519L));
-		Assert.assertTrue(hTokens.get(7).getHost().getHostAddress().equals("ec2-54-80-65-203.compute-1.amazonaws.com"));
+		Assert.assertTrue(hTokens.get(7).getHost().getHostName().equals("ec2-54-80-65-203.compute-1.amazonaws.com"));
 	}
 	@Test
 	public void testParseJsonWithPorts() throws Exception {
@@ -101,35 +101,35 @@ public class TokenMapSupplierTest {
 		List<HostToken> hTokens = tokenSupplier.parseTokenListFromJson(json);
 
 		Assert.assertTrue(hTokens.get(0).getToken().equals(3051939411L));
-		Assert.assertTrue(hTokens.get(0).getHost().getHostAddress().equals("ec2-54-237-143-4.compute-1.amazonaws.com"));
+		Assert.assertTrue(hTokens.get(0).getHost().getHostName().equals("ec2-54-237-143-4.compute-1.amazonaws.com"));
 		Assert.assertEquals(hTokens.get(0).getHost().getPort(), 11211);
 		
 		Assert.assertTrue(hTokens.get(1).getToken().equals(188627880L));
-		Assert.assertTrue(hTokens.get(1).getHost().getHostAddress().equals("ec2-54-237-143-4.compute-1.amazonaws.com"));
+		Assert.assertTrue(hTokens.get(1).getHost().getHostName().equals("ec2-54-237-143-4.compute-1.amazonaws.com"));
 		Assert.assertEquals(hTokens.get(1).getHost().getPort(), 11212);
 		
 		Assert.assertTrue(hTokens.get(2).getToken().equals(2019187467L));
-		Assert.assertTrue(hTokens.get(2).getHost().getHostAddress().equals("ec2-54-237-143-4.compute-1.amazonaws.com"));
+		Assert.assertTrue(hTokens.get(2).getHost().getHostName().equals("ec2-54-237-143-4.compute-1.amazonaws.com"));
 		Assert.assertEquals(hTokens.get(2).getHost().getPort(), 11213);
 		
 		Assert.assertTrue(hTokens.get(3).getToken().equals(3450843231L));
-		Assert.assertTrue(hTokens.get(3).getHost().getHostAddress().equals("ec2-54-237-143-4.compute-1.amazonaws.com"));
+		Assert.assertTrue(hTokens.get(3).getHost().getHostName().equals("ec2-54-237-143-4.compute-1.amazonaws.com"));
 		Assert.assertEquals(hTokens.get(3).getHost().getPort(), 11214);
 		
 		Assert.assertTrue(hTokens.get(4).getToken().equals(587531700L));
-		Assert.assertTrue(hTokens.get(4).getHost().getHostAddress().equals("ec2-54-82-176-215.compute-1.amazonaws.com"));
+		Assert.assertTrue(hTokens.get(4).getHost().getHostName().equals("ec2-54-82-176-215.compute-1.amazonaws.com"));
 		Assert.assertEquals(hTokens.get(4).getHost().getPort(), 11215);
 		
 		Assert.assertTrue(hTokens.get(5).getToken().equals(3101134286L));
-		Assert.assertTrue(hTokens.get(5).getHost().getHostAddress().equals("ec2-54-82-83-115.compute-1.amazonaws.com"));
+		Assert.assertTrue(hTokens.get(5).getHost().getHostName().equals("ec2-54-82-83-115.compute-1.amazonaws.com"));
 		Assert.assertEquals(hTokens.get(5).getHost().getPort(), 11216);
 		
 		Assert.assertTrue(hTokens.get(6).getToken().equals(237822755L));
-		Assert.assertTrue(hTokens.get(6).getHost().getHostAddress().equals("ec2-54-211-220-55.compute-1.amazonaws.com"));
+		Assert.assertTrue(hTokens.get(6).getHost().getHostName().equals("ec2-54-211-220-55.compute-1.amazonaws.com"));
 		Assert.assertEquals(hTokens.get(6).getHost().getPort(), 11217);
 		
 		Assert.assertTrue(hTokens.get(7).getToken().equals(1669478519L));
-		Assert.assertTrue(hTokens.get(7).getHost().getHostAddress().equals("ec2-54-80-65-203.compute-1.amazonaws.com"));
+		Assert.assertTrue(hTokens.get(7).getHost().getHostName().equals("ec2-54-80-65-203.compute-1.amazonaws.com"));
 		Assert.assertEquals(hTokens.get(7).getHost().getPort(), 11218);
 	}
 }


### PR DESCRIPTION
The `equals()` and `hashcode()` contract changed to include all fields of the object which broke the token aware load balancer initialization. Unfortunately the breakage is very subtle; no errors are reported however the resulting topology is completely broken.

I did not revert the breaking change; this set of changes fixes the code that deserializes the json topology into proper Host objects w/all fields assigned. 

I updated the unit test to validate all fields when deserializing Host objects. The reason this wasn't caught in a unit test before is b/c although the test was updated it did not take into account all fields, only fields required by the previous equality contract.
