### PR TITLE
Feature/consul support test

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,11 @@ project(':dyno-contrib') {
         compileApi "com.netflix.archaius:archaius-core:0.7.5"
         compileApi "com.netflix.servo:servo-core:0.12.16"
         compileApi 'com.netflix.eureka:eureka-client:1.6.2'
+        compileApi 'org.apache.commons:commons-lang3:3.5'
+        compileApi ('com.ecwid.consul:consul-api:1.2.1') {
+            exclude group: 'org.apache.httpcomponents'
+        }       
+        testCompile 'com.pszymczyk.consul:embedded-consul:0.3.3'
     }
 }
 

--- a/dyno-contrib/src/main/java/com/netflix/dyno/contrib/consul/ConsulHelper.java
+++ b/dyno-contrib/src/main/java/com/netflix/dyno/contrib/consul/ConsulHelper.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.dyno.contrib.consul;
+
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.lang3.StringUtils;
+
+import com.ecwid.consul.v1.health.model.HealthService;
+
+/**
+ * 
+ * Class with support for consul simple/commons operations
+ */
+public class ConsulHelper {
+
+    public static String findHost(HealthService healthService) {
+        HealthService.Service service = healthService.getService();
+        HealthService.Node node = healthService.getNode();
+
+        if (StringUtils.isNotBlank(service.getAddress())) {
+            return service.getAddress();
+        } else if (StringUtils.isNotBlank(node.getAddress())) {
+            return node.getAddress();
+        }
+        return node.getNode();
+    }
+
+    public static Map<String, String> getMetadata(HealthService healthService) {
+        return getMetadata(healthService.getService().getTags());
+    }
+
+    public static Map<String, String> getMetadata(List<String> tags) {
+        LinkedHashMap<String, String> metadata = new LinkedHashMap<>();
+        if (tags != null) {
+            for (String tag : tags) {
+                String[] parts = StringUtils.split(tag, "=");
+                switch (parts.length) {
+                case 0:
+                    break;
+                case 1:
+                    metadata.put(parts[0], parts[0]);
+                    break;
+                case 2:
+                    metadata.put(parts[0], parts[1]);
+                    break;
+                default:
+                    String[] end = Arrays.copyOfRange(parts, 1, parts.length);
+                    metadata.put(parts[0], StringUtils.join(end, "="));
+                    break;
+                }
+
+            }
+        }
+
+        return metadata;
+    }
+}

