### PR TITLE
Support for REDIS Auth

### DIFF
--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/Host.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/Host.java
@@ -45,6 +45,7 @@ public class Host implements Comparable<Host> {
     private final String rack;
     private final String datacenter;
     private Status status = Status.Down;
+    private String password = null;
 
     public enum Status {
         Up, Down;
@@ -91,6 +92,14 @@ public class Host implements Comparable<Host> {
             return ipAddress;
         }
         return hostname;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
     }
 
     public String getHostName() {

--- a/dyno-jedis/src/main/java/com/netflix/dyno/jedis/JedisConnectionFactory.java
+++ b/dyno-jedis/src/main/java/com/netflix/dyno/jedis/JedisConnectionFactory.java
@@ -85,6 +85,13 @@ public class JedisConnectionFactory implements ConnectionFactory<Jedis> {
 				jedisClient = new Jedis(host.getHostAddress(), host.getPort(), hostPool.getConnectionTimeout(),
 						hostPool.getSocketTimeout(), true, sslSocketFactory,  new SSLParameters(), null);
 			}
+
+			String redisPassword = host.getPassword();
+			if(null != jedisClient && null != redisPassword) {
+				if(!jedisClient.auth(redisPassword).equals("OK")) {
+					Logger.warn("Failed to set REDIS auth Password");
+				}
+			}
 		}
 
 		@Override


### PR DESCRIPTION
Allow REDIS Auth to be configured as part of host configuration. Configure JEDIS client to set Auth if available in host configuration. 