### PR TITLE
Bugfix: scan can go into an infinite loop when used with multi-az cluster

### DIFF
--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/CursorBasedResult.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/CursorBasedResult.java
@@ -24,6 +24,8 @@ public interface CursorBasedResult<T> {
 
     List<T> getResult();
 
+    List<String> getStringResult();
+
     String getCursorForHost(String host);
 
     boolean isComplete();

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/RetryPolicy.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/RetryPolicy.java
@@ -16,8 +16,9 @@
 package com.netflix.dyno.connectionpool;
 
 /**
- * Interface for retry policies when executing {@link Operation}
- * @author poberai
+ * Interface for retry policies when executing an {@link Operation}.
+ *
+ * @author poberai, jcacciatore
  *
  */
 public interface RetryPolicy {
@@ -37,20 +38,21 @@ public interface RetryPolicy {
     void failure(Exception e);
 
     /**
-     * Ask the policy if a retry is allowed. This may internally sleep
+     * Ask the policy if a retry is allowed. Note that this will return false if {@link #success()} has been called.
      * 
      * @return boolean
      */
     boolean allowRetry();
 
     /**
-     * Ask the policy is a retry can use a remote dc 
+     * Ask the policy is a retry can use a remote zone (rack)
+     *
      * @return boolean
      */
     boolean allowCrossZoneFallback();
     
     /**
-     * Return the number of attempts since begin was called
+     * Return the number of attempts since {@link #begin()} was called
      * 
      * @return int
      */

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/lb/HostSelectionWithFallback.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/lb/HostSelectionWithFallback.java
@@ -42,6 +42,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -230,20 +231,24 @@ public class HostSelectionWithFallback<CL> {
 		final Collection<HostToken> localZoneTokens = CollectionUtils.filter(hostTokens.values(), new Predicate<HostToken>() {
 			@Override
 			public boolean apply(HostToken x) {
+				if (localRack == null) {
+					logger.warn("local rack is NULL for {}", this);
+				}
 				return localRack == null || localRack.equalsIgnoreCase(x.getHost().getRack());
 			}
 		});
 		
-		final Collection<Long> tokens = CollectionUtils.transform(localZoneTokens, new Transform<HostToken, Long>() {
-			@Override
-			public Long get(HostToken x) {
+		final Set<Long> tokens = Collections.unmodifiableSet(
+				new HashSet<>(CollectionUtils.transform(localZoneTokens, new Transform<HostToken, Long>() {
+					@Override
+					public Long get(HostToken x) {
 				return x.getToken();
 			}
-		});
+				})));
 		
 		DynoConnectException lastEx = null;
 		
-		List<Connection<CL>> connections = new ArrayList<Connection<CL>>();
+		final List<Connection<CL>> connections = new ArrayList<>();
 				
 		for (Long token : tokens) {
 			try { 
@@ -474,4 +479,22 @@ public class HostSelectionWithFallback<CL> {
     public Long getTokenForKey(String key) {
         return localSelector.getTokenForKey(key).getToken();
     }
+
+	@Override
+	public String toString() {
+		return "HostSelectionWithFallback{" +
+				"localDataCenter='" + localDataCenter + '\'' +
+				", localRack='" + localRack + '\'' +
+				", localSelector=" + localSelector +
+				", remoteDCSelectors=" + remoteDCSelectors +
+				", hostTokens=" + hostTokens +
+				", tokenSupplier=" + tokenSupplier +
+				", cpConfig=" + cpConfig +
+				", cpMonitor=" + cpMonitor +
+				", replicationFactor=" + replicationFactor +
+				", topology=" + topology +
+				", remoteDCNames=" + remoteDCNames +
+				", selectorFactory=" + selectorFactory +
+				'}';
+	}
 }

--- a/dyno-demo/src/main/java/com/netflix/dyno/demo/redis/DynoJedisDemo.java
+++ b/dyno-demo/src/main/java/com/netflix/dyno/demo/redis/DynoJedisDemo.java
@@ -216,8 +216,8 @@ public class DynoJedisDemo {
         logger.info("SCAN TEST -- begin");
 
         if (populateKeys) {
+			logger.info("Writing 500 keys to " );
             for (int i=0; i<500; i++) {
-                logger.info("Writing 500 keys to " );
                 client.set("DynoClientTest_key-"+i, "value-"+i);
             }
         }
@@ -712,7 +712,7 @@ public class DynoJedisDemo {
 	/**
 	 *
 	 * @param args Should contain:
-	 *             <ol>dynomite_cluster_name</ol>
+	 *             <ol>dynomite_cluster_name, e.g. dyno_sandbox_quorum</ol>
 	 *             <ol>
 	 *                 test number, in the set:
 	 *                 1 - simple test
@@ -772,7 +772,8 @@ public class DynoJedisDemo {
 					break;
 				}
                 case 4: {
-                    demo.runScanTest(false);
+                	final boolean writeKeys = Boolean.valueOf(props.getProperty("dyno.demo.scan.populateKeys"));
+                    demo.runScanTest(writeKeys);
                     break;
                 }
                 case 5: {

--- a/dyno-demo/src/main/java/com/netflix/dyno/demo/redis/DynoJedisDemo.java
+++ b/dyno-demo/src/main/java/com/netflix/dyno/demo/redis/DynoJedisDemo.java
@@ -18,6 +18,7 @@ package com.netflix.dyno.demo.redis;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.*;
 import java.util.concurrent.Callable;
@@ -223,10 +224,12 @@ public class DynoJedisDemo {
 
         CursorBasedResult<String> cbi = null;
         do {
-            cbi = client.dyno_scan(cbi, "DynoClientTest_key-*");
+			cbi = client.dyno_scan(cbi, 100, "DynoClientTest_key-*");
 
-            logger.info("result: " + cbi.getResult().toString());
-
+            List<String> results = cbi.getStringResult();
+            for (String res: results) {
+            	logger.info(res);
+			}
         } while (!cbi.isComplete());
 
         logger.info("SCAN TEST -- done");
@@ -562,36 +565,39 @@ public class DynoJedisDemo {
 		return ss;
 	}
 	private List<Host> getHostsFromDiscovery(final String clusterName) {
-		
-		String url = "http://discovery.cloudqa.netflix.net:7001/discovery/v2/apps/" + clusterName;
+
+		String env = System.getProperty("netflix.environment", "test");
+		String discoveryKey = String.format("dyno.demo.discovery.%s", env);
+
+		if (!System.getProperties().containsKey(discoveryKey)) {
+			throw new IllegalArgumentException("Discovery URL not found");
+		}
+
+		final String url = String.format("http://%s/%s", System.getProperty(discoveryKey), clusterName);
 		
 		HttpClient client = new DefaultHttpClient();
 		try {
 			HttpResponse response = client.execute(new HttpGet(url));
 			InputStream in = response.getEntity().getContent();
-			
-			//InputStream in = new FileInputStream(new File("/tmp/aa"));
-			
+
 			SAXParserFactory parserFactor = SAXParserFactory.newInstance();
 			
 			SAXParser parser = parserFactor.newSAXParser();
-			SAXHandler handler = new SAXHandler("instance", "public-hostname", "availability-zone", "status");
+			SAXHandler handler = new SAXHandler("instance", "public-hostname", "availability-zone", "status", "local-ipv4");
 			parser.parse(in, handler);
 			
 			List<Host> hosts = new ArrayList<Host>();
 			
 			for (Map<String, String> map : handler.getList()) {
-				
-
 				String rack = map.get("availability-zone");
 				Status status = map.get("status").equalsIgnoreCase("UP") ? Status.Up : Status.Down;
-                Host host = new Host(map.get("public-hostname"), 8102, rack, status);
+                Host host = new Host(map.get("public-hostname"), map.get("local-ipv4"), rack, status);
 				hosts.add(host);
 				System.out.println("Host: " + host);
 			}
 			
 			return hosts;
-		} catch (Exception e) {
+		} catch (Throwable e) {
 			throw new RuntimeException(e);
 		}
 	}
@@ -712,31 +718,42 @@ public class DynoJedisDemo {
 	 *                 1 - simple test
 	 *                 2 - keys test
 	 *                 3 - multi-threaded
-	 *                 4 - singe pipeline
+	 *                 4 - scan test
 	 *                 5 - pipeline
-	 *                 6 - binary single pipeline
 	 *             </ol>
 	 */
-	public static void main(String args[]) {
+	public static void main(String args[]) throws IOException {
 
 		if (args.length < 2) {
-			System.out.println("Incorrect numer of arguments.");
+			System.out.println("Incorrect number of arguments.");
 			printUsage();
 			System.exit(1);
 		}
 
 		String clusterName = args[0];
 		int testNumber = Integer.valueOf(args[1]);
-        String localDC = args.length > 2 ? args[2] : "us-east-1e";
-        String hostsFile = args.length == 4 ? args[3] : null;
 
-        DynoJedisDemo demo = new DynoJedisDemo(localDC);
+		Properties props = new Properties();
+		props.load(DynoJedisDemo.class.getResourceAsStream("/demo.properties"));
+		for (String name: props.stringPropertyNames()) {
+			System.setProperty(name, props.getProperty(name));
+		}
+
+		if (!props.containsKey("EC2_AVAILABILITY_ZONE") && !props.containsKey("dyno.dyno_demo.lbStrategy")) {
+			throw new IllegalArgumentException("MUST set local for load balancing OR set the load balancing strategy to round robin");
+		}
+
+		String rack = props.getProperty("EC2_AVAILABILITY_ZONE", "us-east-1e");
+		String hostsFile = props.getProperty("dyno.demo.hostsFile");
+		int port = Integer.valueOf(props.getProperty("dyno.demo.port", "8102"));
+
+        DynoJedisDemo demo = new DynoJedisDemo(rack);
 
         try {
 			if (hostsFile != null) {
-                demo.initWithRemoteClusterFromFile(hostsFile, 8102);
+                demo.initWithRemoteClusterFromFile(hostsFile, port);
             } else {
-                demo.initWithRemoteClusterFromEurekaUrl(clusterName, 8102);
+                demo.initWithRemoteClusterFromEurekaUrl(clusterName, port);
             }
 
 			System.out.println("Connected");
@@ -776,11 +793,15 @@ public class DynoJedisDemo {
 			
 			demo.cleanup(demo.numKeys);
 			
-		} catch (Exception e) {
+		} catch (Throwable e) {
 			e.printStackTrace();
 		} finally {
 			demo.stop();
             System.out.println("Done");
+
+			System.out.flush();
+			System.err.flush();
+			System.exit(0);
 		}
 	}
 

--- a/dyno-demo/src/main/resources/demo.properties
+++ b/dyno-demo/src/main/resources/demo.properties
@@ -1,0 +1,22 @@
+####
+## Properties to initialize the demo app
+#
+EC2_REGION=us-east-1
+EC2_AVAILABILITY_ZONE=us-east-1e
+NETFLIX_STACK=dyno_demo
+
+netflix.appinfo.name=dyno_demo
+netflix.environment=prod
+netflix.appinfo.metadata.enableRoute53=false
+netflix.discovery.registration.enabled=false
+netflix.appinfo.validateInstanceId=false
+
+dyno.demo.retryPolicy=RetryNTimes:2
+dyno.demo.port=8102
+dyno.demo.discovery.prod=discovery.cloud.netflix.net:7001/discovery/v2/apps
+dyno.demo.discovery.test=discovery.cloudqa.netflix.net:7001/discovery/v2/apps
+
+## Uncomment for hosts file usage
+#dyno.demo.hostsFile=file:///<path to your file>
+
+

--- a/dyno-demo/src/main/resources/demo.properties
+++ b/dyno-demo/src/main/resources/demo.properties
@@ -6,7 +6,7 @@ EC2_AVAILABILITY_ZONE=us-east-1e
 NETFLIX_STACK=dyno_demo
 
 netflix.appinfo.name=dyno_demo
-netflix.environment=prod
+netflix.environment=test
 netflix.appinfo.metadata.enableRoute53=false
 netflix.discovery.registration.enabled=false
 netflix.appinfo.validateInstanceId=false
@@ -15,6 +15,7 @@ dyno.demo.retryPolicy=RetryNTimes:2
 dyno.demo.port=8102
 dyno.demo.discovery.prod=discovery.cloud.netflix.net:7001/discovery/v2/apps
 dyno.demo.discovery.test=discovery.cloudqa.netflix.net:7001/discovery/v2/apps
+dyno.demo.scan.populateKeys=true
 
 ## Uncomment for hosts file usage
 #dyno.demo.hostsFile=file:///<path to your file>

--- a/dyno-jedis/src/main/java/com/netflix/dyno/jedis/CursorBasedResultImpl.java
+++ b/dyno-jedis/src/main/java/com/netflix/dyno/jedis/CursorBasedResultImpl.java
@@ -54,6 +54,15 @@ public class CursorBasedResultImpl<T> implements CursorBasedResult<T> {
     }
 
     @Override
+    public List<String> getStringResult() {
+        final List<String> aggregated = new ArrayList<>();
+        for (Map.Entry<String, ScanResult<T>> entry: result.entrySet()) {
+            aggregated.add(String.format("%s -> %s", entry.getKey(), entry.getValue().getStringCursor()));
+        }
+        return aggregated;
+    }
+
+    @Override
     public String getCursorForHost(String host) {
         ScanResult<T> sr = result.get(host);
         if (sr != null) {


### PR DESCRIPTION
The bug fix isn't with the cursor handling directly, it's with other contributing factors such as the retry policy (if `RetryNTimes` is used), not taking any action when the local rack is not picked up, not being able to set the count as a scan parameter, etc.

This PR also modifies the demo test app. I split out the properties it expects into a file and some enforcement. Also added the ability to toggle between netflix prod + test for discovering dynomite clusters.