--- a/dyno-contrib/src/main/java/com/netflix/dyno/contrib/consul/ConsulHostsSupplier.java
+++ b/dyno-contrib/src/main/java/com/netflix/dyno/contrib/consul/ConsulHostsSupplier.java
@@ -1,0 +1,155 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.dyno.contrib.consul;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.ecwid.consul.v1.ConsulClient;
+import com.ecwid.consul.v1.QueryParams;
+import com.ecwid.consul.v1.Response;
+import com.ecwid.consul.v1.agent.model.Check;
+import com.ecwid.consul.v1.health.model.HealthService;
+import com.google.common.base.Function;
+import com.google.common.base.Supplier;
+import com.google.common.collect.Collections2;
+import com.google.common.collect.Lists;
+import com.netflix.discovery.DiscoveryManager;
+import com.netflix.dyno.connectionpool.Host;
+import com.netflix.dyno.connectionpool.HostSupplier;
+
+/**
+ * Simple class that implements {@link Supplier}<{@link List}<{@link Host}>>. It provides a List<{@link Host}>
+ * using the {@link DiscoveryManager} which is the consul client. 
+ * 
+ * Note that the class needs the consul application name to discover all instances for that application.
+ * 
+ * Example of register at consul
+ * 
+  curl -X PUT http://localhost:8500/v1/agent/service/register -d "{
+           \"ID\": \"dynomite-8102\",
+           \"Name\": \"dynomite\",
+           \"Tags\": [\"datacenter=dc\",\"cloud=openstack\",\"rack=dc-rack\"],
+           \"Address\": \"127.0.0.2\",
+           \"Port\": 8102,
+           \"Check\": {
+           \"Interval\": \"10s\",
+           \"HTTP\": \"http://127.0.0.1:22222/ping\"
+          }}"
+ * 
+ * @author tiodollar
+ */
+public class ConsulHostsSupplier implements HostSupplier {
+
+    private static final Logger Logger = LoggerFactory.getLogger(ConsulHostsSupplier.class);
+
+    // The Dynomite cluster name for discovering nodes
+    private final String applicationName;
+    private final ConsulClient discoveryClient;
+
+    public ConsulHostsSupplier(String applicationName, ConsulClient discoveryClient) {
+        this.applicationName = applicationName;
+        this.discoveryClient = discoveryClient;
+    }
+
+    public static ConsulHostsSupplier newInstance(String applicationName, ConsulHostsSupplier hostsSupplier) {
+        return new ConsulHostsSupplier(applicationName, hostsSupplier.getDiscoveryClient());
+    }
+
+    @Override
+    public List<Host> getHosts() {
+        return getUpdateFromConsul();
+    }
+
+    private List<Host> getUpdateFromConsul() {
+
+        if (discoveryClient == null) {
+            Logger.error("Discovery client cannot be null");
+            throw new RuntimeException("ConsulHostsSupplier needs a non-null DiscoveryClient");
+        }
+
+        Logger.info("Dyno fetching instance list for app: " + applicationName);
+
+        Response<List<HealthService>> services = discoveryClient.getHealthServices(applicationName, false, QueryParams.DEFAULT);
+
+        List<HealthService> app = services.getValue();
+        List<Host> hosts = new ArrayList<Host>();
+
+        if (app != null && app.size() < 0) {
+            return hosts;
+        }
+
+        hosts = Lists.newArrayList(Collections2.transform(app,
+
+                new Function<HealthService, Host>() {
+                    @Override
+                    public Host apply(HealthService info) {
+
+                        String hostName = ConsulHelper.findHost(info);
+                        Map<String, String> metaData = ConsulHelper.getMetadata(info);
+
+                        Host.Status status = Host.Status.Up;
+                        for (com.ecwid.consul.v1.health.model.Check check : info.getChecks()) {
+                            if (check.getStatus().equals(Check.CheckStatus.CRITICAL)) {
+                                status = Host.Status.Down;
+                                break;
+                            }
+                        }
+
+                        String rack = null;
+                        try {
+                            if (metaData.containsKey("cloud") && StringUtils.equals(metaData.get("cloud"), "aws")) {
+                                rack = metaData.get("availability-zone");
+
+                            } else {
+                                rack = metaData.get("rack");
+                            }
+                        } catch (Throwable t) {
+                            Logger.error("Error getting rack for host " + info.getNode(), t);
+                        }
+                        if (rack == null) {
+                            Logger.error("Rack wasn't found for host:" + info.getNode()
+                                    + " there may be issues matching it up to the token map");
+                        }
+                        Host host = new Host(hostName, hostName, info.getService().getPort(), rack,
+                                String.valueOf(metaData.get("datacenter")), status);
+                        return host;
+                    }
+                }));
+
+        Logger.info("Dyno found hosts from consul - num hosts: " + hosts.size());
+
+        return hosts;
+    }
+
+    @Override
+    public String toString() {
+        return ConsulHostsSupplier.class.getName();
+    }
+
+    public String getApplicationName() {
+        return applicationName;
+    }
+
+    public ConsulClient getDiscoveryClient() {
+        return discoveryClient;
+    }
+
+}

