### PR TITLE
Update ConnectionPoolImpl.java

### DIFF
--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolImpl.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolImpl.java
@@ -393,6 +393,8 @@ public class ConnectionPoolImpl<CL> implements ConnectionPool<CL>, TopologyView 
 						cpMonitor.incOperationSuccess(connection.getHost(), System.currentTimeMillis() - startTime);
 
 						results.add(result);
+						
+						lastException = null;
 
 					} catch (NoAvailableHostsException e) {
 						cpMonitor.incOperationFailure(null, e);


### PR DESCRIPTION
Not able to connect to dynomite if first host is down because even if another host returns the results we are not resetting "lastException" variable, we end up throwing exception.