### PR TITLE
dyno_scan bug returned null the second iteration of the loop fails.

### DIFF
--- a/dyno-jedis/src/main/java/com/netflix/dyno/jedis/CursorBasedResultImpl.java
+++ b/dyno-jedis/src/main/java/com/netflix/dyno/jedis/CursorBasedResultImpl.java
@@ -69,7 +69,7 @@ public class CursorBasedResultImpl<T> implements CursorBasedResult<T> {
             return sr.getStringCursor();
         }
 
-        return null;
+        return "0";
     }
 
     @Override


### PR DESCRIPTION
The second iteration of the loop fails because we try to send `null` to Redis (with the next hostname in the ring).