--- a/dyno-contrib/src/test/java/com/netflix/dyno/contrib/ConsulHostsSupplierTest.java
+++ b/dyno-contrib/src/test/java/com/netflix/dyno/contrib/ConsulHostsSupplierTest.java
@@ -1,0 +1,138 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.dyno.contrib;
+
+import com.ecwid.consul.v1.ConsulClient;
+import com.ecwid.consul.v1.QueryParams;
+import com.ecwid.consul.v1.agent.model.NewCheck;
+import com.ecwid.consul.v1.agent.model.NewService;
+import com.netflix.dyno.connectionpool.Host;
+import com.netflix.dyno.contrib.consul.ConsulHostsSupplier;
+import com.pszymczyk.consul.ConsulProcess;
+import com.pszymczyk.consul.ConsulStarterBuilder;
+import org.codehaus.jettison.json.JSONException;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class ConsulHostsSupplierTest {
+
+    private ConsulProcess consulServer;
+    private ConsulClient consulClient;
+    private static String APPLICATION_NAME = "testApp";
+
+    @Before
+    public void beforeEach() {
+        String config = "{" +
+            "\"datacenter\": \"test-dc\"," +
+            "\"log_level\": \"INFO\"," +
+            "\"node_name\": \"foobar\"" +
+            "}";
+        consulServer = ConsulStarterBuilder.consulStarter().withCustomConfig(config).build().start();
+        consulClient = new ConsulClient("127.0.0.1", consulServer.getHttpPort());
+    }
+
+    @After
+    public void afterEach() throws Exception {
+        consulServer.close();
+    }
+
+    @Test
+    public void testAwsHosts() throws JSONException {
+        List<String> tags = new ArrayList<>();
+        tags.add("cloud=aws");
+        tags.add("availability-zone=us-east-1b");
+        tags.add("datacenter=us-east-1");
+
+        NewService service = new NewService();
+        service.setName(APPLICATION_NAME);
+        service.setTags(tags);
+
+        consulClient.agentServiceRegister(service);
+
+        NewCheck check = new NewCheck();
+        check.setName(APPLICATION_NAME);
+        check.setScript("true");
+        check.setTtl("1m");
+        check.setInterval("30s");
+
+        consulClient.agentCheckRegister(check);
+
+        consulClient.agentCheckPass(APPLICATION_NAME);
+
+        ConsulHostsSupplier hostSupplier = new ConsulHostsSupplier(APPLICATION_NAME, consulClient);
+
+        assertEquals(hostSupplier.getApplicationName(), APPLICATION_NAME);
+
+        List<Host> hosts = hostSupplier.getHosts();
+
+        assertEquals(hosts.size(), 1);
+
+        Host host = hosts.get(0);
+
+        assertEquals(host.getRack(), "us-east-1b");
+        assertEquals(host.getDatacenter(), "us-east-1");
+        assertEquals(host.getHostName(), "127.0.0.1");
+        assertEquals(host.getIpAddress(), "127.0.0.1");
+        assertTrue(host.isUp());
+    }
+
+    @Test
+    public void testOtherCloudProviderHosts() throws JSONException {
+        List<String> tags = new ArrayList<>();
+        tags.add("cloud=kubernetes");
+        tags.add("rack=rack1");
+        tags.add("datacenter=dc1");
+
+        NewService service = new NewService();
+        service.setName(APPLICATION_NAME);
+        service.setTags(tags);
+
+        consulClient.agentServiceRegister(service);
+
+        NewCheck check = new NewCheck();
+        check.setName(APPLICATION_NAME);
+        check.setScript("true");
+        check.setTtl("1m");
+        check.setInterval("30s");
+
+        consulClient.agentCheckRegister(check);
+
+        consulClient.agentCheckPass(APPLICATION_NAME);
+
+        ConsulHostsSupplier hostSupplier = new ConsulHostsSupplier(APPLICATION_NAME, consulClient);
+
+        assertEquals(hostSupplier.getApplicationName(), APPLICATION_NAME);
+
+        List<Host> hosts = hostSupplier.getHosts();
+
+        assertEquals(hosts.size(), 1);
+
+        Host host = hosts.get(0);
+
+        assertEquals(host.getRack(), "rack1");
+        assertEquals(host.getDatacenter(), "dc1");
+        assertEquals(host.getHostName(), "127.0.0.1");
+        assertEquals(host.getIpAddress(), "127.0.0.1");
+        assertTrue(host.isUp());
+    }
+}


### PR DESCRIPTION
Forked off of tiodollar:consul_support and added an integration test by instantiating an embedded Consul server. Netflix/dyno#162
Rebased against the latest on master (Netflix/dyno@9a56ca416ee6f6f449db99d1929edf681f98eaf2)