### PR TITLE
Fix dynomite upgrade

### DIFF
--- a/dyno-contrib/src/main/java/com/netflix/dyno/contrib/EurekaHostsSupplier.java
+++ b/dyno-contrib/src/main/java/com/netflix/dyno/contrib/EurekaHostsSupplier.java
@@ -113,7 +113,7 @@ public class EurekaHostsSupplier implements HostSupplier {
 					}
 				}));
 		
-		Logger.info("Dyno found hosts from eureka - num hosts: " + hosts.size());
+		Logger.info("Dyno found hosts from eureka - num hosts: " + hosts.size() + hosts.toString());
 		
 		return hosts;
 	}

--- a/dyno-contrib/src/main/java/com/netflix/dyno/contrib/EurekaHostsSupplier.java
+++ b/dyno-contrib/src/main/java/com/netflix/dyno/contrib/EurekaHostsSupplier.java
@@ -113,7 +113,7 @@ public class EurekaHostsSupplier implements HostSupplier {
 					}
 				}));
 		
-		Logger.info("Dyno found hosts from eureka - num hosts: " + hosts.size() + hosts.toString());
+		Logger.info("Dyno found hosts from eureka - num hosts: " + hosts.size());
 		
 		return hosts;
 	}

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/Host.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/Host.java
@@ -166,7 +166,7 @@ public class Host implements Comparable<Host> {
         if (compared != 0) {
             return compared;
         }
-        compared = this.rack.compareTo(o.hostname);
+        compared = this.rack.compareTo(o.rack);
         if (compared != 0) {
             return compared;
         }

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/lb/AbstractTokenMapSupplier.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/lb/AbstractTokenMapSupplier.java
@@ -172,7 +172,7 @@ public abstract class AbstractTokenMapSupplier implements TokenMapSupplier {
 
             @Override
             public boolean apply(HostToken x) {
-                return x.getHost().getHostAddress().equals(host.getHostName());
+                return x.getHost().compareTo(host) == 0;
             }
         });
     }

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/lb/HttpEndpointBasedTokenMapSupplier.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/lb/HttpEndpointBasedTokenMapSupplier.java
@@ -153,7 +153,7 @@ public class HttpEndpointBasedTokenMapSupplier extends AbstractTokenMapSupplier 
      * @param activeHosts
      * @return a random host
      */
-    private String getRandomHost(Set<Host> activeHosts) {
+    private Host getRandomHost(Set<Host> activeHosts) {
 	Random random = new Random();
 
 	List<Host> hostsUp = new ArrayList<Host>(CollectionUtils.filter(activeHosts, new Predicate<Host>() {
@@ -164,7 +164,7 @@ public class HttpEndpointBasedTokenMapSupplier extends AbstractTokenMapSupplier 
 	    }
 	}));
 
-	return hostsUp.get(random.nextInt(hostsUp.size())).getHostAddress();
+	return hostsUp.get(random.nextInt(hostsUp.size()));
     }
 
     /**
@@ -179,11 +179,11 @@ public class HttpEndpointBasedTokenMapSupplier extends AbstractTokenMapSupplier 
 	int count = NUM_RETRIES_PER_NODE;
 	String nodeResponse;
 	Exception lastEx;
-	final String randomHost = getRandomHost(activeHosts);
+	final Host randomHost = getRandomHost(activeHosts);
 	do {
 	    try {
 		lastEx = null;
-		nodeResponse = getResponseViaHttp(randomHost);
+		nodeResponse = getResponseViaHttp(randomHost.getHostName());
 		if (nodeResponse != null) {
 
 		    Logger.info("Received topology from " + randomHost);


### PR DESCRIPTION
The linking between TokenMapSupplier and HostSupplier was broken, due to which client constantly connected and disconnection to a dynomite node after dynomite restarts. This should fix it by  linking the host properly.