### PR TITLE
Binary support

### DIFF
--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/BaseOperation.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/BaseOperation.java
@@ -20,6 +20,7 @@ package com.netflix.dyno.connectionpool;
  * connection pool
  * 
  * @author poberai
+ * @author ipapapa
  *
  * @param <CL>
  *            client
@@ -41,5 +42,12 @@ public interface BaseOperation<CL, R> {
      * @return String
      */
     public String getStringKey();
+    
+    /**
+     * The binary key for the operation
+     * 
+     * @return 
+     */
+    public byte[] getBinaryKey();
 
 }

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/BaseOperation.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/BaseOperation.java
@@ -40,6 +40,6 @@ public interface BaseOperation<CL, R> {
      * 
      * @return String
      */
-    public String getKey();
+    public String getStringKey();
 
 }

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/HashPartitioner.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/HashPartitioner.java
@@ -46,9 +46,16 @@ public interface HashPartitioner {
 	public Long hash(String key);
 	
 	/**
+	 * @param key
+	 * @return Long
+	 */
+	public Long hash(byte[] key);
+	
+	/**
 	 * 
 	 * @param keyHash
 	 * @return
 	 */
 	public HostToken getToken(Long keyHash);
+
 }

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/HostSelectionStrategy.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/HostSelectionStrategy.java
@@ -81,6 +81,17 @@ public interface HostSelectionStrategy<CL> {
      */
     HostToken getTokenForKey(String key) throws UnsupportedOperationException;
 
+    
+    /**
+     * Finds the server Host that owns the specified binary key.
+     *
+     * @param key
+     * @return {@link HostToken}
+     * @throws UnsupportedOperationException for non-token aware load balancing strategies
+     */
+	HostToken getTokenForKey(byte[] key) throws UnsupportedOperationException;
+
+    
 	/**
 	 * Init the connection pool with the set of hosts provided
 	 * @param hostPools
@@ -114,6 +125,7 @@ public interface HostSelectionStrategy<CL> {
 		 */
 		public HostSelectionStrategy<CL> vendPoolSelectionStrategy();
 	}
+
 
 
 

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/hash/BinarySearchTokenMapper.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/hash/BinarySearchTokenMapper.java
@@ -33,6 +33,7 @@ import com.netflix.dyno.connectionpool.impl.lb.HostToken;
  * The hash token to be generated from the key is generated using the HashPartitioner provided to this class. 
  *  
  * @author poberai
+ * @author ipapapa
  *
  */
 public class BinarySearchTokenMapper implements HashPartitioner {
@@ -58,6 +59,11 @@ public class BinarySearchTokenMapper implements HashPartitioner {
 
 	@Override
 	public Long hash(String key) {
+		return partitioner.hash(key);
+	}
+	
+	@Override 
+	public Long hash(byte[] key) {
 		return partitioner.hash(key);
 	}
 

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/hash/Murmur1HashPartitioner.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/hash/Murmur1HashPartitioner.java
@@ -40,6 +40,14 @@ public class Murmur1HashPartitioner implements HashPartitioner {
         byte[] b = bb.array();
         return UnsignedIntsUtils.toLong(Murmur1Hash.hash(b, b.length));
 	}
+    
+	@Override
+	public Long hash(byte[] key) {
+		if (key == null) {
+			return 0L;
+		}
+        return UnsignedIntsUtils.toLong(Murmur1Hash.hash(key, key.length));
+	}
 	
     @Override
 	public Long hash(long key) {
@@ -63,4 +71,6 @@ public class Murmur1HashPartitioner implements HashPartitioner {
 	public HostToken getToken(Long keyHash) {
 		throw new RuntimeException("NotImplemented");
 	}
+
+
 }

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/hash/Murmur2HashPartitioner.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/hash/Murmur2HashPartitioner.java
@@ -62,6 +62,14 @@ public class Murmur2HashPartitioner implements HashPartitioner {
 		byte[] b = bb.array();
 		return  UnsignedIntsUtils.toLong(Murmur2Hash.hash32(b, b.length));
 	}
+	
+	@Override
+	public Long hash(byte[] key) {
+		if (key == null) {
+			return 0L;
+		}
+		return  UnsignedIntsUtils.toLong(Murmur2Hash.hash32(key, key.length));
+	}
 
 	@Override
 	public HostToken getToken(Long keyHash) {

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/hash/Murmur3HashPartitioner.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/hash/Murmur3HashPartitioner.java
@@ -62,6 +62,14 @@ public class Murmur3HashPartitioner implements HashPartitioner {
 		byte[] b = bb.array();
 		return UnsignedIntsUtils.toLong(Murmur3Hash.hash32(b, b.length));
 	}
+	
+	@Override
+	public Long hash(byte[] key) {
+		if (key == null) {
+			return 0L;
+		}
+		return UnsignedIntsUtils.toLong(Murmur3Hash.hash32(key, key.length));
+	}
 
 	@Override
 	public HostToken getToken(Long keyHash) {

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/lb/RoundRobinSelection.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/lb/RoundRobinSelection.java
@@ -97,6 +97,11 @@ public class RoundRobinSelection<CL> implements HostSelectionStrategy<CL> {
     public HostToken getTokenForKey(String key) throws UnsupportedOperationException {
         throw new UnsupportedOperationException("Not implemented for Round Robin load balancing strategy");
     }
+    
+	@Override
+	public HostToken getTokenForKey(byte[] key) throws UnsupportedOperationException {
+        throw new UnsupportedOperationException("Not implemented for Round Robin load balancing strategy");
+	}
 
     private HostConnectionPool<CL> getNextConnectionPool() throws NoAvailableHostsException {
 
@@ -156,4 +161,5 @@ public class RoundRobinSelection<CL> implements HostSelectionStrategy<CL> {
 	public String toString() {
 		return "RoundRobinSelector: list: " + circularList.toString();
 	}
+
 }

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/lb/TokenAwareSelection.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/lb/TokenAwareSelection.java
@@ -84,7 +84,7 @@ public class TokenAwareSelection<CL> implements HostSelectionStrategy<CL> {
     @Override
     public HostConnectionPool<CL> getPoolForOperation(BaseOperation<CL, ?> op, String hashtag) throws NoAvailableHostsException {
 
-        String key = op.getKey();
+        String key = op.getStringKey();
 
         HostToken hToken = null;
         if (hashtag == null || hashtag.isEmpty()) {            

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolImplTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolImplTest.java
@@ -682,6 +682,11 @@ public class ConnectionPoolImplTest {
 			public String getStringKey() {
 				return "TestOperation";
 			}
+
+			@Override
+			public byte[] getBinaryKey() {
+				return null;
+			}
 		});
 	}
 
@@ -717,6 +722,11 @@ public class ConnectionPoolImplTest {
 									@Override
 									public String getStringKey() {
 										return "TestOperation";
+									}
+
+									@Override
+									public byte[] getBinaryKey() {
+										return null;
 									}
 
 								});

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolImplTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolImplTest.java
@@ -679,7 +679,7 @@ public class ConnectionPoolImplTest {
 			
 
 			@Override
-			public String getKey() {
+			public String getStringKey() {
 				return "TestOperation";
 			}
 		});
@@ -715,7 +715,7 @@ public class ConnectionPoolImplTest {
 									}
 
 									@Override
-									public String getKey() {
+									public String getStringKey() {
 										return "TestOperation";
 									}
 

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/lb/HostSelectionWithFallbackTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/lb/HostSelectionWithFallbackTest.java
@@ -49,7 +49,6 @@ import com.netflix.dyno.connectionpool.HostConnectionPool;
 import com.netflix.dyno.connectionpool.TokenMapSupplier;
 import com.netflix.dyno.connectionpool.impl.ConnectionPoolConfigurationImpl;
 import com.netflix.dyno.connectionpool.impl.CountingConnectionPoolMonitor;
-import com.netflix.dyno.connectionpool.impl.hash.Murmur3HashPartitioner;
 import com.netflix.dyno.connectionpool.impl.utils.CollectionUtils;
 import com.netflix.dyno.connectionpool.impl.utils.CollectionUtils.Transform;
 import static org.junit.Assert.assertEquals;
@@ -68,6 +67,11 @@ public class HostSelectionWithFallbackTest {
 		@Override
 		public String getStringKey() {
 			return "11";
+		}
+
+		@Override
+		public byte[] getBinaryKey() {
+			return null;
 		}
 	};
         
@@ -687,11 +691,18 @@ public class HostSelectionWithFallbackTest {
                 public Long hash(String key) {
                     return hash;
                 }
+                
+				@Override
+				public Long hash(byte[] key) {
+					return hash;
+				}
 
                 @Override
                 public HostToken getToken(Long keyHash) {
                     throw new RuntimeException("NotImplemented");
                 }
+
+
             };
         }
 }

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/lb/HostSelectionWithFallbackTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/lb/HostSelectionWithFallbackTest.java
@@ -66,7 +66,7 @@ public class HostSelectionWithFallbackTest {
 		}
 
 		@Override
-		public String getKey() {
+		public String getStringKey() {
 			return "11";
 		}
 	};

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/lb/RoundRobinSelectionTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/lb/RoundRobinSelectionTest.java
@@ -67,6 +67,11 @@ public class RoundRobinSelectionTest {
         public String getStringKey() {
             return null;
         }
+
+		@Override
+		public byte[] getBinaryKey() {
+			return null;
+		}
     };
 
     @Test

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/lb/RoundRobinSelectionTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/lb/RoundRobinSelectionTest.java
@@ -64,7 +64,7 @@ public class RoundRobinSelectionTest {
         }
 
         @Override
-        public String getKey() {
+        public String getStringKey() {
             return null;
         }
     };

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/lb/TokenAwareSelectionHastagTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/lb/TokenAwareSelectionHastagTest.java
@@ -162,6 +162,11 @@ public class TokenAwareSelectionHastagTest {
                 return n + "-{" + hashValue + "}";
             }
 
+			@Override
+			public byte[] getBinaryKey() {
+				return null;
+			}
+
         };
     }
 

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/lb/TokenAwareSelectionHastagTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/lb/TokenAwareSelectionHastagTest.java
@@ -158,7 +158,7 @@ public class TokenAwareSelectionHastagTest {
             }
 
             @Override
-            public String getKey() {
+            public String getStringKey() {
                 return n + "-{" + hashValue + "}";
             }
 
@@ -176,11 +176,11 @@ public class TokenAwareSelectionHastagTest {
             String hostName = pool.getHost().getHostAddress();
 
             if (testSelector == 0) {
-                verifyHashtagHash(op.getKey(), hostName, hashtag);
+                verifyHashtagHash(op.getStringKey(), hostName, hashtag);
             } else if (testSelector == 1) {
-                verifyEmptyHashtagHash(op.getKey(), hostName, hashtag);
+                verifyEmptyHashtagHash(op.getStringKey(), hostName, hashtag);
             } else {
-                verifyDifferentHashtagHash(op.getKey(), hostName, hashtag);
+                verifyDifferentHashtagHash(op.getStringKey(), hostName, hashtag);
             }
 
             Integer count = result.get(hostName);

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/lb/TokenAwareSelectionTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/lb/TokenAwareSelectionTest.java
@@ -130,7 +130,7 @@ public class TokenAwareSelectionTest {
 			}
 
 			@Override
-			public String getKey() {
+			public String getStringKey() {
 				return "" + n;
 			}
 		};
@@ -146,7 +146,7 @@ public class TokenAwareSelectionTest {
 
 			String hostName = pool.getHost().getHostAddress();
 
-			verifyKeyHash(op.getKey(), hostName);
+			verifyKeyHash(op.getStringKey(), hostName);
 
 			Integer count = result.get(hostName);
 			if (count == null) {
@@ -166,7 +166,7 @@ public class TokenAwareSelectionTest {
 
 			int port = pool.getHost().getPort();
 
-			verifyKeyHashWithPort(op.getKey(), port);
+			verifyKeyHashWithPort(op.getStringKey(), port);
 
 			Integer count = result.get(port);
 			if (count == null) {

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/lb/TokenAwareSelectionTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/lb/TokenAwareSelectionTest.java
@@ -133,6 +133,11 @@ public class TokenAwareSelectionTest {
 			public String getStringKey() {
 				return "" + n;
 			}
+
+			@Override
+			public byte[] getBinaryKey() {
+				return null;
+			}
 		};
 	}
 

--- a/dyno-demo/src/main/java/com/netflix/dyno/demo/redis/DynoJedisDemo.java
+++ b/dyno-demo/src/main/java/com/netflix/dyno/demo/redis/DynoJedisDemo.java
@@ -20,6 +20,7 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.ByteBuffer;
 import java.util.*;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
@@ -51,955 +52,984 @@ import redis.clients.jedis.ScanResult;
 
 public class DynoJedisDemo {
 
-    private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(DynoJedisDemo.class);
+	private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(DynoJedisDemo.class);
 
-    public static final String randomValue = "dcfa7d0973834e5c9f480b65de19d684dcfa7d097383dcfa7d0973834e5c9f480b65de19d684dcfa7d097383dcfa7d0973834e5c9f480b65de19d684dcfa7d097383dcfa7d0973834e5c9f480b65de19d684dcfa7d097383";
+	public static final String randomValue = "dcfa7d0973834e5c9f480b65de19d684dcfa7d097383dcfa7d0973834e5c9f480b65de19d684dcfa7d097383dcfa7d0973834e5c9f480b65de19d684dcfa7d097383dcfa7d0973834e5c9f480b65de19d684dcfa7d097383";
 
-    protected DynoJedisClient client;
-
-    protected int numKeys;
-
-    protected final String localRack;
-    protected final String clusterName;
-
-    public DynoJedisDemo(String clusterName, String localRack) {
-        this.clusterName = clusterName;
-        this.localRack = localRack;
-    }
-
-    public void initWithLocalHost() throws Exception {
-
-        final int port = 6379;
-
-        final Host localHost = new Host("localhost", port, "localrack", Status.Up);
-
-        final HostSupplier localHostSupplier = new HostSupplier() {
-
-            @Override
-            public Collection<Host> getHosts() {
-                return Collections.singletonList(localHost);
-            }
-        };
-
-        final TokenMapSupplier tokenSupplier = new TokenMapSupplier() {
-
-            final HostToken localHostToken = new HostToken(100000L, localHost);
-
-            @Override
-            public List<HostToken> getTokens(Set<Host> activeHosts) {
-                return Collections.singletonList(localHostToken);
-            }
-
-            @Override
-            public HostToken getTokenForHost(Host host, Set<Host> activeHosts) {
-                return localHostToken;
-            }
-        };
-
-        init(localHostSupplier, port, tokenSupplier);
-    }
-
-    private void initWithRemoteCluster(final List<Host> hosts, final int port) throws Exception {
-        final HostSupplier clusterHostSupplier = new HostSupplier() {
-
-            @Override
-            public Collection<Host> getHosts() {
-                return hosts;
-            }
-        };
-
-        init(clusterHostSupplier, port, null);
-    }
-
-    public void initWithRemoteClusterFromFile(final String filename, final int port) throws Exception {
-        initWithRemoteCluster(readHostsFromFile(filename, port), port);
-    }
-
-    public void initWithRemoteClusterFromEurekaUrl(final String clusterName, final int port) throws Exception {
-        initWithRemoteCluster(getHostsFromDiscovery(clusterName), port);
-    }
-
-    public void init(HostSupplier hostSupplier, int port, TokenMapSupplier tokenSupplier) throws Exception {
-
-        client = new DynoJedisClient.Builder().withApplicationName("demo").withDynomiteClusterName("dyno_dev")
-                .withHostSupplier(hostSupplier)
-//                 .withCPConfig(
-//                 new ConnectionPoolConfigurationImpl("demo")
-//                 .setCompressionStrategy(ConnectionPoolConfiguration.CompressionStrategy.THRESHOLD)
-//                 .setCompressionThreshold(2048)
-//                 .setLocalRack(this.localRack)
-//                 )
-                .build();
-    }
-
-    public void runSimpleTest() throws Exception {
-
-        this.numKeys = 10;
-        System.out.println("Simple test selected");
-
-        // write
-        for (int i = 0; i < numKeys; i++) {
-            System.out.println("Writing key/value => DynoClientTest-" + i + " / " + i);
-            client.set("DynoClientTest-" + i, "" + i);
-        }
-        // read
-        for (int i = 0; i < numKeys; i++) {
-            OperationResult<String> result = client.d_get("DynoClientTest-" + i);
-            System.out.println("Reading Key: " + i + ", Value: " + result.getResult() + " " + result.getNode());
-        }
-    }
-
-    /**
-     * To run this test, the hashtag FP must be set on the Dynomite cluster. The
-     * assumed hashtag for this test is {} hence each key is foo-{<String>}. To
-     * validate that this test succeeds observe the cluster manually.
-     * 
-     * @throws Exception
-     */
-    public void runSimpleTestWithHashtag() throws Exception {
-        
-        this.numKeys = 100;
-        System.out.println("Simple test with hashtag selected");
-
-        // write
-        for (int i = 0; i < numKeys; i++) {
-            System.out.println("Writing key/value => DynoClientTest-" + i + " / " + i);
-            client.set(i + "-{bar}", " " + i);
-        }
-        // read
-        for (int i = 0; i < numKeys; i++) {
-            OperationResult<String> result = client.d_get(i + "-{bar}");
-            System.out.println(
-                    "Reading Key: " + i + "-{bar}" + " , Value: " + result.getResult() + " " + result.getNode());
-        }
-    }
-
-    public void runPipelineEmptyResult() throws Exception {
-        DynoJedisPipeline pipeline = client.pipelined();
-        DynoJedisPipeline pipeline2 = client.pipelined();
-
-        try {
-            byte[] field1 = "field1".getBytes();
-            byte[] field2 = "field2".getBytes();
-
-            pipeline.hset("myHash".getBytes(), field1, "hello".getBytes());
-            pipeline.hset("myHash".getBytes(), field2, "world".getBytes());
-
-            Thread.sleep(1000);
-
-            Response<List<byte[]>> result = pipeline.hmget("myHash".getBytes(), field1, field2, "miss".getBytes());
-
-            pipeline.sync();
-
-            System.out.println("TEST-1: hmget for 2 valid results and 1 non-existent field");
-            for (int i = 0; i < result.get().size(); i++) {
-                byte[] val = result.get().get(i);
-                if (val != null) {
-                    System.out.println("TEST-1:Result => " + i + ") " + new String(val));
-                } else {
-                    System.out.println("TEST-1:Result => " + i + ") " + val);
-                }
-            }
-
-        } catch (Exception e) {
-            pipeline.discardPipelineAndReleaseConnection();
-            throw e;
-        }
-
-        try {
-            Response<List<byte[]>> result2 = pipeline2.hmget("foo".getBytes(), "miss1".getBytes(), "miss2".getBytes());
-
-            pipeline2.sync();
-
-            System.out.println("TEST-2: hmget when all fields (3) are not present in the hash");
-            if (result2.get() == null) {
-                System.out.println("TEST-2: result is null");
-            } else {
-                for (int i = 0; i < result2.get().size(); i++) {
-                    System.out.println("TEST-2:" + Arrays.toString(result2.get().get(i)));
-                }
-            }
-        } catch (Exception e) {
-            pipeline.discardPipelineAndReleaseConnection();
-            throw e;
-        }
-    }
-
-    public void runKeysTest() throws Exception {
-        System.out.println("Writing 10,000 keys to dynomite...");
-
-        for (int i = 0; i < 500; i++) {
-            client.set("DynoClientTest_KEYS-TEST-key" + i, "value-" + i);
-        }
-
-        System.out.println("finished writing 10000 keys, querying for keys(\"DynoClientTest_KYES-TEST*\")");
-
-        Set<String> result = client.keys("DynoClientTest_KEYS-TEST*");
-
-        System.out.println("Got " + result.size() + " results, below");
-        System.out.println(result);
-    }
-
-    public void runScanTest(boolean populateKeys) throws Exception {
-        logger.info("SCAN TEST -- begin");
-
-        final String keyPattern = System.getProperty("dyno.demo.scan.key.pattern", "DynoClientTest_key-*");
-        final String keyPrefix = System.getProperty("dyno.demo.scan.key.prefix", "DynoClientTest_key-");
-
-        if (populateKeys) {
-            logger.info("Writing 500 keys to {} with prefix {}", this.clusterName, keyPrefix);
-            for (int i = 0; i < 500; i++) {
-                client.set(keyPrefix + i, "value-" + i);
-            }
-        }
-
-        logger.info("Reading keys from {} with pattern {}", this.clusterName, keyPattern);
-        CursorBasedResult<String> cbi = null;
-        do {
-            cbi = client.dyno_scan(cbi, 10000, keyPattern);
-
-            List<String> results = cbi.getStringResult();
-            for (String res : results) {
-                logger.info(res);
-            }
-        } while (!cbi.isComplete());
-
-        logger.info("SCAN TEST -- done");
-    }
-
-    public void runSScanTest(boolean populateKeys) throws Exception {
-        logger.info("SET SCAN TEST -- begin");
-
-        final String key = "DynoClientTest_Set";
-
-        if (populateKeys) {
-            logger.info("Populating set in cluster {} with key {}", this.clusterName, key);
-            for (int i = 0; i < 50; i++) {
-                client.sadd(key, "value-" + i);
-            }
-        }
-
-        logger.info("Reading members of set from cluster {} with key {}", this.clusterName, key);
-        ScanResult<String> scanResult;
-        final Set<String> matches = new HashSet<>();
-        String cursor = "0";
-        do {
-
-            final ScanParams scanParams = new ScanParams().count(10);
-            scanParams.match("*");
-            scanResult = client.sscan(key, cursor, scanParams);
-            matches.addAll(scanResult.getResult());
-            cursor = scanResult.getStringCursor();
-            if ("0".equals(cursor)) {
-                break;
-            }
-        } while (true);
-        logger.info("SET SCAN TEST -- done");
-    }
-
-    public void cleanup(int nKeys) throws Exception {
-
-        // writes for initial seeding
-        for (int i = 0; i < nKeys; i++) {
-            System.out.println("Deleting : " + i);
-            client.del("DynoDemoTest" + i);
-        }
-    }
-
-    public void runMultiThreaded() throws Exception {
-        this.runMultiThreaded(1000, true, 2, 2);
-    }
-
-    public void runMultiThreaded(final int items, boolean doSeed, final int numReaders, final int numWriters)
-            throws Exception {
-
-        final int nKeys = items;
-        if (doSeed) {
-            // writes for initial seeding
-            for (int i = 0; i < nKeys; i++) {
-                System.out.println("Writing : " + i);
-                client.set("DynoDemoTest" + i, "" + i);
-            }
-        }
-
-        final int nThreads = numReaders + numWriters + 1;
-
-        final ExecutorService threadPool = Executors.newFixedThreadPool(nThreads);
-
-        final AtomicBoolean stop = new AtomicBoolean(false);
-        final CountDownLatch latch = new CountDownLatch(nThreads);
-
-        final AtomicInteger success = new AtomicInteger(0);
-        final AtomicInteger failure = new AtomicInteger(0);
-        final AtomicInteger emptyReads = new AtomicInteger(0);
-
-        startWrites(nKeys, numWriters, threadPool, stop, latch, success, failure);
-        startReads(nKeys, numReaders, threadPool, stop, latch, success, failure, emptyReads);
-
-        threadPool.submit(new Callable<Void>() {
-
-            @Override
-            public Void call() throws Exception {
-                while (!stop.get()) {
-                    System.out.println("Success: " + success.get() + ", failure: " + failure.get() + ", emptyReads: "
-                            + emptyReads.get());
-                    Thread.sleep(1000);
-                }
-                latch.countDown();
-                return null;
-            }
-
-        });
-
-        Thread.sleep(15 * 1000);
-
-        stop.set(true);
-        latch.await();
-        threadPool.shutdownNow();
-
-        executePostRunActions();
-
-        System.out.println("Cleaning up keys");
-        cleanup(nKeys);
-
-        System.out.println("FINAL RESULT \nSuccess: " + success.get() + ", failure: " + failure.get() + ", emptyReads: "
-                + emptyReads.get());
-
-    }
-
-    protected void executePostRunActions() {
-        // nothing to do here
-    }
-
-    protected void startWrites(final int nKeys, final int numWriters, final ExecutorService threadPool,
-            final AtomicBoolean stop, final CountDownLatch latch, final AtomicInteger success,
-            final AtomicInteger failure) {
-
-        for (int i = 0; i < numWriters; i++) {
-
-            threadPool.submit(new Callable<Void>() {
-
-                final Random random = new Random();
-
-                @Override
-                public Void call() throws Exception {
-
-                    while (!stop.get()) {
-                        int key = random.nextInt(nKeys);
-                        int value = random.nextInt(nKeys);
-
-                        try {
-                            client.set("DynoDemoTest" + key, "" + value);
-                            success.incrementAndGet();
-                        } catch (Exception e) {
-                            System.out.println("WRITE FAILURE: " + e.getMessage());
-                            failure.incrementAndGet();
-                        }
-                    }
-
-                    latch.countDown();
-                    return null;
-                }
-
-            });
-        }
-    }
-
-    protected void startReads(final int nKeys, final int numReaders, final ExecutorService threadPool,
-            final AtomicBoolean stop, final CountDownLatch latch, final AtomicInteger success,
-            final AtomicInteger failure, final AtomicInteger emptyReads) {
-
-        for (int i = 0; i < numReaders; i++) {
-
-            threadPool.submit(new Callable<Void>() {
-
-                final Random random = new Random();
-
-                @Override
-                public Void call() throws Exception {
-
-                    while (!stop.get()) {
-                        int key = random.nextInt(nKeys);
-
-                        try {
-                            String value = client.get("DynoDemoTest" + key);
-                            success.incrementAndGet();
-                            if (value == null || value.isEmpty()) {
-                                emptyReads.incrementAndGet();
-                            }
-                        } catch (Exception e) {
-                            System.out.println("READ FAILURE: " + e.getMessage());
-                            failure.incrementAndGet();
-                        }
-                    }
-
-                    latch.countDown();
-                    return null;
-                }
-            });
-        }
-    }
-
-    public void stop() {
-        if (client != null) {
-            client.stopClient();
-        }
-    }
-
-    private List<Host> readHostsFromFile(String filename, int port) throws Exception {
-
-        List<Host> hosts = new ArrayList<Host>();
-        File file = new File(filename);
-        BufferedReader reader = new BufferedReader(new FileReader(file));
-
-        try {
-            String line = null;
-            while ((line = reader.readLine()) != null) {
-                if (line.trim().isEmpty()) {
-                    continue;
-                }
-                String[] parts = line.trim().split(" ");
-                if (parts.length != 2) {
-                    throw new RuntimeException("Bad data format in file:" + line);
-                }
-                Host host = new Host(parts[0].trim(), port, parts[1].trim(), Status.Up);
-                hosts.add(host);
-            }
-        } finally {
-            reader.close();
-        }
-        return hosts;
-    }
-
-    public void runBinarySinglePipeline() throws Exception {
-
-        for (int i = 0; i < 10; i++) {
-            DynoJedisPipeline pipeline = client.pipelined();
-
-            Map<byte[], byte[]> bar = new HashMap<byte[], byte[]>();
-            bar.put("key__1".getBytes(), "value__1".getBytes());
-            bar.put("key__2".getBytes(), "value__2".getBytes());
-
-            Response<String> hmsetResult = pipeline.hmset(("hash__" + i).getBytes(), bar);
-
-            pipeline.sync();
-
-            System.out.println(hmsetResult.get());
-        }
-
-        System.out.println("Reading all keys");
-
-        DynoJedisPipeline readPipeline = client.pipelined();
-        Response<Map<byte[], byte[]>> resp = readPipeline.hgetAll("hash__1".getBytes());
-        readPipeline.sync();
-
-        StringBuilder sb = new StringBuilder();
-        for (byte[] bytes : resp.get().keySet()) {
-            if (sb.length() > 0) {
-                sb.append(",");
-            }
-            sb.append(new String(bytes));
-        }
-        System.out.println("Got hash :" + sb.toString());
-    }
-
-    public void runCompressionInPipelineTest() throws Exception {
-        final int maxNumKeys = 100;
-        final int maxPipelineSize = 10;
-        final int maxOperations = 500;
-        final Random rand = new Random();
-
-
-        for (int operationIter = 0; operationIter < maxOperations; operationIter++) {
-
-            DynoJedisPipeline pipeline = client.pipelined();
-            int pipelineSize = 1 + rand.nextInt(maxPipelineSize) ;
-
-            // key to be used in pipeline
-            String key = "hash__" + rand.nextInt(maxNumKeys);
-
-            // Map of field -> value
-            Map<String, String> map = new HashMap<>();
-
-            // List of fields to be later used in HMGet
-            List<String> fields = new ArrayList<>(pipelineSize);
-
-            // Create a map of field -> value, also accumulate all fields
-            for (int pipelineIter = 0; pipelineIter < pipelineSize; pipelineIter++) {
-                String field = "field_" + pipelineIter;
-                fields.add(field);
-                String prefixSuffix = key + "_" + field;
-                String value = prefixSuffix + "_" + generateValue(pipelineIter) + "_" + prefixSuffix;
-                map.put(field, value);
-            }
-
-            Response<String> HMSetResult = pipeline.hmset(key, map);
-            Response<List<String>> HMGetResult = pipeline.hmget(key, fields.toArray(new String[fields.size()]));
-            try {
-                pipeline.sync();
-            } catch (Exception e) {
-                pipeline.discardPipelineAndReleaseConnection();
-                System.out.println("Exception while writing key " + key + " fields: " + fields);
-                throw e;
-            }
-
-            if (!HMSetResult.get().equals("OK")) {
-                System.out.println("Result mismatch for HMSet key: '" + key + "' fields: '" + fields + "' result: '" + HMSetResult.get() + "'");
-            }
-            if ((operationIter % 100) == 0) {
-                System.out.println("\n>>>>>>>> " + operationIter + " operations performed....");
-            }
-            List<String> HMGetResultStrings = HMGetResult.get();
-            for (int i = 0; i < HMGetResultStrings.size(); i++) {
-                String prefixSuffix = key + "_" + fields.get(i);
-                String value = HMGetResultStrings.get(i);
-                if (value.startsWith(prefixSuffix) && value.endsWith(prefixSuffix)) {
-                    continue;
-                }
-                else {
-                    System.out.println("Result mismatch key: '" + key + "' field: '" + fields.get(i) + "' value: '" + HMGetResultStrings.get(i) + "'");
-                }
-
-            }
-        }
-        System.out.println("Compression test Done: " + maxOperations + " pipeline operations performed.");
-
-    }
-
-    public void runSandboxTest() throws Exception {
-        Set<String> keys = client.keys("zuulRules:*");
-        System.out.println("GOT KEYS");
-        System.out.println(keys.size());
-    }
-
-    private static String generateValue(int kilobytes) {
-        StringBuilder sb = new StringBuilder(kilobytes * 512); // estimating 2
-                                                               // bytes per char
-        for (int i = 0; i < kilobytes; i++) {
-            for (int j = 0; j < 10; j++) {
-                sb.append("abcdefghijklmnopqrstuvwxzy0123456789a1b2c3d4f5g6h7"); // 50
-                                                                                 // characters
-                                                                                 // (~100
-                                                                                 // bytes)
-                sb.append(":");
-                sb.append("abcdefghijklmnopqrstuvwxzy0123456789a1b2c3d4f5g6h7");
-                sb.append(":");
-            }
-        }
-
-        return sb.toString();
-
-    }
-
-    /**
-     * This demo runs a pipeline across ten different keys.
-     * The pipeline leverages the hash value {bar} to determine
-     * the node where to send the data.
-     * @throws Exception
-     */
-    public void runPipelineWithHashtag() throws Exception {
-
-        
-        DynoJedisPipeline pipeline = client.pipelined();
-        try {
-
-            pipeline.set("pipeline-hashtag1-{bar}", "value-1");
-            pipeline.set("pipeline-hashtag2-{bar}", "value-2");
-            pipeline.set("pipeline-hashtag3-{bar}", "value-3");
-            pipeline.set("pipeline-hashtag4-{bar}", "value-4");
-            pipeline.set("pipeline-hashtag5-{bar}", "value-5");
-            pipeline.set("pipeline-hashtag6-{bar}", "value-6");
-            pipeline.set("pipeline-hashtag7-{bar}", "value-7");
-            pipeline.set("pipeline-hashtag8-{bar}", "value-8");
-            pipeline.set("pipeline-hashtag9-{bar}", "value-9");
-            pipeline.set("pipeline-hashtag10-{bar}", "value-10");
-
-
-            Response<String> value1 = pipeline.get("pipeline-hashtag1-{bar}");
-            Response<String> value2 = pipeline.get("pipeline-hashtag2-{bar}");
-            Response<String> value3 = pipeline.get("pipeline-hashtag3-{bar}");
-            Response<String> value4 = pipeline.get("pipeline-hashtag4-{bar}");
-            Response<String> value5 = pipeline.get("pipeline-hashtag5-{bar}");
-            Response<String> value6 = pipeline.get("pipeline-hashtag6-{bar}");           
-            pipeline.sync();
-            
-            System.out.println(value1.get());
-            System.out.println(value2.get());
-            System.out.println(value3.get());
-            System.out.println(value4.get());
-            System.out.println(value5.get());
-            System.out.println(value6.get());
-        } catch (Exception e) {
-            pipeline.discardPipelineAndReleaseConnection();
-            throw e;
-        }
-    }
-
-    public void runPipeline() throws Exception {
-
-        int numThreads = 5;
-
-        final ExecutorService threadPool = Executors.newFixedThreadPool(numThreads);
-        final AtomicBoolean stop = new AtomicBoolean(false);
-        final CountDownLatch latch = new CountDownLatch(numThreads);
-
-        for (int i = 0; i < numThreads; i++) {
-            threadPool.submit(new Callable<Void>() {
-
-                final Random rand = new Random();
-
-                @Override
-                public Void call() throws Exception {
-
-                    final AtomicInteger iter = new AtomicInteger(0);
-
-                    while (!stop.get()) {
-                        int index = rand.nextInt(5);
-                        int i = iter.incrementAndGet();
-                        DynoJedisPipeline pipeline = client.pipelined();
-
-                        try {
-                            Response<Long> resultA1 = pipeline.hset("DynoJedisDemo_pipeline-" + index, "a1",
-                                    constructRandomValue(index));
-                            Response<Long> resultA2 = pipeline.hset("DynoJedisDemo_pipeline-" + index, "a2",
-                                    "value-" + i);
-
-                            pipeline.sync();
-
-                            System.out.println(resultA1.get() + " " + resultA2.get());
-
-                        } catch (Exception e) {
-                            pipeline.discardPipelineAndReleaseConnection();
-                            throw e;
-                        }
-
-                    }
-                    latch.countDown();
-                    return null;
-                }
-            });
-        }
-
-        Thread.sleep(5000);
-        stop.set(true);
-        latch.await();
-
-        threadPool.shutdownNow();
-    }
-
-    private String constructRandomValue(int sizeInKB) {
-
-        int requriredLength = sizeInKB * 1024;
-
-        String s = randomValue;
-        int sLength = s.length();
-
-        StringBuilder sb = new StringBuilder();
-        int lengthSoFar = 0;
-
-        do {
-            sb.append(s);
-            lengthSoFar += sLength;
-        } while (lengthSoFar < requriredLength);
-
-        String ss = sb.toString();
-
-        if (ss.length() > requriredLength) {
-            ss = sb.substring(0, requriredLength);
-        }
-
-        return ss;
-    }
-
-    private List<Host> getHostsFromDiscovery(final String clusterName) {
-
-        String env = System.getProperty("netflix.environment", "test");
-        String discoveryKey = String.format("dyno.demo.discovery.%s", env);
-
-        if (!System.getProperties().containsKey(discoveryKey)) {
-            throw new IllegalArgumentException("Discovery URL not found");
-        }
-
-        String region = System.getProperty("EC2_REGION");
-        final String discoveryUrl = String.format(System.getProperty(discoveryKey), region);
-
-        final String url = String.format("http://%s/%s", discoveryUrl, clusterName);
-
-        HttpClient client = new DefaultHttpClient();
-        try {
-            HttpResponse response = client.execute(new HttpGet(url));
-            InputStream in = response.getEntity().getContent();
-
-            SAXParserFactory parserFactor = SAXParserFactory.newInstance();
-
-            SAXParser parser = parserFactor.newSAXParser();
-            SAXHandler handler = new SAXHandler("instance", "public-hostname", "availability-zone", "status",
-                    "local-ipv4");
-            parser.parse(in, handler);
-
-            List<Host> hosts = new ArrayList<Host>();
-
-            for (Map<String, String> map : handler.getList()) {
-                String rack = map.get("availability-zone");
-                Status status = map.get("status").equalsIgnoreCase("UP") ? Status.Up : Status.Down;
-                Host host = new Host(map.get("public-hostname"), map.get("local-ipv4"), rack, status);
-                hosts.add(host);
-                System.out.println("Host: " + host);
-            }
-
-            return hosts;
-        } catch (Throwable e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    public void runLongTest() throws InterruptedException {
-
-        final ExecutorService threadPool = Executors.newFixedThreadPool(2);
-
-        final AtomicBoolean stop = new AtomicBoolean(false);
-        final CountDownLatch latch = new CountDownLatch(2);
-
-        final AtomicInteger success = new AtomicInteger(0);
-        final AtomicInteger failure = new AtomicInteger(0);
-        final AtomicInteger emptyReads = new AtomicInteger(0);
-
-        threadPool.submit(new Callable<Void>() {
-
-            @Override
-            public Void call() throws Exception {
-                while (!stop.get()) {
-                    System.out.println("Getting Value for key '0'");
-                    String value = client.get("0");
-                    System.out.println("Got Value for key '0' : " + value);
-                    Thread.sleep(5000);
-                }
-                latch.countDown();
-                return null;
-            }
-
-        });
-
-        threadPool.submit(new Callable<Void>() {
-
-            @Override
-            public Void call() throws Exception {
-                while (!stop.get()) {
-                    System.out.println("Success: " + success.get() + ", failure: " + failure.get() + ", emptyReads: "
-                            + emptyReads.get());
-                    Thread.sleep(1000);
-                }
-                latch.countDown();
-                return null;
-            }
-
-        });
-
-        Thread.sleep(60 * 1000);
-
-        stop.set(true);
-        latch.await();
-        threadPool.shutdownNow();
-    }
-
-    private class SAXHandler extends DefaultHandler {
-
-        private final List<Map<String, String>> list = new ArrayList<Map<String, String>>();
-        private final String rootElement;
-        private final Set<String> interestElements = new HashSet<String>();
-
-        private Map<String, String> currentPayload = null;
-        private String currentInterestElement = null;
-
-        private SAXHandler(String root, String... interests) {
-
-            rootElement = root;
-            for (String s : interests) {
-                interestElements.add(s);
-            }
-        }
-
-        @Override
-        public void startElement(String uri, String localName, String qName, Attributes attributes)
-                throws SAXException {
-
-            if (qName.equalsIgnoreCase(rootElement)) {
-                // prep for next instance
-                currentPayload = new HashMap<String, String>();
-                return;
-            }
-
-            if (interestElements.contains(qName)) {
-                // note the element to be parsed. this will be used in chars
-                // callback
-                currentInterestElement = qName;
-            }
-        }
-
-        @Override
-        public void endElement(String uri, String localName, String qName) throws SAXException {
-
-            // add host to list
-            if (qName.equalsIgnoreCase(rootElement)) {
-                list.add(currentPayload);
-                currentPayload = null;
-            }
-        }
-
-        @Override
-        public void characters(char[] ch, int start, int length) throws SAXException {
-
-            String value = new String(ch, start, length);
-
-            if (currentInterestElement != null && currentPayload != null) {
-                currentPayload.put(currentInterestElement, value);
-                currentInterestElement = null;
-            }
-        }
-
-        public List<Map<String, String>> getList() {
-            return list;
-        }
-    };
-
-    public void runEvalTest() throws Exception {
-
-        client.set("EvalTest", "true");
-        List<String> keys = Arrays.asList("EvalTest");
-        List<String> args = Arrays.asList("true");
-        Object obj = client.eval("if redis.call('get', KEYS[1]) == ARGV[1] then return redis.call('del', KEYS[1]) else return 0 end", keys, args);
-        if (obj.toString().equals("1"))
-            System.out.println("EVAL Test Succeeded");
-        else
-            System.out.println("EVAL Test Failed");
-
-    }
-
-    /**
-     *
-     * @param args
-     *            Should contain:
-     *            <ol>
-     *            dynomite_cluster_name, e.g. dyno_sandbox_quorum
-     *            </ol>
-     *            <ol>
-     *            test number, in the set: 
-     *            1 - simple test 
-     *            2 - keys test 
-     *            3 - simple test with hashtag
-     *            4-  multi-threaded 
-     *            5 - SCAN test 
-     *            6 - pipeline 
-     *            7 - run pipeline with hashtag 
-     *            7 - runn SSCAN test
-     *            </ol>
-     */
-    public static void main(String args[]) throws IOException {
-
-        if (args.length < 2) {
-            System.out.println("Incorrect number of arguments.");
-            printUsage();
-            System.exit(1);
-        }
-
-        String clusterName = args[0];
-        int testNumber = Integer.valueOf(args[1]);
-
-        Properties props = new Properties();
-        props.load(DynoJedisDemo.class.getResourceAsStream("/demo.properties"));
-        for (String name : props.stringPropertyNames()) {
-            System.setProperty(name, props.getProperty(name));
-        }
-
-        if (!props.containsKey("EC2_AVAILABILITY_ZONE") && !props.containsKey("dyno.dyno_demo.lbStrategy")) {
-            throw new IllegalArgumentException(
-                    "MUST set local for load balancing OR set the load balancing strategy to round robin");
-        }
-
-        String rack = props.getProperty("EC2_AVAILABILITY_ZONE", "us-east-1e");
-        String hostsFile = props.getProperty("dyno.demo.hostsFile");
-        int port = Integer.valueOf(props.getProperty("dyno.demo.port", "8102"));
-
-        DynoJedisDemo demo = new DynoJedisDemo(clusterName, rack);
-
-        try {
-            if (hostsFile != null) {
-                demo.initWithRemoteClusterFromFile(hostsFile, port);
-            } else {
-                demo.initWithRemoteClusterFromEurekaUrl(clusterName, port);
-            }
-
-            System.out.println("Connected");
-
-            switch (testNumber) {
-            case 1: {
-                demo.runSimpleTest();
-                break;
-            }
-            case 2: {
-                demo.runKeysTest();
-                break;
-            }
-            case 3: {
-                demo.runSimpleTestWithHashtag();
-                break;
-            }
-            case 4: {
-                demo.runMultiThreaded();
-                break;
-            }
-            case 5: {
-                final boolean writeKeys = Boolean.valueOf(props.getProperty("dyno.demo.scan.populateKeys"));
-                demo.runScanTest(writeKeys);
-                break;
-            }
-            case 6: {
-                demo.runPipeline();
-                break;
-            }
-            case 7: {
-                demo.runPipelineWithHashtag();
-                break;
-            }
-            case 8: {
-                demo.runSScanTest(true);
-                break;
-            }
-            case 9: {
-                    demo.runCompressionInPipelineTest();
-                    break;
-                }
-            case 10: {
-                    demo.runEvalTest();
-                    break;
-                }
-            }
-
-            // demo.runSinglePipeline();
-            // demo.runPipeline();
-            // demo.runBinarySinglePipeline();
-            // demo.runPipelineEmptyResult();
-            // demo.runSinglePipelineWithCompression(false);
-            // demo.runLongTest();
-            // demo.runSandboxTest();
-
-            Thread.sleep(1000);
-
-           // demo.cleanup(demo.numKeys);
-
-        } catch (Throwable e) {
-            e.printStackTrace();
-        } finally {
-            demo.stop();
-            System.out.println("Done");
-
-            System.out.flush();
-            System.err.flush();
-            System.exit(0);
-        }
-    }
-
-    protected static void printUsage() {
-        // todo
-    }
+	protected DynoJedisClient client;
+
+	protected int numKeys;
+
+	protected final String localRack;
+	protected final String clusterName;
+
+	public DynoJedisDemo(String clusterName, String localRack) {
+		this.clusterName = clusterName;
+		this.localRack = localRack;
+	}
+
+	public void initWithLocalHost() throws Exception {
+
+		final int port = 6379;
+
+		final Host localHost = new Host("localhost", port, "localrack", Status.Up);
+
+		final HostSupplier localHostSupplier = new HostSupplier() {
+
+			@Override
+			public Collection<Host> getHosts() {
+				return Collections.singletonList(localHost);
+			}
+		};
+
+		final TokenMapSupplier tokenSupplier = new TokenMapSupplier() {
+
+			final HostToken localHostToken = new HostToken(100000L, localHost);
+
+			@Override
+			public List<HostToken> getTokens(Set<Host> activeHosts) {
+				return Collections.singletonList(localHostToken);
+			}
+
+			@Override
+			public HostToken getTokenForHost(Host host, Set<Host> activeHosts) {
+				return localHostToken;
+			}
+		};
+
+		init(localHostSupplier, port, tokenSupplier);
+	}
+
+	private void initWithRemoteCluster(final List<Host> hosts, final int port) throws Exception {
+		final HostSupplier clusterHostSupplier = new HostSupplier() {
+
+			@Override
+			public Collection<Host> getHosts() {
+				return hosts;
+			}
+		};
+
+		init(clusterHostSupplier, port, null);
+	}
+
+	public void initWithRemoteClusterFromFile(final String filename, final int port) throws Exception {
+		initWithRemoteCluster(readHostsFromFile(filename, port), port);
+	}
+
+	public void initWithRemoteClusterFromEurekaUrl(final String clusterName, final int port) throws Exception {
+		initWithRemoteCluster(getHostsFromDiscovery(clusterName), port);
+	}
+
+	public void init(HostSupplier hostSupplier, int port, TokenMapSupplier tokenSupplier) throws Exception {
+
+		client = new DynoJedisClient.Builder().withApplicationName("demo").withDynomiteClusterName("dyno_dev")
+				.withHostSupplier(hostSupplier)
+				// .withCPConfig(
+				// new ConnectionPoolConfigurationImpl("demo")
+				// .setCompressionStrategy(ConnectionPoolConfiguration.CompressionStrategy.THRESHOLD)
+				// .setCompressionThreshold(2048)
+				// .setLocalRack(this.localRack)
+				// )
+				.build();
+	}
+
+	public void runSimpleTest() throws Exception {
+
+		this.numKeys = 10;
+		System.out.println("Simple test selected");
+
+		// write
+		for (int i = 0; i < numKeys; i++) {
+			System.out.println("Writing key/value => DynoClientTest-" + i + " / " + i);
+			client.set("DynoClientTest-" + i, "" + i);
+		}
+		// read
+		for (int i = 0; i < numKeys; i++) {
+			OperationResult<String> result = client.d_get("DynoClientTest-" + i);
+			System.out.println("Reading Key: " + i + ", Value: " + result.getResult() + " " + result.getNode());
+		}
+	}
+
+	/**
+	 * This tests covers the use of binary keys
+	 * 
+	 * @throws Exception
+	 */
+	public void runBinaryKeyTest() throws Exception {
+
+		System.out.println("Binary Key test selected");
+        byte[] videoInt =ByteBuffer.allocate(4).putInt(new Integer(100)).array();
+        byte[] locInt =ByteBuffer.allocate(4).putInt(new Integer(200)).array();
+        byte[] overallKey = new byte[videoInt.length + locInt.length];
+		
+		byte[] firstWindow = ByteBuffer.allocate(4).putFloat(new Float(1.25)).array();
+		byte[] secondWindow = ByteBuffer.allocate(4).putFloat(new Float(1.5)).array();
+		byte[] thirdWindow = ByteBuffer.allocate(4).putFloat(new Float(1.75)).array();
+		byte[] fourthWindow = ByteBuffer.allocate(4).putFloat(new Float(2.0)).array();
+
+		byte[] overallVal = new byte[firstWindow.length + secondWindow.length + thirdWindow.length
+				+ fourthWindow.length];
+
+		// write
+		client.set(overallKey, overallVal);
+		System.out.println("Writing Key: " + overallKey.toString());
+		
+		// read
+		OperationResult<byte[]> result = client.d_get(overallKey);
+		System.out.println("Reading Key: " + overallKey.toString() + ", Value: " + result.getResult().toString() + " " + result.getNode());
+		
+	}
+
+	/**
+	 * To run this test, the hashtag FP must be set on the Dynomite cluster. The
+	 * assumed hashtag for this test is {} hence each key is foo-{<String>}. To
+	 * validate that this test succeeds observe the cluster manually.
+	 * 
+	 * @throws Exception
+	 */
+	public void runSimpleTestWithHashtag() throws Exception {
+
+		this.numKeys = 100;
+		System.out.println("Simple test with hashtag selected");
+
+		// write
+		for (int i = 0; i < numKeys; i++) {
+			System.out.println("Writing key/value => DynoClientTest-" + i + " / " + i);
+			client.set(i + "-{bar}", " " + i);
+		}
+		// read
+		for (int i = 0; i < numKeys; i++) {
+			OperationResult<String> result = client.d_get(i + "-{bar}");
+			System.out.println(
+					"Reading Key: " + i + "-{bar}" + " , Value: " + result.getResult() + " " + result.getNode());
+		}
+	}
+
+	public void runPipelineEmptyResult() throws Exception {
+		DynoJedisPipeline pipeline = client.pipelined();
+		DynoJedisPipeline pipeline2 = client.pipelined();
+
+		try {
+			byte[] field1 = "field1".getBytes();
+			byte[] field2 = "field2".getBytes();
+
+			pipeline.hset("myHash".getBytes(), field1, "hello".getBytes());
+			pipeline.hset("myHash".getBytes(), field2, "world".getBytes());
+
+			Thread.sleep(1000);
+
+			Response<List<byte[]>> result = pipeline.hmget("myHash".getBytes(), field1, field2, "miss".getBytes());
+
+			pipeline.sync();
+
+			System.out.println("TEST-1: hmget for 2 valid results and 1 non-existent field");
+			for (int i = 0; i < result.get().size(); i++) {
+				byte[] val = result.get().get(i);
+				if (val != null) {
+					System.out.println("TEST-1:Result => " + i + ") " + new String(val));
+				} else {
+					System.out.println("TEST-1:Result => " + i + ") " + val);
+				}
+			}
+
+		} catch (Exception e) {
+			pipeline.discardPipelineAndReleaseConnection();
+			throw e;
+		}
+
+		try {
+			Response<List<byte[]>> result2 = pipeline2.hmget("foo".getBytes(), "miss1".getBytes(), "miss2".getBytes());
+
+			pipeline2.sync();
+
+			System.out.println("TEST-2: hmget when all fields (3) are not present in the hash");
+			if (result2.get() == null) {
+				System.out.println("TEST-2: result is null");
+			} else {
+				for (int i = 0; i < result2.get().size(); i++) {
+					System.out.println("TEST-2:" + Arrays.toString(result2.get().get(i)));
+				}
+			}
+		} catch (Exception e) {
+			pipeline.discardPipelineAndReleaseConnection();
+			throw e;
+		}
+	}
+
+	public void runKeysTest() throws Exception {
+		System.out.println("Writing 10,000 keys to dynomite...");
+
+		for (int i = 0; i < 500; i++) {
+			client.set("DynoClientTest_KEYS-TEST-key" + i, "value-" + i);
+		}
+
+		System.out.println("finished writing 10000 keys, querying for keys(\"DynoClientTest_KYES-TEST*\")");
+
+		Set<String> result = client.keys("DynoClientTest_KEYS-TEST*");
+
+		System.out.println("Got " + result.size() + " results, below");
+		System.out.println(result);
+	}
+
+	public void runScanTest(boolean populateKeys) throws Exception {
+		logger.info("SCAN TEST -- begin");
+
+		final String keyPattern = System.getProperty("dyno.demo.scan.key.pattern", "DynoClientTest_key-*");
+		final String keyPrefix = System.getProperty("dyno.demo.scan.key.prefix", "DynoClientTest_key-");
+
+		if (populateKeys) {
+			logger.info("Writing 500 keys to {} with prefix {}", this.clusterName, keyPrefix);
+			for (int i = 0; i < 500; i++) {
+				client.set(keyPrefix + i, "value-" + i);
+			}
+		}
+
+		logger.info("Reading keys from {} with pattern {}", this.clusterName, keyPattern);
+		CursorBasedResult<String> cbi = null;
+		do {
+			cbi = client.dyno_scan(cbi, 10000, keyPattern);
+
+			List<String> results = cbi.getStringResult();
+			for (String res : results) {
+				logger.info(res);
+			}
+		} while (!cbi.isComplete());
+
+		logger.info("SCAN TEST -- done");
+	}
+
+	public void runSScanTest(boolean populateKeys) throws Exception {
+		logger.info("SET SCAN TEST -- begin");
+
+		final String key = "DynoClientTest_Set";
+
+		if (populateKeys) {
+			logger.info("Populating set in cluster {} with key {}", this.clusterName, key);
+			for (int i = 0; i < 50; i++) {
+				client.sadd(key, "value-" + i);
+			}
+		}
+
+		logger.info("Reading members of set from cluster {} with key {}", this.clusterName, key);
+		ScanResult<String> scanResult;
+		final Set<String> matches = new HashSet<>();
+		String cursor = "0";
+		do {
+
+			final ScanParams scanParams = new ScanParams().count(10);
+			scanParams.match("*");
+			scanResult = client.sscan(key, cursor, scanParams);
+			matches.addAll(scanResult.getResult());
+			cursor = scanResult.getStringCursor();
+			if ("0".equals(cursor)) {
+				break;
+			}
+		} while (true);
+		logger.info("SET SCAN TEST -- done");
+	}
+
+	public void cleanup(int nKeys) throws Exception {
+
+		// writes for initial seeding
+		for (int i = 0; i < nKeys; i++) {
+			System.out.println("Deleting : " + i);
+			client.del("DynoDemoTest" + i);
+		}
+	}
+
+	public void runMultiThreaded() throws Exception {
+		this.runMultiThreaded(1000, true, 2, 2);
+	}
+
+	public void runMultiThreaded(final int items, boolean doSeed, final int numReaders, final int numWriters)
+			throws Exception {
+
+		final int nKeys = items;
+		if (doSeed) {
+			// writes for initial seeding
+			for (int i = 0; i < nKeys; i++) {
+				System.out.println("Writing : " + i);
+				client.set("DynoDemoTest" + i, "" + i);
+			}
+		}
+
+		final int nThreads = numReaders + numWriters + 1;
+
+		final ExecutorService threadPool = Executors.newFixedThreadPool(nThreads);
+
+		final AtomicBoolean stop = new AtomicBoolean(false);
+		final CountDownLatch latch = new CountDownLatch(nThreads);
+
+		final AtomicInteger success = new AtomicInteger(0);
+		final AtomicInteger failure = new AtomicInteger(0);
+		final AtomicInteger emptyReads = new AtomicInteger(0);
+
+		startWrites(nKeys, numWriters, threadPool, stop, latch, success, failure);
+		startReads(nKeys, numReaders, threadPool, stop, latch, success, failure, emptyReads);
+
+		threadPool.submit(new Callable<Void>() {
+
+			@Override
+			public Void call() throws Exception {
+				while (!stop.get()) {
+					System.out.println("Success: " + success.get() + ", failure: " + failure.get() + ", emptyReads: "
+							+ emptyReads.get());
+					Thread.sleep(1000);
+				}
+				latch.countDown();
+				return null;
+			}
+
+		});
+
+		Thread.sleep(15 * 1000);
+
+		stop.set(true);
+		latch.await();
+		threadPool.shutdownNow();
+
+		executePostRunActions();
+
+		System.out.println("Cleaning up keys");
+		cleanup(nKeys);
+
+		System.out.println("FINAL RESULT \nSuccess: " + success.get() + ", failure: " + failure.get() + ", emptyReads: "
+				+ emptyReads.get());
+
+	}
+
+	protected void executePostRunActions() {
+		// nothing to do here
+	}
+
+	protected void startWrites(final int nKeys, final int numWriters, final ExecutorService threadPool,
+			final AtomicBoolean stop, final CountDownLatch latch, final AtomicInteger success,
+			final AtomicInteger failure) {
+
+		for (int i = 0; i < numWriters; i++) {
+
+			threadPool.submit(new Callable<Void>() {
+
+				final Random random = new Random();
+
+				@Override
+				public Void call() throws Exception {
+
+					while (!stop.get()) {
+						int key = random.nextInt(nKeys);
+						int value = random.nextInt(nKeys);
+
+						try {
+							client.set("DynoDemoTest" + key, "" + value);
+							success.incrementAndGet();
+						} catch (Exception e) {
+							System.out.println("WRITE FAILURE: " + e.getMessage());
+							failure.incrementAndGet();
+						}
+					}
+
+					latch.countDown();
+					return null;
+				}
+
+			});
+		}
+	}
+
+	protected void startReads(final int nKeys, final int numReaders, final ExecutorService threadPool,
+			final AtomicBoolean stop, final CountDownLatch latch, final AtomicInteger success,
+			final AtomicInteger failure, final AtomicInteger emptyReads) {
+
+		for (int i = 0; i < numReaders; i++) {
+
+			threadPool.submit(new Callable<Void>() {
+
+				final Random random = new Random();
+
+				@Override
+				public Void call() throws Exception {
+
+					while (!stop.get()) {
+						int key = random.nextInt(nKeys);
+
+						try {
+							String value = client.get("DynoDemoTest" + key);
+							success.incrementAndGet();
+							if (value == null || value.isEmpty()) {
+								emptyReads.incrementAndGet();
+							}
+						} catch (Exception e) {
+							System.out.println("READ FAILURE: " + e.getMessage());
+							failure.incrementAndGet();
+						}
+					}
+
+					latch.countDown();
+					return null;
+				}
+			});
+		}
+	}
+
+	public void stop() {
+		if (client != null) {
+			client.stopClient();
+		}
+	}
+
+	private List<Host> readHostsFromFile(String filename, int port) throws Exception {
+
+		List<Host> hosts = new ArrayList<Host>();
+		File file = new File(filename);
+		BufferedReader reader = new BufferedReader(new FileReader(file));
+
+		try {
+			String line = null;
+			while ((line = reader.readLine()) != null) {
+				if (line.trim().isEmpty()) {
+					continue;
+				}
+				String[] parts = line.trim().split(" ");
+				if (parts.length != 2) {
+					throw new RuntimeException("Bad data format in file:" + line);
+				}
+				Host host = new Host(parts[0].trim(), port, parts[1].trim(), Status.Up);
+				hosts.add(host);
+			}
+		} finally {
+			reader.close();
+		}
+		return hosts;
+	}
+
+	public void runBinarySinglePipeline() throws Exception {
+
+		for (int i = 0; i < 10; i++) {
+			DynoJedisPipeline pipeline = client.pipelined();
+
+			Map<byte[], byte[]> bar = new HashMap<byte[], byte[]>();
+			bar.put("key__1".getBytes(), "value__1".getBytes());
+			bar.put("key__2".getBytes(), "value__2".getBytes());
+
+			Response<String> hmsetResult = pipeline.hmset(("hash__" + i).getBytes(), bar);
+
+			pipeline.sync();
+
+			System.out.println(hmsetResult.get());
+		}
+
+		System.out.println("Reading all keys");
+
+		DynoJedisPipeline readPipeline = client.pipelined();
+		Response<Map<byte[], byte[]>> resp = readPipeline.hgetAll("hash__1".getBytes());
+		readPipeline.sync();
+
+		StringBuilder sb = new StringBuilder();
+		for (byte[] bytes : resp.get().keySet()) {
+			if (sb.length() > 0) {
+				sb.append(",");
+			}
+			sb.append(new String(bytes));
+		}
+		System.out.println("Got hash :" + sb.toString());
+	}
+
+	public void runCompressionInPipelineTest() throws Exception {
+		final int maxNumKeys = 100;
+		final int maxPipelineSize = 10;
+		final int maxOperations = 500;
+		final Random rand = new Random();
+
+		for (int operationIter = 0; operationIter < maxOperations; operationIter++) {
+
+			DynoJedisPipeline pipeline = client.pipelined();
+			int pipelineSize = 1 + rand.nextInt(maxPipelineSize);
+
+			// key to be used in pipeline
+			String key = "hash__" + rand.nextInt(maxNumKeys);
+
+			// Map of field -> value
+			Map<String, String> map = new HashMap<>();
+
+			// List of fields to be later used in HMGet
+			List<String> fields = new ArrayList<>(pipelineSize);
+
+			// Create a map of field -> value, also accumulate all fields
+			for (int pipelineIter = 0; pipelineIter < pipelineSize; pipelineIter++) {
+				String field = "field_" + pipelineIter;
+				fields.add(field);
+				String prefixSuffix = key + "_" + field;
+				String value = prefixSuffix + "_" + generateValue(pipelineIter) + "_" + prefixSuffix;
+				map.put(field, value);
+			}
+
+			Response<String> HMSetResult = pipeline.hmset(key, map);
+			Response<List<String>> HMGetResult = pipeline.hmget(key, fields.toArray(new String[fields.size()]));
+			try {
+				pipeline.sync();
+			} catch (Exception e) {
+				pipeline.discardPipelineAndReleaseConnection();
+				System.out.println("Exception while writing key " + key + " fields: " + fields);
+				throw e;
+			}
+
+			if (!HMSetResult.get().equals("OK")) {
+				System.out.println("Result mismatch for HMSet key: '" + key + "' fields: '" + fields + "' result: '"
+						+ HMSetResult.get() + "'");
+			}
+			if ((operationIter % 100) == 0) {
+				System.out.println("\n>>>>>>>> " + operationIter + " operations performed....");
+			}
+			List<String> HMGetResultStrings = HMGetResult.get();
+			for (int i = 0; i < HMGetResultStrings.size(); i++) {
+				String prefixSuffix = key + "_" + fields.get(i);
+				String value = HMGetResultStrings.get(i);
+				if (value.startsWith(prefixSuffix) && value.endsWith(prefixSuffix)) {
+					continue;
+				} else {
+					System.out.println("Result mismatch key: '" + key + "' field: '" + fields.get(i) + "' value: '"
+							+ HMGetResultStrings.get(i) + "'");
+				}
+
+			}
+		}
+		System.out.println("Compression test Done: " + maxOperations + " pipeline operations performed.");
+
+	}
+
+	public void runSandboxTest() throws Exception {
+		Set<String> keys = client.keys("zuulRules:*");
+		System.out.println("GOT KEYS");
+		System.out.println(keys.size());
+	}
+
+	private static String generateValue(int kilobytes) {
+		StringBuilder sb = new StringBuilder(kilobytes * 512); // estimating 2
+																// bytes per char
+		for (int i = 0; i < kilobytes; i++) {
+			for (int j = 0; j < 10; j++) {
+				sb.append("abcdefghijklmnopqrstuvwxzy0123456789a1b2c3d4f5g6h7"); // 50
+																					// characters
+																					// (~100
+																					// bytes)
+				sb.append(":");
+				sb.append("abcdefghijklmnopqrstuvwxzy0123456789a1b2c3d4f5g6h7");
+				sb.append(":");
+			}
+		}
+
+		return sb.toString();
+
+	}
+
+	/**
+	 * This demo runs a pipeline across ten different keys. The pipeline leverages
+	 * the hash value {bar} to determine the node where to send the data.
+	 * 
+	 * @throws Exception
+	 */
+	public void runPipelineWithHashtag() throws Exception {
+
+		DynoJedisPipeline pipeline = client.pipelined();
+		try {
+
+			pipeline.set("pipeline-hashtag1-{bar}", "value-1");
+			pipeline.set("pipeline-hashtag2-{bar}", "value-2");
+			pipeline.set("pipeline-hashtag3-{bar}", "value-3");
+			pipeline.set("pipeline-hashtag4-{bar}", "value-4");
+			pipeline.set("pipeline-hashtag5-{bar}", "value-5");
+			pipeline.set("pipeline-hashtag6-{bar}", "value-6");
+			pipeline.set("pipeline-hashtag7-{bar}", "value-7");
+			pipeline.set("pipeline-hashtag8-{bar}", "value-8");
+			pipeline.set("pipeline-hashtag9-{bar}", "value-9");
+			pipeline.set("pipeline-hashtag10-{bar}", "value-10");
+
+			Response<String> value1 = pipeline.get("pipeline-hashtag1-{bar}");
+			Response<String> value2 = pipeline.get("pipeline-hashtag2-{bar}");
+			Response<String> value3 = pipeline.get("pipeline-hashtag3-{bar}");
+			Response<String> value4 = pipeline.get("pipeline-hashtag4-{bar}");
+			Response<String> value5 = pipeline.get("pipeline-hashtag5-{bar}");
+			Response<String> value6 = pipeline.get("pipeline-hashtag6-{bar}");
+			pipeline.sync();
+
+			System.out.println(value1.get());
+			System.out.println(value2.get());
+			System.out.println(value3.get());
+			System.out.println(value4.get());
+			System.out.println(value5.get());
+			System.out.println(value6.get());
+		} catch (Exception e) {
+			pipeline.discardPipelineAndReleaseConnection();
+			throw e;
+		}
+	}
+
+	public void runPipeline() throws Exception {
+
+		int numThreads = 5;
+
+		final ExecutorService threadPool = Executors.newFixedThreadPool(numThreads);
+		final AtomicBoolean stop = new AtomicBoolean(false);
+		final CountDownLatch latch = new CountDownLatch(numThreads);
+
+		for (int i = 0; i < numThreads; i++) {
+			threadPool.submit(new Callable<Void>() {
+
+				final Random rand = new Random();
+
+				@Override
+				public Void call() throws Exception {
+
+					final AtomicInteger iter = new AtomicInteger(0);
+
+					while (!stop.get()) {
+						int index = rand.nextInt(5);
+						int i = iter.incrementAndGet();
+						DynoJedisPipeline pipeline = client.pipelined();
+
+						try {
+							Response<Long> resultA1 = pipeline.hset("DynoJedisDemo_pipeline-" + index, "a1",
+									constructRandomValue(index));
+							Response<Long> resultA2 = pipeline.hset("DynoJedisDemo_pipeline-" + index, "a2",
+									"value-" + i);
+
+							pipeline.sync();
+
+							System.out.println(resultA1.get() + " " + resultA2.get());
+
+						} catch (Exception e) {
+							pipeline.discardPipelineAndReleaseConnection();
+							throw e;
+						}
+
+					}
+					latch.countDown();
+					return null;
+				}
+			});
+		}
+
+		Thread.sleep(5000);
+		stop.set(true);
+		latch.await();
+
+		threadPool.shutdownNow();
+	}
+
+	private String constructRandomValue(int sizeInKB) {
+
+		int requriredLength = sizeInKB * 1024;
+
+		String s = randomValue;
+		int sLength = s.length();
+
+		StringBuilder sb = new StringBuilder();
+		int lengthSoFar = 0;
+
+		do {
+			sb.append(s);
+			lengthSoFar += sLength;
+		} while (lengthSoFar < requriredLength);
+
+		String ss = sb.toString();
+
+		if (ss.length() > requriredLength) {
+			ss = sb.substring(0, requriredLength);
+		}
+
+		return ss;
+	}
+
+	private List<Host> getHostsFromDiscovery(final String clusterName) {
+
+		String env = System.getProperty("netflix.environment", "test");
+		String discoveryKey = String.format("dyno.demo.discovery.%s", env);
+
+		if (!System.getProperties().containsKey(discoveryKey)) {
+			throw new IllegalArgumentException("Discovery URL not found");
+		}
+
+		String region = System.getProperty("EC2_REGION");
+		final String discoveryUrl = String.format(System.getProperty(discoveryKey), region);
+
+		final String url = String.format("http://%s/%s", discoveryUrl, clusterName);
+
+		HttpClient client = new DefaultHttpClient();
+		try {
+			HttpResponse response = client.execute(new HttpGet(url));
+			InputStream in = response.getEntity().getContent();
+
+			SAXParserFactory parserFactor = SAXParserFactory.newInstance();
+
+			SAXParser parser = parserFactor.newSAXParser();
+			SAXHandler handler = new SAXHandler("instance", "public-hostname", "availability-zone", "status",
+					"local-ipv4");
+			parser.parse(in, handler);
+
+			List<Host> hosts = new ArrayList<Host>();
+
+			for (Map<String, String> map : handler.getList()) {
+				String rack = map.get("availability-zone");
+				Status status = map.get("status").equalsIgnoreCase("UP") ? Status.Up : Status.Down;
+				Host host = new Host(map.get("public-hostname"), map.get("local-ipv4"), rack, status);
+				hosts.add(host);
+				System.out.println("Host: " + host);
+			}
+
+			return hosts;
+		} catch (Throwable e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	public void runLongTest() throws InterruptedException {
+
+		final ExecutorService threadPool = Executors.newFixedThreadPool(2);
+
+		final AtomicBoolean stop = new AtomicBoolean(false);
+		final CountDownLatch latch = new CountDownLatch(2);
+
+		final AtomicInteger success = new AtomicInteger(0);
+		final AtomicInteger failure = new AtomicInteger(0);
+		final AtomicInteger emptyReads = new AtomicInteger(0);
+
+		threadPool.submit(new Callable<Void>() {
+
+			@Override
+			public Void call() throws Exception {
+				while (!stop.get()) {
+					System.out.println("Getting Value for key '0'");
+					String value = client.get("0");
+					System.out.println("Got Value for key '0' : " + value);
+					Thread.sleep(5000);
+				}
+				latch.countDown();
+				return null;
+			}
+
+		});
+
+		threadPool.submit(new Callable<Void>() {
+
+			@Override
+			public Void call() throws Exception {
+				while (!stop.get()) {
+					System.out.println("Success: " + success.get() + ", failure: " + failure.get() + ", emptyReads: "
+							+ emptyReads.get());
+					Thread.sleep(1000);
+				}
+				latch.countDown();
+				return null;
+			}
+
+		});
+
+		Thread.sleep(60 * 1000);
+
+		stop.set(true);
+		latch.await();
+		threadPool.shutdownNow();
+	}
+
+	private class SAXHandler extends DefaultHandler {
+
+		private final List<Map<String, String>> list = new ArrayList<Map<String, String>>();
+		private final String rootElement;
+		private final Set<String> interestElements = new HashSet<String>();
+
+		private Map<String, String> currentPayload = null;
+		private String currentInterestElement = null;
+
+		private SAXHandler(String root, String... interests) {
+
+			rootElement = root;
+			for (String s : interests) {
+				interestElements.add(s);
+			}
+		}
+
+		@Override
+		public void startElement(String uri, String localName, String qName, Attributes attributes)
+				throws SAXException {
+
+			if (qName.equalsIgnoreCase(rootElement)) {
+				// prep for next instance
+				currentPayload = new HashMap<String, String>();
+				return;
+			}
+
+			if (interestElements.contains(qName)) {
+				// note the element to be parsed. this will be used in chars
+				// callback
+				currentInterestElement = qName;
+			}
+		}
+
+		@Override
+		public void endElement(String uri, String localName, String qName) throws SAXException {
+
+			// add host to list
+			if (qName.equalsIgnoreCase(rootElement)) {
+				list.add(currentPayload);
+				currentPayload = null;
+			}
+		}
+
+		@Override
+		public void characters(char[] ch, int start, int length) throws SAXException {
+
+			String value = new String(ch, start, length);
+
+			if (currentInterestElement != null && currentPayload != null) {
+				currentPayload.put(currentInterestElement, value);
+				currentInterestElement = null;
+			}
+		}
+
+		public List<Map<String, String>> getList() {
+			return list;
+		}
+	};
+
+	public void runEvalTest() throws Exception {
+
+		client.set("EvalTest", "true");
+		List<String> keys = Arrays.asList("EvalTest");
+		List<String> args = Arrays.asList("true");
+		Object obj = client.eval(
+				"if redis.call('get', KEYS[1]) == ARGV[1] then return redis.call('del', KEYS[1]) else return 0 end",
+				keys, args);
+		if (obj.toString().equals("1"))
+			System.out.println("EVAL Test Succeeded");
+		else
+			System.out.println("EVAL Test Failed");
+
+	}
+
+	/**
+	 *
+	 * @param args
+	 *            Should contain:
+	 *            <ol>
+	 *            dynomite_cluster_name, e.g. dyno_sandbox_quorum
+	 *            </ol>
+	 *            <ol>
+	 *            test number, in the set: 1 - simple test 2 - keys test 3 - simple
+	 *            test with hashtag 4- multi-threaded 5 - SCAN test 6 - pipeline 7 -
+	 *            run pipeline with hashtag 7 - runn SSCAN test
+	 *            </ol>
+	 */
+	public static void main(String args[]) throws IOException {
+
+		if (args.length < 2) {
+			System.out.println("Incorrect number of arguments.");
+			printUsage();
+			System.exit(1);
+		}
+
+		String clusterName = args[0];
+		int testNumber = Integer.valueOf(args[1]);
+
+		Properties props = new Properties();
+		props.load(DynoJedisDemo.class.getResourceAsStream("/demo.properties"));
+		for (String name : props.stringPropertyNames()) {
+			System.setProperty(name, props.getProperty(name));
+		}
+
+		if (!props.containsKey("EC2_AVAILABILITY_ZONE") && !props.containsKey("dyno.dyno_demo.lbStrategy")) {
+			throw new IllegalArgumentException(
+					"MUST set local for load balancing OR set the load balancing strategy to round robin");
+		}
+
+		String rack = props.getProperty("EC2_AVAILABILITY_ZONE", "us-east-1e");
+		String hostsFile = props.getProperty("dyno.demo.hostsFile");
+		int port = Integer.valueOf(props.getProperty("dyno.demo.port", "8102"));
+
+		DynoJedisDemo demo = new DynoJedisDemo(clusterName, rack);
+
+		try {
+			if (hostsFile != null) {
+				demo.initWithRemoteClusterFromFile(hostsFile, port);
+			} else {
+				demo.initWithRemoteClusterFromEurekaUrl(clusterName, port);
+			}
+
+			System.out.println("Connected");
+
+			switch (testNumber) {
+			case 1: {
+				demo.runSimpleTest();
+				break;
+			}
+			case 2: {
+				demo.runKeysTest();
+				break;
+			}
+			case 3: {
+				demo.runSimpleTestWithHashtag();
+				break;
+			}
+			case 4: {
+				demo.runMultiThreaded();
+				break;
+			}
+			case 5: {
+				final boolean writeKeys = Boolean.valueOf(props.getProperty("dyno.demo.scan.populateKeys"));
+				demo.runScanTest(writeKeys);
+				break;
+			}
+			case 6: {
+				demo.runPipeline();
+				break;
+			}
+			case 7: {
+				demo.runPipelineWithHashtag();
+				break;
+			}
+			case 8: {
+				demo.runSScanTest(true);
+				break;
+			}
+			case 9: {
+				demo.runCompressionInPipelineTest();
+				break;
+			}
+			case 10: {
+				demo.runEvalTest();
+				break;
+			}
+
+			case 11: {
+				demo.runBinaryKeyTest();
+				break;
+			}
+			}
+
+			// demo.runSinglePipeline();
+			// demo.runPipeline();
+			// demo.runBinarySinglePipeline();
+			// demo.runPipelineEmptyResult();
+			// demo.runSinglePipelineWithCompression(false);
+			// demo.runLongTest();
+			// demo.runSandboxTest();
+
+			Thread.sleep(1000);
+
+			// demo.cleanup(demo.numKeys);
+
+		} catch (Throwable e) {
+			e.printStackTrace();
+		} finally {
+			demo.stop();
+			System.out.println("Done");
+
+			System.out.flush();
+			System.err.flush();
+			System.exit(0);
+		}
+	}
+
+	protected static void printUsage() {
+		// todo
+	}
 }

--- a/dyno-demo/src/main/java/com/netflix/dyno/demo/redis/DynoJedisDemo.java
+++ b/dyno-demo/src/main/java/com/netflix/dyno/demo/redis/DynoJedisDemo.java
@@ -21,6 +21,7 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
 import java.util.*;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
@@ -170,13 +171,15 @@ public class DynoJedisDemo {
 		byte[] overallVal = new byte[firstWindow.length + secondWindow.length + thirdWindow.length
 				+ fourthWindow.length];
 
+        byte[] newKey = new byte[videoInt.length+locInt.length];
+		
 		// write
 		client.set(overallKey, overallVal);
-		System.out.println("Writing Key: " + overallKey.toString());
+		System.out.println("Writing Key: " +  new String(overallKey, Charset.forName("UTF-8")));
 		
 		// read
-		OperationResult<byte[]> result = client.d_get(overallKey);
-		System.out.println("Reading Key: " + overallKey.toString() + ", Value: " + result.getResult().toString() + " " + result.getNode());
+		OperationResult<byte[]> result = client.d_get(newKey);
+		System.out.println("Reading Key: " + new String(newKey, Charset.forName("UTF-8")) + ", Value: " + result.getResult().toString() + " " + result.getNode());
 		
 	}
 

--- a/dyno-jedis/src/main/java/com/netflix/dyno/jedis/DynoJedisClient.java
+++ b/dyno-jedis/src/main/java/com/netflix/dyno/jedis/DynoJedisClient.java
@@ -410,7 +410,6 @@ public class DynoJedisClient implements JedisCommands, BinaryJedisCommands, Mult
             public Long execute(Jedis client, ConnectionContext state) {
                 return client.expire(key, seconds);
             }
-
         });
     }
 
@@ -1421,7 +1420,6 @@ public class DynoJedisClient implements JedisCommands, BinaryJedisCommands, Mult
                 }
             });
         }
-
     }
 
     @Override
@@ -2863,13 +2861,13 @@ public class DynoJedisClient implements JedisCommands, BinaryJedisCommands, Mult
     }
 
     public OperationResult<byte[]> d_get(final byte[] key) {
-        return connPool.executeWithFailover(new BaseKeyOperation<byte[]>(key, OpName.GET) {
-            @Override
-            public byte[] execute(Jedis client, ConnectionContext state) throws DynoException {
-                return client.get(key);
-            }
-        });
 
+            return connPool.executeWithFailover(new BaseKeyOperation<byte[]>(key, OpName.GET) {
+                @Override
+                public byte[] execute(Jedis client, ConnectionContext state) throws DynoException {
+                    return client.get(key);
+                }
+            });
     }
 
     @Override
@@ -2887,13 +2885,34 @@ public class DynoJedisClient implements JedisCommands, BinaryJedisCommands, Mult
     }
 
     @Override
-    public String set(byte[] key, byte[] value, byte[] nxxx, byte[] expx, long time) {
-        throw new UnsupportedOperationException("not yet implemented");
+    public String set(final byte[] key, final byte[] value, final byte[] nxxx, final byte[] expx, final long time) {
+        return d_set(key, value, nxxx, expx, time).getResult();
     }
 
+    public OperationResult<String> d_set(final byte[] key, final byte[] value, final byte[] nxxx, final byte[] expx,
+            final long time) {
+            return connPool.executeWithFailover(new BaseKeyOperation<String>(key, OpName.SET) {
+                @Override
+                public String execute(Jedis client, ConnectionContext state) throws DynoException {
+                    return client.set(key, value, nxxx, expx, time);
+                }
+            });
+    }
+
+
     @Override
-    public Boolean exists(byte[] key) {
-        throw new UnsupportedOperationException("not yet implemented");
+    public Boolean exists(final byte[] key) {
+        return d_exists(key).getResult();
+    }
+
+    public OperationResult<Boolean> d_exists(final byte[] key) {
+        return connPool.executeWithFailover(new BaseKeyOperation<Boolean>(key, OpName.EXISTS) {
+
+            @Override
+            public Boolean execute(Jedis client, ConnectionContext state) {
+                return client.exists(key);
+            }
+        });
     }
 
     @Override
@@ -2907,9 +2926,21 @@ public class DynoJedisClient implements JedisCommands, BinaryJedisCommands, Mult
     }
 
     @Override
-    public Long expire(byte[] key, int seconds) {
-        throw new UnsupportedOperationException("not yet implemented");
+    public Long expire(final byte[] key, final int seconds) {
+        return d_expire(key, seconds).getResult();
     }
+
+    public OperationResult<Long> d_expire(final byte[] key, final int seconds) {
+
+        return connPool.executeWithFailover(new BaseKeyOperation<Long>(key, OpName.EXPIRE) {
+
+            @Override
+            public Long execute(Jedis client, ConnectionContext state) {
+                return client.expire(key, seconds);
+            }
+        });
+    }
+
 
     @Override
     public Long pexpire(byte[] key, final long milliseconds) {
@@ -2917,8 +2948,20 @@ public class DynoJedisClient implements JedisCommands, BinaryJedisCommands, Mult
     }
 
     @Override
-    public Long expireAt(byte[] key, long unixTime) {
-        throw new UnsupportedOperationException("not yet implemented");
+    public Long expireAt(final byte[] key, final long unixTime) {
+        return d_expireAt(key, unixTime).getResult();
+    }
+
+    public OperationResult<Long> d_expireAt(final byte[] key, final long unixTime) {
+
+        return connPool.executeWithFailover(new BaseKeyOperation<Long>(key, OpName.EXPIREAT) {
+
+            @Override
+            public Long execute(Jedis client, ConnectionContext state) {
+                return client.expireAt(key, unixTime);
+            }
+
+        });
     }
 
     @Override
@@ -2927,8 +2970,20 @@ public class DynoJedisClient implements JedisCommands, BinaryJedisCommands, Mult
     }
 
     @Override
-    public Long ttl(byte[] key) {
-        throw new UnsupportedOperationException("not yet implemented");
+    public Long ttl(final byte[] key) {
+        return d_ttl(key).getResult();
+    }
+
+    public OperationResult<Long> d_ttl(final byte[] key) {
+
+        return connPool.executeWithFailover(new BaseKeyOperation<Long>(key, OpName.TTL) {
+
+            @Override
+            public Long execute(Jedis client, ConnectionContext state) {
+                return client.ttl(key);
+            }
+
+        });
     }
 
     @Override
@@ -3002,13 +3057,31 @@ public class DynoJedisClient implements JedisCommands, BinaryJedisCommands, Mult
     }
 
     @Override
-    public Long hset(byte[] key, byte[] field, byte[] value) {
-        throw new UnsupportedOperationException("not yet implemented");
+    public Long hset(final byte[] key, final byte[] field, final byte[] value) {
+        return d_hset(key, field, value).getResult();
+    }
+
+    public OperationResult<Long> d_hset(final byte[] key, final byte[] field, final byte[] value) {
+            return connPool.executeWithFailover(new BaseKeyOperation<Long>(key, OpName.HSET) {
+                @Override
+                public Long execute(Jedis client, ConnectionContext state) {
+                    return client.hset(key, field, value);
+                }
+            });
     }
 
     @Override
-    public byte[] hget(byte[] key, byte[] field) {
-        throw new UnsupportedOperationException("not yet implemented");
+    public byte[] hget(final byte[] key, final byte[] field) {
+        return d_hget(key, field).getResult();
+    }
+
+    public OperationResult<byte[]> d_hget(final byte[] key, final byte[] field) {
+            return connPool.executeWithFailover(new BaseKeyOperation<byte[]>(key, OpName.HGET) {
+                @Override
+                public byte[] execute(Jedis client, ConnectionContext state) throws DynoException {
+                    return client.hget(key, field);
+                }
+            });       
     }
 
     @Override
@@ -3017,13 +3090,31 @@ public class DynoJedisClient implements JedisCommands, BinaryJedisCommands, Mult
     }
 
     @Override
-    public String hmset(byte[] key, Map<byte[], byte[]> hash) {
-        throw new UnsupportedOperationException("not yet implemented");
+    public String hmset(final byte[] key, final Map<byte[], byte[]> hash) {
+        return d_hmset(key, hash).getResult();
+    }
+
+    public OperationResult<String> d_hmset(final byte[] key, final Map<byte[], byte[]> hash) {
+            return connPool.executeWithFailover(new BaseKeyOperation<String>(key, OpName.HMSET) {
+                @Override
+                public String execute(Jedis client, ConnectionContext state) {
+                    return client.hmset(key, hash);
+                }
+            });
     }
 
     @Override
-    public List<byte[]> hmget(byte[] key, byte[]... fields) {
-        throw new UnsupportedOperationException("not yet implemented");
+    public List<byte[]> hmget(final byte[] key, final byte[]... fields) {
+        return d_hmget(key, fields).getResult();
+    }
+
+    public OperationResult<List<byte[]>> d_hmget(final byte[] key, final byte[]... fields) {
+            return connPool.executeWithFailover(new BaseKeyOperation<List<byte[]>>(key, OpName.HMGET) {
+                @Override
+                public List<byte[]> execute(Jedis client, ConnectionContext state) {
+                    return client.hmget(key, fields);
+                }
+            });
     }
 
     @Override
@@ -3042,18 +3133,54 @@ public class DynoJedisClient implements JedisCommands, BinaryJedisCommands, Mult
     }
 
     @Override
-    public Long hdel(byte[] key, byte[]... field) {
-        throw new UnsupportedOperationException("not yet implemented");
+    public Long hdel(final byte[] key, final byte[]... fields) {
+        return d_hdel(key, fields).getResult();
+    }
+
+    public OperationResult<Long> d_hdel(final byte[] key, final byte[]... fields) {
+
+        return connPool.executeWithFailover(new BaseKeyOperation<Long>(key, OpName.HDEL) {
+
+            @Override
+            public Long execute(Jedis client, ConnectionContext state) {
+                return client.hdel(key, fields);
+            }
+
+        });
     }
 
     @Override
-    public Long hlen(byte[] key) {
-        throw new UnsupportedOperationException("not yet implemented");
+    public Long hlen(final byte[] key) {
+        return d_hlen(key).getResult();
+    }
+
+    public OperationResult<Long> d_hlen(final byte[] key) {
+
+        return connPool.executeWithFailover(new BaseKeyOperation<Long>(key, OpName.HLEN) {
+
+            @Override
+            public Long execute(Jedis client, ConnectionContext state) {
+                return client.hlen(key);
+            }
+
+        });
     }
 
     @Override
-    public Set<byte[]> hkeys(byte[] key) {
-        throw new UnsupportedOperationException("not yet implemented");
+    public Set<byte[]> hkeys(final byte[] key) {
+        return d_hkeys(key).getResult();
+    }
+
+    public OperationResult<Set<byte[]>> d_hkeys(final byte[] key) {
+
+        return connPool.executeWithFailover(new BaseKeyOperation<Set<byte[]>>(key, OpName.HKEYS) {
+
+            @Override
+            public Set<byte[]> execute(Jedis client, ConnectionContext state) {
+                return client.hkeys(key);
+            }
+
+        });
     }
 
     @Override
@@ -3062,8 +3189,17 @@ public class DynoJedisClient implements JedisCommands, BinaryJedisCommands, Mult
     }
 
     @Override
-    public Map<byte[], byte[]> hgetAll(byte[] key) {
-        throw new UnsupportedOperationException("not yet implemented");
+    public Map<byte[], byte[]> hgetAll(final  byte[] key) {
+        return d_hgetAll(key).getResult();
+    }
+
+    public OperationResult<Map< byte[],  byte[]>> d_hgetAll(final  byte[] key) {
+            return connPool.executeWithFailover(new BaseKeyOperation<Map< byte[],  byte[]>>(key, OpName.HGETALL) {
+                @Override
+                public Map< byte[], byte[]> execute(Jedis client, ConnectionContext state) throws DynoException {
+                    return client.hgetAll(key);
+                }
+            });
     }
 
     @Override
@@ -3117,23 +3253,69 @@ public class DynoJedisClient implements JedisCommands, BinaryJedisCommands, Mult
     }
 
     @Override
-    public Long sadd(byte[] key, byte[]... member) {
-        throw new UnsupportedOperationException("not yet implemented");
+    public Long sadd(final byte[] key, final byte[]... members) {
+        return d_sadd(key, members).getResult();
+    }
+
+    public OperationResult<Long> d_sadd(final byte[] key, final byte[]... members) {
+
+        return connPool.executeWithFailover(new BaseKeyOperation<Long>(key, OpName.SADD) {
+
+            @Override
+            public Long execute(Jedis client, ConnectionContext state) {
+                return client.sadd(key, members);
+            }
+
+        });
     }
 
     @Override
-    public Set<byte[]> smembers(byte[] key) {
-        throw new UnsupportedOperationException("not yet implemented");
+    public Set<byte[]> smembers(final byte[] key) {
+        return d_smembers(key).getResult();
+    }
+
+    public OperationResult<Set<byte[]>> d_smembers(final byte[] key) {
+
+        return connPool.executeWithFailover(new BaseKeyOperation<Set<byte[]>>(key, OpName.SMEMBERS) {
+
+            @Override
+            public Set<byte[]> execute(Jedis client, ConnectionContext state) {
+                return client.smembers(key);
+            }
+        });
     }
 
     @Override
-    public Long srem(byte[] key, byte[]... member) {
-        throw new UnsupportedOperationException("not yet implemented");
+    public Long srem(final byte[] key, final byte[]... members) {
+        return d_srem(key, members).getResult();
+    }
+
+    public OperationResult<Long> d_srem(final byte[] key, final byte[]... members) {
+
+        return connPool.executeWithFailover(new BaseKeyOperation<Long>(key, OpName.SREM) {
+
+            @Override
+            public Long execute(Jedis client, ConnectionContext state) {
+                return client.srem(key, members);
+            }
+
+        });
     }
 
     @Override
-    public byte[] spop(byte[] key) {
-        throw new UnsupportedOperationException("not yet implemented");
+    public byte[] spop(final byte[] key) {
+        return d_spop(key).getResult();
+    }
+
+    public OperationResult< byte[]> d_spop(final byte[] key) {
+
+        return connPool.executeWithFailover(new BaseKeyOperation< byte[]>(key, OpName.SPOP) {
+
+            @Override
+            public  byte[] execute(Jedis client, ConnectionContext state) {
+                return client.spop(key);
+            }
+        });
     }
 
     @Override
@@ -3142,10 +3324,21 @@ public class DynoJedisClient implements JedisCommands, BinaryJedisCommands, Mult
     }
 
     @Override
-    public Long scard(byte[] key) {
-        throw new UnsupportedOperationException("not yet implemented");
+    public Long scard(final byte[] key) {
+        return d_scard(key).getResult();
     }
 
+    public OperationResult<Long> d_scard(final byte[] key) {
+
+        return connPool.executeWithFailover(new BaseKeyOperation<Long>(key, OpName.SCARD) {
+
+            @Override
+            public Long execute(Jedis client, ConnectionContext state) {
+                return client.scard(key);
+            }
+
+        });
+    }
     @Override
     public Boolean sismember(byte[] key, byte[] member) {
         throw new UnsupportedOperationException("not yet implemented");
@@ -3162,8 +3355,20 @@ public class DynoJedisClient implements JedisCommands, BinaryJedisCommands, Mult
     }
 
     @Override
-    public Long strlen(byte[] key) {
-        throw new UnsupportedOperationException("not yet implemented");
+    public Long strlen(final byte[] key) {
+        return d_strlen(key).getResult();
+    }
+
+    public OperationResult<Long> d_strlen(final  byte[] key) {
+
+        return connPool.executeWithFailover(new BaseKeyOperation<Long>(key, OpName.STRLEN) {
+
+            @Override
+            public Long execute(Jedis client, ConnectionContext state) {
+                return client.strlen(key);
+            }
+
+        });
     }
 
     @Override
@@ -3217,15 +3422,39 @@ public class DynoJedisClient implements JedisCommands, BinaryJedisCommands, Mult
     }
 
     @Override
-    public Long zcard(byte[] key) {
-        throw new UnsupportedOperationException("not yet implemented");
+    public Long zcard(final byte[] key) {
+        return d_zcard(key).getResult();
+    }
+
+    public OperationResult<Long> d_zcard(final byte[] key) {
+
+        return connPool.executeWithFailover(new BaseKeyOperation<Long>(key, OpName.ZCARD) {
+
+            @Override
+            public Long execute(Jedis client, ConnectionContext state) {
+                return client.zcard(key);
+            }
+
+        });
     }
 
     @Override
-    public Double zscore(byte[] key, byte[] member) {
-        throw new UnsupportedOperationException("not yet implemented");
+    public Double zscore(final byte[] key, final byte[] member) {
+        return d_zscore(key, member).getResult();
     }
 
+    public OperationResult<Double> d_zscore(final byte[] key, final byte[] member) {
+
+        return connPool.executeWithFailover(new BaseKeyOperation<Double>(key, OpName.ZSCORE) {
+
+            @Override
+            public Double execute(Jedis client, ConnectionContext state) {
+                return client.zscore(key, member);
+            }
+
+        });
+    }
+    
     @Override
     public List<byte[]> sort(byte[] key) {
         throw new UnsupportedOperationException("not yet implemented");
@@ -3397,8 +3626,20 @@ public class DynoJedisClient implements JedisCommands, BinaryJedisCommands, Mult
     }
 
     @Override
-    public Long del(byte[] key) {
-        throw new UnsupportedOperationException("not yet implemented");
+    public Long del(final byte[] key) {
+        return d_del(key).getResult();
+    }
+
+    public OperationResult<Long> d_del(final byte[] key) {
+
+        return connPool.executeWithFailover(new BaseKeyOperation<Long>(key, OpName.DEL) {
+
+            @Override
+            public Long execute(Jedis client, ConnectionContext state) {
+                return client.del(key);
+            }
+
+        });
     }
 
     @Override
@@ -3923,7 +4164,7 @@ public class DynoJedisClient implements JedisCommands, BinaryJedisCommands, Mult
     public Long zadd(byte[] arg0, double arg1, byte[] arg2, ZAddParams arg3) {
         throw new UnsupportedOperationException("not yet implemented");
     }
-
+    
     @Override
     public Double zincrby(byte[] arg0, double arg1, byte[] arg2, ZIncrByParams arg3) {
         throw new UnsupportedOperationException("not yet implemented");

--- a/dyno-jedis/src/main/java/com/netflix/dyno/jedis/DynoJedisClient.java
+++ b/dyno-jedis/src/main/java/com/netflix/dyno/jedis/DynoJedisClient.java
@@ -96,7 +96,7 @@ public class DynoJedisClient implements JedisCommands, BinaryJedisCommands, Mult
 
         private BaseKeyOperation(final byte[] k, final OpName o) {
             this.key = null;
-            this.binaryKey = null;
+            this.binaryKey = k;
             this.op = o;
         }
 

--- a/dyno-jedis/src/main/java/com/netflix/dyno/jedis/DynoJedisClient.java
+++ b/dyno-jedis/src/main/java/com/netflix/dyno/jedis/DynoJedisClient.java
@@ -106,7 +106,7 @@ public class DynoJedisClient implements JedisCommands, BinaryJedisCommands, Mult
         }
 
         @Override
-        public String getKey() {
+        public String getStringKey() {
             return this.key;
         }
 
@@ -140,7 +140,7 @@ public class DynoJedisClient implements JedisCommands, BinaryJedisCommands, Mult
         }
 
         @Override
-        public String getKey() {
+        public String getStringKey() {
             return this.keys.get(0);
         }
 
@@ -210,7 +210,7 @@ public class DynoJedisClient implements JedisCommands, BinaryJedisCommands, Mult
                 }
             } catch (IOException e) {
                 Logger.warn(
-                        "UNABLE to compress [" + value + "] for key [" + getKey() + "]; sending value uncompressed");
+                        "UNABLE to compress [" + value + "] for key [" + getStringKey() + "]; sending value uncompressed");
             }
 
             return result;
@@ -272,7 +272,7 @@ public class DynoJedisClient implements JedisCommands, BinaryJedisCommands, Mult
                 }
             } catch (IOException e) {
                 Logger.warn(
-                        "UNABLE to compress [" + value + "] for key [" + getKey() + "]; sending value uncompressed");
+                        "UNABLE to compress [" + value + "] for key [" + getStringKey() + "]; sending value uncompressed");
             }
 
             return result;

--- a/dyno-jedis/src/main/java/com/netflix/dyno/jedis/DynoJedisPipeline.java
+++ b/dyno-jedis/src/main/java/com/netflix/dyno/jedis/DynoJedisPipeline.java
@@ -803,10 +803,6 @@ public class DynoJedisPipeline implements RedisPipeline, BinaryRedisPipeline, Au
 
 	}
 
-	/**
-	 * This method is a BinaryRedisPipeline command which dyno does not yet properly
-	 * support, therefore the interface is not yet implemented.
-	 */
 	public Response<Map<byte[], byte[]>> hgetAll(final byte[] key) {
 		if (CompressionStrategy.NONE == connPool.getConfiguration().getCompressionStrategy()) {
 			return new PipelineOperation<Map<byte[], byte[]>>() {

--- a/dyno-jedis/src/main/java/com/netflix/dyno/jedis/DynoJedisPipeline.java
+++ b/dyno-jedis/src/main/java/com/netflix/dyno/jedis/DynoJedisPipeline.java
@@ -31,7 +31,6 @@ import org.slf4j.LoggerFactory;
 
 import redis.clients.jedis.BinaryClient.LIST_POSITION;
 import redis.clients.jedis.*;
-import redis.clients.jedis.RedisPipeline;
 import redis.clients.jedis.exceptions.JedisConnectionException;
 import redis.clients.jedis.params.geo.GeoRadiusParam;
 import redis.clients.jedis.params.sortedset.ZAddParams;
@@ -50,2116 +49,2810 @@ import java.util.concurrent.atomic.AtomicReference;
 import static com.netflix.dyno.connectionpool.ConnectionPoolConfiguration.CompressionStrategy;
 
 @NotThreadSafe
-public class DynoJedisPipeline implements RedisPipeline, AutoCloseable {
-
-    private static final Logger Logger = LoggerFactory.getLogger(DynoJedisPipeline.class);
-
-    // ConnPool and connection to exec the pipeline
-    private final ConnectionPoolImpl<Jedis> connPool;
-    private volatile Connection<Jedis> connection;
-    private final DynoJedisPipelineMonitor opMonitor;
-    private final ConnectionPoolMonitor cpMonitor;
-
-    // the cached pipeline
-    private volatile Pipeline jedisPipeline = null;
-    // the cached row key for the pipeline. all subsequent requests to pipeline
-    // must be the same. this is used to check that.
-    private final AtomicReference<String> theKey = new AtomicReference<String>(null);
-    private final AtomicReference<String> hashtag = new AtomicReference<String>(null);
-    // used for tracking errors
-    private final AtomicReference<DynoException> pipelineEx = new AtomicReference<DynoException>(null);
-
-    private static final String DynoPipeline = "DynoPipeline";
-
-    DynoJedisPipeline(ConnectionPoolImpl<Jedis> cPool, DynoJedisPipelineMonitor operationMonitor,
-            ConnectionPoolMonitor connPoolMonitor) {
-        this.connPool = cPool;
-        this.opMonitor = operationMonitor;
-        this.cpMonitor = connPoolMonitor;
-    }
-
-    private void pipelined(final String key) {
-        try {
-            try {
-                connection = connPool.getConnectionForOperation(new BaseOperation<Jedis, String>() {
-
-                    @Override
-                    public String getName() {
-                        return DynoPipeline;
-                    }
-
-                    @Override
-                    public String getStringKey() {
-                        return key;
-                    }
-
-                });
-            } catch (NoAvailableHostsException nahe) {
-                cpMonitor.incOperationFailure(connection != null ? connection.getHost() : null, nahe);
-                discardPipelineAndReleaseConnection();
-                throw nahe;
-            }
-        } catch (NoAvailableHostsException nahe) {
-            cpMonitor.incOperationFailure(connection != null ? connection.getHost() : null, nahe);
-            discardPipelineAndReleaseConnection();
-            throw nahe;
-        }
-        Jedis jedis = ((JedisConnection) connection).getClient();
-        jedisPipeline = jedis.pipelined();
-        cpMonitor.incOperationSuccess(connection.getHost(), 0);
-    }
-
-    private void checkHashtag(final String key, final String hashtagValue) {
-        if (this.hashtag.get() != null) {
-            verifyHashtagValue(hashtagValue);
-        } else {
-            boolean success = this.hashtag.compareAndSet(null, hashtagValue);
-            if (!success) {
-                verifyHashtagValue(hashtagValue);
-            } else {
-                pipelined(key);
-            }
-        }
-
-    }
-
-    /**
-     * Checks that a pipeline is associated with a single key. If there is a
-     * hashtag defined in the first host of the connectionpool then we check
-     * that first.
-     * 
-     * @param key
-     */
-    private void checkKey(final String key) {
-
-        /*
-         * Get hashtag from the first host of the active pool We cannot use the
-         * connection object because as of now we have not selected a
-         * connection. A connection is selected based on the key or hashtag
-         * respectively.
-         */
-        String hashtag = connPool.getConfiguration().getHashtag();
-        if (hashtag == null || hashtag.isEmpty()) {
-            if (theKey.get() != null) {
-                verifyKey(key);
-            } else {
-                boolean success = theKey.compareAndSet(null, key);
-                if (!success) {
-                    // someone already beat us to it. that's fine, just verify
-                    // that the key is the same
-                    verifyKey(key);
-                } else {
-                    pipelined(key);
-                }
-            }
-        } else {
-            /*
-             * We have a identified a hashtag in the Host object. That means
-             * Dynomite has a defined hashtag. Producing the hashvalue out of
-             * the hashtag and using that as a reference to the pipeline
-             */
-            String hashValue = StringUtils.substringBetween(key, Character.toString(hashtag.charAt(0)),
-                    Character.toString(hashtag.charAt(1)));
-            checkHashtag(key, hashValue);
-        }
-    }
-
-    private void verifyKey(final String key) {
-
-        if (!theKey.get().equals(key)) {
-            try {
-                throw new RuntimeException("Must have same key for Redis Pipeline in Dynomite. This key: " + key);
-            } finally {
-                discardPipelineAndReleaseConnection();
-            }
-        }
-    }
-
-    private void verifyHashtagValue(final String hashtagValue) {
-
-        if (!this.hashtag.get().equals(hashtagValue)) {
-            try {
-                throw new RuntimeException(
-                        "Must have same hashtag for Redis Pipeline in Dynomite. This hashvalue: " + hashtagValue);
-            } finally {
-                discardPipelineAndReleaseConnection();
-            }
-        }
-    }
-
-    private String decompressValue(String value) {
-        try {
-            if (ZipUtils.isCompressed(value)) {
-                return ZipUtils.decompressFromBase64String(value);
-            }
-        } catch (IOException e) {
-            Logger.warn("Unable to decompress value [" + value + "]");
-        }
-
-        return value;
-    }
-
-    private byte[] decompressValue(byte[] value) {
-        try {
-            if (ZipUtils.isCompressed(value)) {
-                return ZipUtils.decompressBytesNonBase64(value);
-            }
-        } catch (IOException e) {
-            Logger.warn("Unable to decompress byte array value [" + value + "]");
-        }
-        return value;
-    }
-
-    /**
-     * As long as jdk 7 and below is supported we need to define our own
-     * function interfaces
-     */
-    private interface Func0<R> {
-        R call();
-    }
-
-    public class PipelineResponse extends Response<String> {
-
-        private Response<String> response;
-
-        public PipelineResponse(Builder<String> b) {
-            super(BuilderFactory.STRING);
-        }
-
-        public PipelineResponse apply(Func0<? extends Response<String>> f) {
-            this.response = f.call();
-            return this;
-        }
-
-        @Override
-        public String get() {
-            return decompressValue(response.get());
-        }
-
-    }
-
-    public class PipelineLongResponse extends Response<Long> {
-        private Response<Long> response;
-
-        public PipelineLongResponse(Builder<Long> b) {
-            super(b);
-        }
-
-        public PipelineLongResponse apply(Func0<? extends Response<Long>> f) {
-            this.response = f.call();
-            return this;
-        }
-    }
-
-    public class PipelineListResponse extends Response<List<String>> {
-
-        private Response<List<String>> response;
-
-        public PipelineListResponse(Builder<List> b) {
-            super(BuilderFactory.STRING_LIST);
-        }
-
-        public PipelineListResponse apply(Func0<? extends Response<List<String>>> f) {
-            this.response = f.call();
-            return this;
-        }
-
-        @Override
-        public List<String> get() {
-            return new ArrayList<String>(
-                    CollectionUtils.transform(response.get(), new CollectionUtils.Transform<String, String>() {
-                        @Override
-                        public String get(String s) {
-                            return decompressValue(s);
-                        }
-                    }));
-        }
-    }
-
-    public class PipelineBinaryResponse extends Response<byte[]> {
-
-        private Response<byte[]> response;
-
-        public PipelineBinaryResponse(Builder<String> b) {
-            super(BuilderFactory.BYTE_ARRAY);
-        }
-
-        public PipelineBinaryResponse apply(Func0<? extends Response<byte[]>> f) {
-            this.response = f.call();
-            return this;
-        }
-
-        @Override
-        public byte[] get() {
-            return decompressValue(response.get());
-        }
-
-    }
-
-    public class PipelineMapResponse extends Response<Map<String, String>> {
-
-        private Response<Map<String, String>> response;
-
-        public PipelineMapResponse(Builder<Map<String, String>> b) {
-            super(BuilderFactory.STRING_MAP);
-        }
-
-        @Override
-        public Map<String, String> get() {
-            return CollectionUtils.transform(response.get(),
-                    new CollectionUtils.MapEntryTransform<String, String, String>() {
-                        @Override
-                        public String get(String key, String val) {
-                            return decompressValue(val);
-                        }
-                    });
-        }
-    }
-
-    public class PipelineBinaryMapResponse extends Response<Map<byte[], byte[]>> {
-
-        private Response<Map<byte[], byte[]>> response;
-
-        public PipelineBinaryMapResponse(Builder<Map<byte[], byte[]>> b) {
-            super(BuilderFactory.BYTE_ARRAY_MAP);
-        }
-
-        public PipelineBinaryMapResponse apply(Func0<? extends Response<Map<byte[], byte[]>>> f) {
-            this.response = f.call();
-            return this;
-        }
-
-        @Override
-        public Map<byte[], byte[]> get() {
-            return CollectionUtils.transform(response.get(),
-                    new CollectionUtils.MapEntryTransform<byte[], byte[], byte[]>() {
-                        @Override
-                        public byte[] get(byte[] key, byte[] val) {
-                            return decompressValue(val);
-                        }
-                    });
-        }
-
-    }
-
-    private abstract class PipelineOperation<R> {
-
-        abstract Response<R> execute(Pipeline jedisPipeline) throws DynoException;
-
-        Response<R> execute(final byte[] key, final OpName opName) {
-            // For now simply convert the key into a String. Properly supporting
-            // this
-            // functionality requires significant changes to plumb this
-            // throughout for the LB
-            return execute(new String(key), opName);
-        }
-
-        Response<R> execute(final String key, final OpName opName) {
-
-            checkKey(key);
-            return executeOperation(opName);
-
-        }
-
-        Response<R> executeOperation(final OpName opName) {
-            try {
-                opMonitor.recordOperation(opName.name());
-                return execute(jedisPipeline);
-
-            } catch (JedisConnectionException ex) {
-                handleConnectionException(ex);
-                throw ex;
-            }
-        }
-
-        void handleConnectionException(JedisConnectionException ex) {
-            DynoException e = new FatalConnectionException(ex).setAttempt(1);
-            pipelineEx.set(e);
-            cpMonitor.incOperationFailure(connection.getHost(), e);
-        }
-    }
-
-    private abstract class PipelineCompressionOperation<R> extends PipelineOperation<R> {
-
-        /**
-         * Compresses the value based on the threshold defined by
-         * {@link ConnectionPoolConfiguration#getValueCompressionThreshold()}
-         *
-         * @param value
-         * @return
-         */
-        public String compressValue(String value) {
-            String result = value;
-            int thresholdBytes = connPool.getConfiguration().getValueCompressionThreshold();
-
-            try {
-                // prefer speed over accuracy here so rather than using
-                // getBytes() to get the actual size
-                // just estimate using 2 bytes per character
-                if ((2 * value.length()) > thresholdBytes) {
-                    result = ZipUtils.compressStringToBase64String(value);
-                }
-            } catch (IOException e) {
-                Logger.warn("UNABLE to compress [" + value + "]; sending value uncompressed");
-            }
-
-            return result;
-        }
-
-        public byte[] compressValue(byte[] value) {
-            int thresholdBytes = connPool.getConfiguration().getValueCompressionThreshold();
-
-            if (value.length > thresholdBytes) {
-                try {
-                    return ZipUtils.compressBytesNonBase64(value);
-                } catch (IOException e) {
-                    Logger.warn("UNABLE to compress byte array [" + value + "]; sending value uncompressed");
-                }
-            }
-
-            return value;
-        }
-
-    }
-
-    @Override
-    public Response<Long> append(final String key, final String value) {
-
-        return new PipelineOperation<Long>() {
-
-            @Override
-            Response<Long> execute(Pipeline jedisPipeline) throws DynoException {
-                return jedisPipeline.append(key, value);
-            }
-
-        }.execute(key, OpName.APPEND);
-    }
-
-    @Override
-    public Response<List<String>> blpop(final String arg) {
-
-        return new PipelineOperation<List<String>>() {
-
-            @Override
-            Response<List<String>> execute(Pipeline jedisPipeline) throws DynoException {
-                return jedisPipeline.blpop(arg);
-            }
-        }.execute(arg, OpName.BLPOP);
-
-    }
-
-    @Override
-    public Response<List<String>> brpop(final String arg) {
-        return new PipelineOperation<List<String>>() {
-
-            @Override
-            Response<List<String>> execute(Pipeline jedisPipeline) throws DynoException {
-                return jedisPipeline.brpop(arg);
-            }
-        }.execute(arg, OpName.BRPOP);
-
-    }
-
-    @Override
-    public Response<Long> decr(final String key) {
-        return new PipelineOperation<Long>() {
-
-            @Override
-            Response<Long> execute(Pipeline jedisPipeline) throws DynoException {
-                return jedisPipeline.decr(key);
-            }
-        }.execute(key, OpName.DECR);
-
-    }
-
-    @Override
-    public Response<Long> decrBy(final String key, final long integer) {
-        return new PipelineOperation<Long>() {
-
-            @Override
-            Response<Long> execute(Pipeline jedisPipeline) throws DynoException {
-                return jedisPipeline.decrBy(key, integer);
-            }
-        }.execute(key, OpName.DECRBY);
-
-    }
-
-    @Override
-    public Response<Long> del(final String key) {
-        return new PipelineOperation<Long>() {
-
-            @Override
-            Response<Long> execute(Pipeline jedisPipeline) throws DynoException {
-                return jedisPipeline.del(key);
-            }
-        }.execute(key, OpName.DEL);
-
-    }
-
-    @Override
-    public Response<String> echo(final String string) {
-        return new PipelineOperation<String>() {
-
-            @Override
-            Response<String> execute(Pipeline jedisPipeline) throws DynoException {
-                return jedisPipeline.echo(string);
-            }
-        }.execute(string, OpName.ECHO);
-
-    }
-
-    @Override
-    public Response<Boolean> exists(final String key) {
-        return new PipelineOperation<Boolean>() {
-
-            @Override
-            Response<Boolean> execute(final Pipeline jedisPipeline) throws DynoException {
-                return jedisPipeline.exists(key);
-            }
-        }.execute(key, OpName.EXISTS);
-
-    }
-
-    @Override
-    public Response<Long> expire(final String key, final int seconds) {
-        return new PipelineOperation<Long>() {
-
-            @Override
-            Response<Long> execute(final Pipeline jedisPipeline) throws DynoException {
-                long startTime = System.nanoTime() / 1000;
-                try {
-                    return jedisPipeline.expire(key, seconds);
-                } finally {
-                    long duration = System.nanoTime() / 1000 - startTime;
-                    opMonitor.recordSendLatency(OpName.EXPIRE.name(), duration, TimeUnit.MICROSECONDS);
-                }
-            }
-        }.execute(key, OpName.EXPIRE);
-
-    }
-
-    @Override
-    public Response<Long> pexpire(String key, long milliseconds) {
-        throw new UnsupportedOperationException("not yet implemented");
-    }
-
-    @Override
-    public Response<Long> expireAt(final String key, final long unixTime) {
-        return new PipelineOperation<Long>() {
-
-            @Override
-            Response<Long> execute(final Pipeline jedisPipeline) throws DynoException {
-                return jedisPipeline.expireAt(key, unixTime);
-            }
-        }.execute(key, OpName.EXPIREAT);
-
-    }
-
-    @Override
-    public Response<Long> pexpireAt(String key, long millisecondsTimestamp) {
-        throw new UnsupportedOperationException("not yet implemented");
-    }
-
-    @Override
-    public Response<String> get(final String key) {
-        if (CompressionStrategy.NONE == connPool.getConfiguration().getCompressionStrategy()) {
-            return new PipelineOperation<String>() {
-                @Override
-                Response<String> execute(Pipeline jedisPipeline) throws DynoException {
-                    long startTime = System.nanoTime() / 1000;
-                    try {
-                        return jedisPipeline.get(key);
-                    } finally {
-                        long duration = System.nanoTime() / 1000 - startTime;
-                        opMonitor.recordSendLatency(OpName.GET.name(), duration, TimeUnit.MICROSECONDS);
-                    }
-                }
-            }.execute(key, OpName.GET);
-        } else {
-            return new PipelineCompressionOperation<String>() {
-                @Override
-                Response<String> execute(final Pipeline jedisPipeline) throws DynoException {
-                    return new PipelineResponse(null).apply(new Func0<Response<String>>() {
-                        @Override
-                        public Response<String> call() {
-                            return jedisPipeline.get(key);
-                        }
-                    });
-                }
-            }.execute(key, OpName.GET);
-        }
-
-    }
-
-    @Override
-    public Response<Boolean> getbit(final String key, final long offset) {
-        return new PipelineOperation<Boolean>() {
-
-            @Override
-            Response<Boolean> execute(Pipeline jedisPipeline) throws DynoException {
-                return jedisPipeline.getbit(key, offset);
-            }
-        }.execute(key, OpName.GETBIT);
-
-    }
-
-    @Override
-    public Response<String> getrange(final String key, final long startOffset, final long endOffset) {
-        return new PipelineOperation<String>() {
-
-            @Override
-            Response<String> execute(Pipeline jedisPipeline) throws DynoException {
-                return jedisPipeline.getrange(key, startOffset, endOffset);
-            }
-        }.execute(key, OpName.GETRANGE);
-
-    }
-
-    @Override
-    public Response<String> getSet(final String key, final String value) {
-        if (CompressionStrategy.NONE == connPool.getConfiguration().getCompressionStrategy()) {
-            return new PipelineOperation<String>() {
-                @Override
-                Response<String> execute(Pipeline jedisPipeline) throws DynoException {
-                    return jedisPipeline.getSet(key, value);
-                }
-            }.execute(key, OpName.GETSET);
-        } else {
-            return new PipelineCompressionOperation<String>() {
-                @Override
-                Response<String> execute(final Pipeline jedisPipeline) throws DynoException {
-                    return new PipelineResponse(null).apply(new Func0<Response<String>>() {
-                        @Override
-                        public Response<String> call() {
-                            return jedisPipeline.getSet(key, compressValue(value));
-                        }
-                    });
-                }
-            }.execute(key, OpName.GETSET);
-        }
-    }
-
-    @Override
-    public Response<Long> hdel(final String key, final String... field) {
-        return new PipelineOperation<Long>() {
-
-            @Override
-            Response<Long> execute(Pipeline jedisPipeline) throws DynoException {
-                return jedisPipeline.hdel(key, field);
-            }
-        }.execute(key, OpName.HDEL);
-
-    }
-
-    @Override
-    public Response<Boolean> hexists(final String key, final String field) {
-        return new PipelineOperation<Boolean>() {
-
-            @Override
-            Response<Boolean> execute(Pipeline jedisPipeline) throws DynoException {
-                return jedisPipeline.hexists(key, field);
-            }
-        }.execute(key, OpName.HEXISTS);
-
-    }
-
-    @Override
-    public Response<String> hget(final String key, final String field) {
-        if (CompressionStrategy.NONE == connPool.getConfiguration().getCompressionStrategy()) {
-            return new PipelineOperation<String>() {
-                @Override
-                Response<String> execute(Pipeline jedisPipeline) throws DynoException {
-                    return jedisPipeline.hget(key, field);
-                }
-            }.execute(key, OpName.HGET);
-        } else {
-            return new PipelineCompressionOperation<String>() {
-                @Override
-                Response<String> execute(final Pipeline jedisPipeline) throws DynoException {
-                    return new PipelineResponse(null).apply(new Func0<Response<String>>() {
-                        @Override
-                        public Response<String> call() {
-                            return jedisPipeline.hget(key, field);
-                        }
-                    });
-                }
-            }.execute(key, OpName.HGET);
-        }
-
-    }
-
-    /**
-     * This method is a BinaryRedisPipeline command which dyno does not yet
-     * properly support, therefore the interface is not yet implemented.
-     */
-    public Response<byte[]> hget(final byte[] key, final byte[] field) {
-        if (CompressionStrategy.NONE == connPool.getConfiguration().getCompressionStrategy()) {
-            return new PipelineOperation<byte[]>() {
-                @Override
-                Response<byte[]> execute(Pipeline jedisPipeline) throws DynoException {
-                    return jedisPipeline.hget(key, field);
-                }
-            }.execute(key, OpName.HGET);
-        } else {
-            return new PipelineCompressionOperation<byte[]>() {
-                @Override
-                Response<byte[]> execute(final Pipeline jedisPipeline) throws DynoException {
-                    return new PipelineBinaryResponse(null).apply(new Func0<Response<byte[]>>() {
-                        @Override
-                        public Response<byte[]> call() {
-                            return jedisPipeline.hget(key, field);
-                        }
-                    });
-                }
-            }.execute(key, OpName.HGET);
-        }
-    }
-
-    @Override
-    public Response<Map<String, String>> hgetAll(final String key) {
-
-        return new PipelineOperation<Map<String, String>>() {
-
-            @Override
-            Response<Map<String, String>> execute(Pipeline jedisPipeline) throws DynoException {
-                long startTime = System.nanoTime() / 1000;
-                try {
-                    return jedisPipeline.hgetAll(key);
-                } finally {
-                    long duration = System.nanoTime() / 1000 - startTime;
-                    opMonitor.recordSendLatency(OpName.HGETALL.name(), duration, TimeUnit.MICROSECONDS);
-                }
-            }
-
-        }.execute(key, OpName.HGETALL);
-
-    }
-
-    /**
-     * This method is a BinaryRedisPipeline command which dyno does not yet
-     * properly support, therefore the interface is not yet implemented.
-     */
-    public Response<Map<byte[], byte[]>> hgetAll(final byte[] key) {
-        if (CompressionStrategy.NONE == connPool.getConfiguration().getCompressionStrategy()) {
-            return new PipelineOperation<Map<byte[], byte[]>>() {
-                @Override
-                Response<Map<byte[], byte[]>> execute(Pipeline jedisPipeline) throws DynoException {
-                    long startTime = System.nanoTime() / 1000;
-                    try {
-                        return jedisPipeline.hgetAll(key);
-                    } finally {
-                        long duration = System.nanoTime() / 1000 - startTime;
-                        opMonitor.recordSendLatency(OpName.HGETALL.name(), duration, TimeUnit.MICROSECONDS);
-                    }
-                }
-            }.execute(key, OpName.HGETALL);
-        } else {
-            return new PipelineCompressionOperation<Map<byte[], byte[]>>() {
-                @Override
-                Response<Map<byte[], byte[]>> execute(final Pipeline jedisPipeline) throws DynoException {
-                    return new PipelineBinaryMapResponse(null).apply(new Func0<Response<Map<byte[], byte[]>>>() {
-                        @Override
-                        public Response<Map<byte[], byte[]>> call() {
-                            return jedisPipeline.hgetAll(key);
-                        }
-                    });
-                }
-            }.execute(key, OpName.HGETALL);
-        }
-    }
-
-    @Override
-    public Response<Long> hincrBy(final String key, final String field, final long value) {
-        return new PipelineOperation<Long>() {
-
-            @Override
-            Response<Long> execute(Pipeline jedisPipeline) throws DynoException {
-                return jedisPipeline.hincrBy(key, field, value);
-            }
-        }.execute(key, OpName.HINCRBY);
-    }
-
-    /* not supported by RedisPipeline 2.7.3 */
-    public Response<Double> hincrByFloat(final String key, final String field, final double value) {
-        return new PipelineOperation<Double>() {
-
-            @Override
-            Response<Double> execute(Pipeline jedisPipeline) throws DynoException {
-                return jedisPipeline.hincrByFloat(key, field, value);
-            }
-        }.execute(key, OpName.HINCRBYFLOAT);
-    }
-
-    @Override
-    public Response<Set<String>> hkeys(final String key) {
-        return new PipelineOperation<Set<String>>() {
-
-            @Override
-            Response<Set<String>> execute(Pipeline jedisPipeline) throws DynoException {
-                return jedisPipeline.hkeys(key);
-            }
-        }.execute(key, OpName.HKEYS);
-
-    }
-
-    public Response<ScanResult<Map.Entry<String, String>>> hscan(final String key, int cursor) {
-        throw new UnsupportedOperationException("'HSCAN' cannot be called in pipeline");
-    }
-
-    @Override
-    public Response<Long> hlen(final String key) {
-        return new PipelineOperation<Long>() {
-
-            @Override
-            Response<Long> execute(Pipeline jedisPipeline) throws DynoException {
-                return jedisPipeline.hlen(key);
-            }
-        }.execute(key, OpName.HLEN);
-
-    }
-
-    /**
-     * This method is a BinaryRedisPipeline command which dyno does not yet
-     * properly support, therefore the interface is not yet implemented.
-     */
-    public Response<List<byte[]>> hmget(final byte[] key, final byte[]... fields) {
-        return new PipelineOperation<List<byte[]>>() {
-
-            @Override
-            Response<List<byte[]>> execute(Pipeline jedisPipeline) throws DynoException {
-                long startTime = System.nanoTime() / 1000;
-                try {
-                    return jedisPipeline.hmget(key, fields);
-                } finally {
-                    long duration = System.nanoTime() / 1000 - startTime;
-                    opMonitor.recordSendLatency(OpName.HMGET.name(), duration, TimeUnit.MICROSECONDS);
-                }
-            }
-        }.execute(key, OpName.HMGET);
-    }
-
-    @Override
-    public Response<List<String>> hmget(final String key, final String... fields) {
-        if (CompressionStrategy.NONE == connPool.getConfiguration().getCompressionStrategy()) {
-            return new PipelineOperation<List<String>>() {
-                @Override
-                Response<List<String>> execute(Pipeline jedisPipeline) throws DynoException {
-                    long startTime = System.nanoTime() / 1000;
-                    try {
-                        return jedisPipeline.hmget(key, fields);
-                    } finally {
-                        long duration = System.nanoTime() / 1000 - startTime;
-                        opMonitor.recordSendLatency(OpName.HMGET.name(), duration, TimeUnit.MICROSECONDS);
-                    }
-                }
-            }.execute(key, OpName.HMGET);
-        } else {
-            return new PipelineCompressionOperation<List<String>>() {
-                @Override
-                Response<List<String>> execute(final Pipeline jedisPipeline) throws DynoException {
-                    long startTime = System.nanoTime() / 1000;
-                    try {
-                        return new PipelineListResponse(null).apply(new Func0<Response<List<String>>>() {
-                            @Override
-                            public Response<List<String>> call() {
-                                return jedisPipeline.hmget(key, fields);
-                            }
-                        });
-                    } finally {
-                        long duration = System.nanoTime() / 1000 - startTime;
-                        opMonitor.recordSendLatency(OpName.HMGET.name(), duration, TimeUnit.MICROSECONDS);
-                    }
-                }
-            }.execute(key, OpName.HGET);
-        }
-    }
-
-    /**
-     * This method is a BinaryRedisPipeline command which dyno does not yet
-     * properly support, therefore the interface is not yet implemented since
-     * only a few binary commands are present.
-     */
-    public Response<String> hmset(final byte[] key, final Map<byte[], byte[]> hash) {
-        if (CompressionStrategy.NONE == connPool.getConfiguration().getCompressionStrategy()) {
-            return new PipelineOperation<String>() {
-                @Override
-                Response<String> execute(Pipeline jedisPipeline) throws DynoException {
-                    long startTime = System.nanoTime() / 1000;
-                    try {
-                        return jedisPipeline.hmset(key, hash);
-                    } finally {
-                        long duration = System.nanoTime() / 1000 - startTime;
-                        opMonitor.recordSendLatency(OpName.HMSET.name(), duration, TimeUnit.MICROSECONDS);
-                    }
-                }
-            }.execute(key, OpName.HMSET);
-        } else {
-            return new PipelineCompressionOperation<String>() {
-                @Override
-                Response<String> execute(final Pipeline jedisPipeline) throws DynoException {
-                    return new PipelineResponse(null).apply(new Func0<Response<String>>() {
-                        @Override
-                        public Response<String> call() {
-                            return jedisPipeline.hmset(key, CollectionUtils.transform(hash,
-                                    new CollectionUtils.MapEntryTransform<byte[], byte[], byte[]>() {
-                                        @Override
-                                        public byte[] get(byte[] key, byte[] val) {
-                                            return compressValue(val);
-                                        }
-                                    }));
-                        }
-                    });
-                }
-            }.execute(key, OpName.HMSET);
-        }
-    }
-
-    @Override
-    public Response<String> hmset(final String key, final Map<String, String> hash) {
-        if (CompressionStrategy.NONE == connPool.getConfiguration().getCompressionStrategy()) {
-            return new PipelineOperation<String>() {
-                @Override
-                Response<String> execute(Pipeline jedisPipeline) throws DynoException {
-                    long startTime = System.nanoTime() / 1000;
-                    try {
-                        return jedisPipeline.hmset(key, hash);
-                    } finally {
-                        long duration = System.nanoTime() / 1000 - startTime;
-                        opMonitor.recordSendLatency(OpName.HMSET.name(), duration, TimeUnit.MICROSECONDS);
-                    }
-                }
-            }.execute(key, OpName.HMSET);
-        } else {
-            return new PipelineCompressionOperation<String>() {
-                @Override
-                Response<String> execute(final Pipeline jedisPipeline) throws DynoException {
-                    return new PipelineResponse(null).apply(new Func0<Response<String>>() {
-                        @Override
-                        public Response<String> call() {
-                            return jedisPipeline.hmset(key, CollectionUtils.transform(hash,
-                                    new CollectionUtils.MapEntryTransform<String, String, String>() {
-                                        @Override
-                                        public String get(String key, String val) {
-                                            return compressValue(val);
-                                        }
-                                    }));
-                        }
-                    });
-                }
-            }.execute(key, OpName.HMSET);
-        }
-
-    }
-
-    @Override
-    public Response<Long> hset(final String key, final String field, final String value) {
-        if (CompressionStrategy.NONE == connPool.getConfiguration().getCompressionStrategy()) {
-            return new PipelineOperation<Long>() {
-                @Override
-                Response<Long> execute(Pipeline jedisPipeline) throws DynoException {
-                    return jedisPipeline.hset(key, field, value);
-                }
-            }.execute(key, OpName.HSET);
-        } else {
-            return new PipelineCompressionOperation<Long>() {
-                @Override
-                Response<Long> execute(final Pipeline jedisPipeline) throws DynoException {
-                    return new PipelineLongResponse(null).apply(new Func0<Response<Long>>() {
-                        @Override
-                        public Response<Long> call() {
-                            return jedisPipeline.hset(key, field, compressValue(value));
-                        }
-                    });
-                }
-            }.execute(key, OpName.HSET);
-        }
-    }
-
-    /**
-     * This method is a BinaryRedisPipeline command which dyno does not yet
-     * properly support, therefore the interface is not yet implemented.
-     */
-    public Response<Long> hset(final byte[] key, final byte[] field, final byte[] value) {
-        if (CompressionStrategy.NONE == connPool.getConfiguration().getCompressionStrategy()) {
-            return new PipelineOperation<Long>() {
-                @Override
-                Response<Long> execute(Pipeline jedisPipeline) throws DynoException {
-                    return jedisPipeline.hset(key, field, value);
-                }
-            }.execute(key, OpName.HSET);
-        } else {
-            return new PipelineCompressionOperation<Long>() {
-                @Override
-                Response<Long> execute(final Pipeline jedisPipeline) throws DynoException {
-                    return new PipelineLongResponse(null).apply(new Func0<Response<Long>>() {
-                        @Override
-                        public Response<Long> call() {
-                            return jedisPipeline.hset(key, field, compressValue(value));
-                        }
-                    });
-                }
-            }.execute(key, OpName.HSET);
-        }
-    }
-
-    @Override
-    public Response<Long> hsetnx(final String key, final String field, final String value) {
-        if (CompressionStrategy.NONE == connPool.getConfiguration().getCompressionStrategy()) {
-            return new PipelineOperation<Long>() {
-                @Override
-                Response<Long> execute(Pipeline jedisPipeline) throws DynoException {
-                    return jedisPipeline.hsetnx(key, field, value);
-                }
-            }.execute(key, OpName.HSETNX);
-        } else {
-            return new PipelineCompressionOperation<Long>() {
-                @Override
-                Response<Long> execute(final Pipeline jedisPipeline) throws DynoException {
-                    return new PipelineLongResponse(null).apply(new Func0<Response<Long>>() {
-                        @Override
-                        public Response<Long> call() {
-                            return jedisPipeline.hsetnx(key, field, compressValue(value));
-                        }
-                    });
-                }
-            }.execute(key, OpName.HSETNX);
-        }
-    }
-
-    @Override
-    public Response<List<String>> hvals(final String key) {
-        if (CompressionStrategy.NONE == connPool.getConfiguration().getCompressionStrategy()) {
-            return new PipelineOperation<List<String>>() {
-                @Override
-                Response<List<String>> execute(Pipeline jedisPipeline) throws DynoException {
-                    return jedisPipeline.hvals(key);
-                }
-            }.execute(key, OpName.HVALS);
-        } else {
-            return new PipelineCompressionOperation<List<String>>() {
-                @Override
-                Response<List<String>> execute(final Pipeline jedisPipeline) throws DynoException {
-                    return new PipelineListResponse(null).apply(new Func0<Response<List<String>>>() {
-                        @Override
-                        public Response<List<String>> call() {
-                            return jedisPipeline.hvals(key);
-                        }
-                    });
-                }
-            }.execute(key, OpName.HVALS);
-        }
-
-    }
-
-    @Override
-    public Response<Long> incr(final String key) {
-        return new PipelineOperation<Long>() {
-
-            @Override
-            Response<Long> execute(Pipeline jedisPipeline) throws DynoException {
-                return jedisPipeline.incr(key);
-            }
-
-        }.execute(key, OpName.INCR);
-
-    }
-
-    @Override
-    public Response<Long> incrBy(final String key, final long integer) {
-        return new PipelineOperation<Long>() {
-
-            @Override
-            Response<Long> execute(Pipeline jedisPipeline) throws DynoException {
-                return jedisPipeline.incrBy(key, integer);
-            }
-
-        }.execute(key, OpName.INCRBY);
-
-    }
-
-    /* not supported by RedisPipeline 2.7.3 */
-    public Response<Double> incrByFloat(final String key, final double increment) {
-        return new PipelineOperation<Double>() {
-
-            @Override
-            Response<Double> execute(Pipeline jedisPipeline) throws DynoException {
-                return jedisPipeline.incrByFloat(key, increment);
-            }
-
-        }.execute(key, OpName.INCRBYFLOAT);
-
-    }
-
-    @Override
-    public Response<String> lindex(final String key, final long index) {
-        return new PipelineOperation<String>() {
-
-            @Override
-            Response<String> execute(Pipeline jedisPipeline) throws DynoException {
-                return jedisPipeline.lindex(key, index);
-            }
-
-        }.execute(key, OpName.LINDEX);
-
-    }
-
-    @Override
-    public Response<Long> linsert(final String key, final LIST_POSITION where, final String pivot, final String value) {
-        return new PipelineOperation<Long>() {
-
-            @Override
-            Response<Long> execute(Pipeline jedisPipeline) throws DynoException {
-                return jedisPipeline.linsert(key, where, pivot, value);
-            }
-
-        }.execute(key, OpName.LINSERT);
-
-    }
-
-    @Override
-    public Response<Long> llen(final String key) {
-        return new PipelineOperation<Long>() {
-
-            @Override
-            Response<Long> execute(Pipeline jedisPipeline) throws DynoException {
-                return jedisPipeline.llen(key);
-            }
-
-        }.execute(key, OpName.LLEN);
-
-    }
-
-    @Override
-    public Response<String> lpop(final String key) {
-        return new PipelineOperation<String>() {
-
-            @Override
-            Response<String> execute(Pipeline jedisPipeline) throws DynoException {
-                return jedisPipeline.lpop(key);
-            }
-
-        }.execute(key, OpName.LPOP);
-
-    }
-
-    @Override
-    public Response<Long> lpush(final String key, final String... string) {
-        return new PipelineOperation<Long>() {
-
-            @Override
-            Response<Long> execute(Pipeline jedisPipeline) throws DynoException {
-                return jedisPipeline.lpush(key, string);
-            }
-
-        }.execute(key, OpName.LPUSH);
-
-    }
-
-    @Override
-    public Response<Long> lpushx(final String key, final String... string) {
-        return new PipelineOperation<Long>() {
-
-            @Override
-            Response<Long> execute(Pipeline jedisPipeline) throws DynoException {
-                return jedisPipeline.lpushx(key, string);
-            }
-
-        }.execute(key, OpName.LPUSHX);
-
-    }
-
-    @Override
-    public Response<List<String>> lrange(final String key, final long start, final long end) {
-        return new PipelineOperation<List<String>>() {
-
-            @Override
-            Response<List<String>> execute(Pipeline jedisPipeline) throws DynoException {
-                return jedisPipeline.lrange(key, start, end);
-            }
-
-        }.execute(key, OpName.LRANGE);
-
-    }
-
-    @Override
-    public Response<Long> lrem(final String key, final long count, final String value) {
-        return new PipelineOperation<Long>() {
-
-            @Override
-            Response<Long> execute(Pipeline jedisPipeline) throws DynoException {
-                return jedisPipeline.lrem(key, count, value);
-            }
-
-        }.execute(key, OpName.LREM);
-
-    }
-
-    @Override
-    public Response<String> lset(final String key, final long index, final String value) {
-        return new PipelineOperation<String>() {
-
-            @Override
-            Response<String> execute(Pipeline jedisPipeline) throws DynoException {
-                return jedisPipeline.lset(key, index, value);
-            }
-
-        }.execute(key, OpName.LSET);
-
-    }
-
-    @Override
-    public Response<String> ltrim(final String key, final long start, final long end) {
-        return new PipelineOperation<String>() {
-
-            @Override
-            Response<String> execute(Pipeline jedisPipeline) throws DynoException {
-                return jedisPipeline.ltrim(key, start, end);
-            }
-
-        }.execute(key, OpName.LTRIM);
-
-    }
-
-    @Override
-    public Response<Long> move(final String key, final int dbIndex) {
-        return new PipelineOperation<Long>() {
-
-            @Override
-            Response<Long> execute(Pipeline jedisPipeline) throws DynoException {
-                return jedisPipeline.move(key, dbIndex);
-            }
-
-        }.execute(key, OpName.MOVE);
-
-    }
-
-    @Override
-    public Response<Long> persist(final String key) {
-        return new PipelineOperation<Long>() {
-
-            @Override
-            Response<Long> execute(Pipeline jedisPipeline) throws DynoException {
-                return jedisPipeline.persist(key);
-            }
-
-        }.execute(key, OpName.PERSIST);
-
-    }
-
-    /* not supported by RedisPipeline 2.7.3 */
-    public Response<String> rename(final String oldkey, final String newkey) {
-        return new PipelineOperation<String>() {
-
-            @Override
-            Response<String> execute(Pipeline jedisPipeline) throws DynoException {
-                return jedisPipeline.rename(oldkey, newkey);
-            }
-        }.execute(oldkey, OpName.RENAME);
-
-    }
-
-    /* not supported by RedisPipeline 2.7.3 */
-    public Response<Long> renamenx(final String oldkey, final String newkey) {
-        return new PipelineOperation<Long>() {
-
-            @Override
-            Response<Long> execute(Pipeline jedisPipeline) throws DynoException {
-                return jedisPipeline.renamenx(oldkey, newkey);
-            }
-        }.execute(oldkey, OpName.RENAMENX);
-
-    }
-
-    @Override
-    public Response<String> rpop(final String key) {
-        return new PipelineOperation<String>() {
-
-            @Override
-            Response<String> execute(Pipeline jedisPipeline) throws DynoException {
-                return jedisPipeline.rpop(key);
-            }
-
-        }.execute(key, OpName.RPOP);
-
-    }
-
-    @Override
-    public Response<Long> rpush(final String key, final String... string) {
-        return new PipelineOperation<Long>() {
-
-            @Override
-            Response<Long> execute(Pipeline jedisPipeline) throws DynoException {
-                return jedisPipeline.rpush(key, string);
-            }
-
-        }.execute(key, OpName.RPUSH);
-
-    }
-
-    @Override
-    public Response<Long> rpushx(final String key, final String... string) {
-        return new PipelineOperation<Long>() {
-
-            @Override
-            Response<Long> execute(Pipeline jedisPipeline) throws DynoException {
-                return jedisPipeline.rpushx(key, string);
-            }
-
-        }.execute(key, OpName.RPUSHX);
-
-    }
-
-    @Override
-    public Response<Long> sadd(final String key, final String... member) {
-        return new PipelineOperation<Long>() {
-
-            @Override
-            Response<Long> execute(Pipeline jedisPipeline) throws DynoException {
-                return jedisPipeline.sadd(key, member);
-            }
-
-        }.execute(key, OpName.SADD);
-
-    }
-
-    @Override
-    public Response<Long> scard(final String key) {
-        return new PipelineOperation<Long>() {
-
-            @Override
-            Response<Long> execute(Pipeline jedisPipeline) throws DynoException {
-                return jedisPipeline.scard(key);
-            }
-
-        }.execute(key, OpName.SCARD);
-
-    }
-
-    @Override
-    public Response<Boolean> sismember(final String key, final String member) {
-        return new PipelineOperation<Boolean>() {
-
-            @Override
-            Response<Boolean> execute(Pipeline jedisPipeline) throws DynoException {
-                return jedisPipeline.sismember(key, member);
-            }
-
-        }.execute(key, OpName.SISMEMBER);
-
-    }
-
-    @Override
-    public Response<String> set(final String key, final String value) {
-        if (CompressionStrategy.NONE == connPool.getConfiguration().getCompressionStrategy()) {
-            return new PipelineOperation<String>() {
-                @Override
-                Response<String> execute(Pipeline jedisPipeline) throws DynoException {
-                    long startTime = System.nanoTime() / 1000;
-                    try {
-                        return jedisPipeline.set(key, value);
-                    } finally {
-                        long duration = System.nanoTime() / 1000 - startTime;
-                        opMonitor.recordSendLatency(OpName.SET.name(), duration, TimeUnit.MICROSECONDS);
-                    }
-                }
-
-            }.execute(key, OpName.SET);
-        } else {
-            return new PipelineCompressionOperation<String>() {
-                @Override
-                Response<String> execute(final Pipeline jedisPipeline) throws DynoException {
-                    long startTime = System.nanoTime() / 1000;
-                    try {
-                        return new PipelineResponse(null).apply(new Func0<Response<String>>() {
-                            @Override
-                            public Response<String> call() {
-                                return jedisPipeline.set(key, compressValue(value));
-                            }
-                        });
-                    } finally {
-                        long duration = System.nanoTime() / 1000 - startTime;
-                        opMonitor.recordSendLatency(OpName.SET.name(), duration, TimeUnit.MICROSECONDS);
-                    }
-                }
-            }.execute(key, OpName.SET);
-        }
-
-    }
-
-    @Override
-    public Response<Boolean> setbit(final String key, final long offset, final boolean value) {
-        return new PipelineOperation<Boolean>() {
-
-            @Override
-            Response<Boolean> execute(Pipeline jedisPipeline) throws DynoException {
-                return jedisPipeline.setbit(key, offset, value);
-            }
-
-        }.execute(key, OpName.SETBIT);
-
-    }
-
-    @Override
-    public Response<String> setex(final String key, final int seconds, final String value) {
-        if (CompressionStrategy.NONE == connPool.getConfiguration().getCompressionStrategy()) {
-            return new PipelineOperation<String>() {
-                @Override
-                Response<String> execute(Pipeline jedisPipeline) throws DynoException {
-                    return jedisPipeline.setex(key, seconds, value);
-                }
-            }.execute(key, OpName.SETEX);
-        } else {
-            return new PipelineCompressionOperation<String>() {
-                @Override
-                Response<String> execute(final Pipeline jedisPipeline) throws DynoException {
-                    return new PipelineResponse(null).apply(new Func0<Response<String>>() {
-                        @Override
-                        public Response<String> call() {
-                            return jedisPipeline.setex(key, seconds, compressValue(value));
-                        }
-                    });
-                }
-            }.execute(key, OpName.SETEX);
-        }
-
-    }
-
-    @Override
-    public Response<Long> setnx(final String key, final String value) {
-        return new PipelineOperation<Long>() {
-            @Override
-            Response<Long> execute(Pipeline jedisPipeline) throws DynoException {
-                return jedisPipeline.setnx(key, value);
-            }
-        }.execute(key, OpName.SETNX);
-    }
-
-    @Override
-    public Response<Long> setrange(final String key, final long offset, final String value) {
-        return new PipelineOperation<Long>() {
-
-            @Override
-            Response<Long> execute(Pipeline jedisPipeline) throws DynoException {
-                return jedisPipeline.setrange(key, offset, value);
-            }
-
-        }.execute(key, OpName.SETRANGE);
-
-    }
-
-    @Override
-    public Response<Set<String>> smembers(final String key) {
-        return new PipelineOperation<Set<String>>() {
-
-            @Override
-            Response<Set<String>> execute(Pipeline jedisPipeline) throws DynoException {
-                return jedisPipeline.smembers(key);
-            }
-
-        }.execute(key, OpName.SMEMBERS);
-
-    }
-
-    @Override
-    public Response<List<String>> sort(final String key) {
-        return new PipelineOperation<List<String>>() {
-
-            @Override
-            Response<List<String>> execute(Pipeline jedisPipeline) throws DynoException {
-                return jedisPipeline.sort(key);
-            }
-
-        }.execute(key, OpName.SORT);
-
-    }
-
-    @Override
-    public Response<List<String>> sort(final String key, final SortingParams sortingParameters) {
-        return new PipelineOperation<List<String>>() {
-
-            @Override
-            Response<List<String>> execute(Pipeline jedisPipeline) throws DynoException {
-                return jedisPipeline.sort(key, sortingParameters);
-            }
-
-        }.execute(key, OpName.SORT);
-
-    }
-
-    @Override
-    public Response<String> spop(final String key) {
-        return new PipelineOperation<String>() {
-
-            @Override
-            Response<String> execute(Pipeline jedisPipeline) throws DynoException {
-                return jedisPipeline.spop(key);
-            }
-
-        }.execute(key, OpName.SPOP);
-
-    }
-
-    @Override
-    public Response<Set<String>> spop(final String key, final long count) {
-        throw new UnsupportedOperationException("not yet implemented");
-    }
-
-    @Override
-    public Response<String> srandmember(final String key) {
-        return new PipelineOperation<String>() {
-
-            @Override
-            Response<String> execute(Pipeline jedisPipeline) throws DynoException {
-                return jedisPipeline.srandmember(key);
-            }
-
-        }.execute(key, OpName.SRANDMEMBER);
-
-    }
-
-    @Override
-    public Response<Long> srem(final String key, final String... member) {
-        return new PipelineOperation<Long>() {
-
-            @Override
-            Response<Long> execute(Pipeline jedisPipeline) throws DynoException {
-                return jedisPipeline.srem(key, member);
-            }
-
-        }.execute(key, OpName.SREM);
-
-    }
-
-    /**
-     * This method is not supported by the BinaryRedisPipeline interface.
-     */
-    public Response<ScanResult<String>> sscan(final String key, final int cursor) {
-        throw new UnsupportedOperationException("'SSCAN' cannot be called in pipeline");
-    }
-
-    /**
-     * This method is not supported by the BinaryRedisPipeline interface.
-     */
-    public Response<ScanResult<String>> sscan(final String key, final String cursor) {
-        throw new UnsupportedOperationException("'SSCAN' cannot be called in pipeline");
-    }
-
-    @Override
-    public Response<Long> strlen(final String key) {
-        return new PipelineOperation<Long>() {
-
-            @Override
-            Response<Long> execute(Pipeline jedisPipeline) throws DynoException {
-                return jedisPipeline.strlen(key);
-            }
-
-        }.execute(key, OpName.STRLEN);
-
-    }
-
-    @Override
-    public Response<String> substr(final String key, final int start, final int end) {
-        return new PipelineOperation<String>() {
-
-            @Override
-            Response<String> execute(Pipeline jedisPipeline) throws DynoException {
-                return jedisPipeline.substr(key, start, end);
-            }
-
-        }.execute(key, OpName.SUBSTR);
-
-    }
-
-    @Override
-    public Response<Long> ttl(final String key) {
-        return new PipelineOperation<Long>() {
-
-            @Override
-            Response<Long> execute(Pipeline jedisPipeline) throws DynoException {
-                return jedisPipeline.ttl(key);
-            }
-
-        }.execute(key, OpName.TTL);
-
-    }
-
-    @Override
-    public Response<String> type(final String key) {
-        return new PipelineOperation<String>() {
-
-            @Override
-            Response<String> execute(Pipeline jedisPipeline) throws DynoException {
-                return jedisPipeline.type(key);
-            }
-
-        }.execute(key, OpName.TYPE);
-
-    }
-
-    @Override
-    public Response<Long> zadd(final String key, final double score, final String member) {
-        return new PipelineOperation<Long>() {
-
-            @Override
-            Response<Long> execute(Pipeline jedisPipeline) throws DynoException {
-                return jedisPipeline.zadd(key, score, member);
-            }
-
-        }.execute(key, OpName.ZADD);
-
-    }
-
-    @Override
-    public Response<Long> zadd(final String key, final Map<String, Double> scoreMembers) {
-        return new PipelineOperation<Long>() {
-
-            @Override
-            Response<Long> execute(Pipeline jedisPipeline) throws DynoException {
-                return jedisPipeline.zadd(key, scoreMembers);
-            }
-
-        }.execute(key, OpName.ZADD);
-
-    }
-
-    @Override
-    public Response<Long> zcard(final String key) {
-        return new PipelineOperation<Long>() {
-
-            @Override
-            Response<Long> execute(Pipeline jedisPipeline) throws DynoException {
-                return jedisPipeline.zcard(key);
-            }
-
-        }.execute(key, OpName.ZCARD);
-
-    }
-
-    @Override
-    public Response<Long> zcount(final String key, final double min, final double max) {
-        return new PipelineOperation<Long>() {
-
-            @Override
-            Response<Long> execute(Pipeline jedisPipeline) throws DynoException {
-                return jedisPipeline.zcount(key, min, max);
-            }
-
-        }.execute(key, OpName.ZCOUNT);
-
-    }
-
-    @Override
-    public Response<Double> zincrby(final String key, final double score, final String member) {
-        return new PipelineOperation<Double>() {
-
-            @Override
-            Response<Double> execute(Pipeline jedisPipeline) throws DynoException {
-                return jedisPipeline.zincrby(key, score, member);
-            }
-
-        }.execute(key, OpName.ZINCRBY);
-
-    }
-
-    @Override
-    public Response<Set<String>> zrange(final String key, final long start, final long end) {
-        return new PipelineOperation<Set<String>>() {
-
-            @Override
-            Response<Set<String>> execute(Pipeline jedisPipeline) throws DynoException {
-                return jedisPipeline.zrange(key, start, end);
-            }
-
-        }.execute(key, OpName.ZRANGE);
-
-    }
-
-    @Override
-    public Response<Set<String>> zrangeByScore(final String key, final double min, final double max) {
-        return new PipelineOperation<Set<String>>() {
-
-            @Override
-            Response<Set<String>> execute(Pipeline jedisPipeline) throws DynoException {
-                return jedisPipeline.zrangeByScore(key, min, max);
-            }
-
-        }.execute(key, OpName.ZRANGEBYSCORE);
-
-    }
-
-    @Override
-    public Response<Set<String>> zrangeByScore(final String key, final String min, final String max) {
-        return new PipelineOperation<Set<String>>() {
-
-            @Override
-            Response<Set<String>> execute(Pipeline jedisPipeline) throws DynoException {
-                return jedisPipeline.zrangeByScore(key, min, max);
-            }
-
-        }.execute(key, OpName.ZRANGEBYSCORE);
-
-    }
-
-    @Override
-    public Response<Set<String>> zrangeByScore(final String key, final double min, final double max, final int offset,
-            final int count) {
-        return new PipelineOperation<Set<String>>() {
-
-            @Override
-            Response<Set<String>> execute(Pipeline jedisPipeline) throws DynoException {
-                return jedisPipeline.zrangeByScore(key, min, max, offset, count);
-            }
-
-        }.execute(key, OpName.ZRANGEBYSCORE);
-
-    }
-
-    @Override
-    public Response<Set<Tuple>> zrangeByScoreWithScores(final String key, final double min, final double max) {
-        return new PipelineOperation<Set<Tuple>>() {
-
-            @Override
-            Response<Set<Tuple>> execute(Pipeline jedisPipeline) throws DynoException {
-                return jedisPipeline.zrangeByScoreWithScores(key, min, max);
-            }
-
-        }.execute(key, OpName.ZRANGEBYSCOREWITHSCORES);
-
-    }
-
-    @Override
-    public Response<Set<Tuple>> zrangeByScoreWithScores(final String key, final double min, final double max,
-            final int offset, final int count) {
-        return new PipelineOperation<Set<Tuple>>() {
-
-            @Override
-            Response<Set<Tuple>> execute(Pipeline jedisPipeline) throws DynoException {
-                return jedisPipeline.zrangeByScoreWithScores(key, min, max, offset, count);
-            }
-
-        }.execute(key, OpName.ZRANGEBYSCOREWITHSCORES);
-
-    }
-
-    @Override
-    public Response<Set<String>> zrevrangeByScore(final String key, final double max, final double min) {
-        return new PipelineOperation<Set<String>>() {
-
-            @Override
-            Response<Set<String>> execute(Pipeline jedisPipeline) throws DynoException {
-                return jedisPipeline.zrevrangeByScore(key, max, min);
-            }
-
-        }.execute(key, OpName.ZREVRANGEBYSCORE);
-
-    }
-
-    @Override
-    public Response<Set<String>> zrevrangeByScore(final String key, final String max, final String min) {
-        return new PipelineOperation<Set<String>>() {
-
-            @Override
-            Response<Set<String>> execute(Pipeline jedisPipeline) throws DynoException {
-                return jedisPipeline.zrevrangeByScore(key, max, min);
-            }
-
-        }.execute(key, OpName.ZREVRANGEBYSCORE);
-
-    }
-
-    @Override
-    public Response<Set<String>> zrevrangeByScore(final String key, final double max, final double min,
-            final int offset, final int count) {
-        return new PipelineOperation<Set<String>>() {
-
-            @Override
-            Response<Set<String>> execute(Pipeline jedisPipeline) throws DynoException {
-                return jedisPipeline.zrevrangeByScore(key, max, min, offset, count);
-            }
-
-        }.execute(key, OpName.ZREVRANGEBYSCORE);
-
-    }
-
-    @Override
-    public Response<Set<Tuple>> zrevrangeByScoreWithScores(final String key, final double max, final double min) {
-        return new PipelineOperation<Set<Tuple>>() {
-
-            @Override
-            Response<Set<Tuple>> execute(Pipeline jedisPipeline) throws DynoException {
-                return jedisPipeline.zrevrangeByScoreWithScores(key, max, min);
-            }
-
-        }.execute(key, OpName.ZREVRANGEBYSCOREWITHSCORES);
-
-    }
-
-    @Override
-    public Response<Set<Tuple>> zrevrangeByScoreWithScores(final String key, final double max, final double min,
-            final int offset, final int count) {
-        return new PipelineOperation<Set<Tuple>>() {
-
-            @Override
-            Response<Set<Tuple>> execute(Pipeline jedisPipeline) throws DynoException {
-                return jedisPipeline.zrevrangeByScoreWithScores(key, max, min, offset, count);
-            }
-
-        }.execute(key, OpName.ZREVRANGEBYSCOREWITHSCORES);
-
-    }
-
-    @Override
-    public Response<Set<Tuple>> zrangeWithScores(final String key, final long start, final long end) {
-        return new PipelineOperation<Set<Tuple>>() {
-
-            @Override
-            Response<Set<Tuple>> execute(Pipeline jedisPipeline) throws DynoException {
-                return jedisPipeline.zrangeWithScores(key, start, end);
-            }
-
-        }.execute(key, OpName.ZRANGEWITHSCORES);
-
-    }
-
-    @Override
-    public Response<Long> zrank(final String key, final String member) {
-        return new PipelineOperation<Long>() {
-
-            @Override
-            Response<Long> execute(Pipeline jedisPipeline) throws DynoException {
-                return jedisPipeline.zrank(key, member);
-            }
-
-        }.execute(key, OpName.ZRANK);
-
-    }
-
-    @Override
-    public Response<Long> zrem(final String key, final String... member) {
-        return new PipelineOperation<Long>() {
-
-            @Override
-            Response<Long> execute(Pipeline jedisPipeline) throws DynoException {
-                return jedisPipeline.zrem(key, member);
-            }
-
-        }.execute(key, OpName.ZREM);
-
-    }
-
-    @Override
-    public Response<Long> zremrangeByRank(final String key, final long start, final long end) {
-        return new PipelineOperation<Long>() {
-
-            @Override
-            Response<Long> execute(Pipeline jedisPipeline) throws DynoException {
-                return jedisPipeline.zremrangeByRank(key, start, end);
-            }
-
-        }.execute(key, OpName.ZREMRANGEBYRANK);
-
-    }
-
-    @Override
-    public Response<Long> zremrangeByScore(final String key, final double start, final double end) {
-        return new PipelineOperation<Long>() {
-
-            @Override
-            Response<Long> execute(Pipeline jedisPipeline) throws DynoException {
-                return jedisPipeline.zremrangeByScore(key, start, end);
-            }
-
-        }.execute(key, OpName.ZREMRANGEBYSCORE);
-
-    }
-
-    @Override
-    public Response<Set<String>> zrevrange(final String key, final long start, final long end) {
-        return new PipelineOperation<Set<String>>() {
-
-            @Override
-            Response<Set<String>> execute(Pipeline jedisPipeline) throws DynoException {
-                return jedisPipeline.zrevrange(key, start, end);
-            }
-
-        }.execute(key, OpName.ZREVRANGE);
-
-    }
-
-    @Override
-    public Response<Set<Tuple>> zrevrangeWithScores(final String key, final long start, final long end) {
-        return new PipelineOperation<Set<Tuple>>() {
-
-            @Override
-            Response<Set<Tuple>> execute(Pipeline jedisPipeline) throws DynoException {
-                return jedisPipeline.zrevrangeWithScores(key, start, end);
-            }
-
-        }.execute(key, OpName.ZREVRANGEWITHSCORES);
-
-    }
-
-    @Override
-    public Response<Long> zrevrank(final String key, final String member) {
-        return new PipelineOperation<Long>() {
-
-            @Override
-            Response<Long> execute(Pipeline jedisPipeline) throws DynoException {
-                return jedisPipeline.zrevrank(key, member);
-            }
-
-        }.execute(key, OpName.ZREVRANK);
-
-    }
-
-    @Override
-    public Response<Double> zscore(final String key, final String member) {
-        return new PipelineOperation<Double>() {
-
-            @Override
-            Response<Double> execute(Pipeline jedisPipeline) throws DynoException {
-                return jedisPipeline.zscore(key, member);
-            }
-
-        }.execute(key, OpName.ZSCORE);
-
-    }
-
-    /**
-     * This method is not supported by the BinaryRedisPipeline interface.
-     */
-    public Response<ScanResult<Tuple>> zscan(final String key, final int cursor) {
-        throw new UnsupportedOperationException("'ZSCAN' cannot be called in pipeline");
-    }
-
-    @Override
-    public Response<Long> zlexcount(String key, String min, String max) {
-        throw new UnsupportedOperationException("not yet implemented");
-    }
-
-    @Override
-    public Response<Set<String>> zrangeByLex(String key, String min, String max) {
-        throw new UnsupportedOperationException("not yet implemented");
-    }
-
-    @Override
-    public Response<Set<String>> zrangeByLex(String key, String min, String max, int offset, int count) {
-        throw new UnsupportedOperationException("not yet implemented");
-    }
-
-    @Override
-    public Response<Long> zremrangeByLex(String key, String start, String end) {
-        throw new UnsupportedOperationException("not yet implemented");
-    }
-
-    @Override
-    public Response<Long> bitcount(final String key) {
-        return new PipelineOperation<Long>() {
-
-            @Override
-            Response<Long> execute(Pipeline jedisPipeline) throws DynoException {
-                return jedisPipeline.bitcount(key);
-            }
-
-        }.execute(key, OpName.BITCOUNT);
-
-    }
-
-    @Override
-    public Response<Long> bitcount(final String key, final long start, final long end) {
-        return new PipelineOperation<Long>() {
-
-            @Override
-            Response<Long> execute(Pipeline jedisPipeline) throws DynoException {
-                return jedisPipeline.bitcount(key, start, end);
-            }
-
-        }.execute(key, OpName.BITCOUNT);
-
-    }
-
-    @Override
-    public Response<Long> pfadd(String key, String... elements) {
-        throw new UnsupportedOperationException("not yet implemented");
-    }
-
-    @Override
-    public Response<Long> pfcount(String key) {
-        throw new UnsupportedOperationException("not yet implemented");
-    }
-
-    @Override
-    public Response<List<Long>> bitfield(String key, String... arguments) {
-        throw new UnsupportedOperationException("not yet implemented");
-    }
-
-    @Override
-    public Response<Set<String>> zrevrangeByLex(String key, String max, String min) {
-        throw new UnsupportedOperationException("not yet implemented");
-    }
-
-    @Override
-    public Response<Set<String>> zrevrangeByLex(String key, String max, String min, int offset, int count) {
-        throw new UnsupportedOperationException("not yet implemented");
-    }
-
-    @Override
-    public Response<Long> geoadd(String arg0, Map<String, GeoCoordinate> arg1) {
-        throw new UnsupportedOperationException("not yet implemented");
-    }
-
-    @Override
-    public Response<Long> geoadd(String arg0, double arg1, double arg2, String arg3) {
-        throw new UnsupportedOperationException("not yet implemented");
-    }
-
-    @Override
-    public Response<Double> geodist(String arg0, String arg1, String arg2) {
-        throw new UnsupportedOperationException("not yet implemented");
-    }
-
-    @Override
-    public Response<Double> geodist(String arg0, String arg1, String arg2, GeoUnit arg3) {
-        throw new UnsupportedOperationException("not yet implemented");
-    }
-
-    @Override
-    public Response<List<String>> geohash(String arg0, String... arg1) {
-        throw new UnsupportedOperationException("not yet implemented");
-    }
-
-    @Override
-    public Response<List<GeoCoordinate>> geopos(String arg0, String... arg1) {
-        throw new UnsupportedOperationException("not yet implemented");
-    }
-
-    @Override
-    public Response<List<GeoRadiusResponse>> georadius(String arg0, double arg1, double arg2, double arg3,
-            GeoUnit arg4) {
-        throw new UnsupportedOperationException("not yet implemented");
-    }
-
-    @Override
-    public Response<List<GeoRadiusResponse>> georadius(String arg0, double arg1, double arg2, double arg3, GeoUnit arg4,
-            GeoRadiusParam arg5) {
-        throw new UnsupportedOperationException("not yet implemented");
-    }
-
-    @Override
-    public Response<List<GeoRadiusResponse>> georadiusByMember(String arg0, String arg1, double arg2, GeoUnit arg3) {
-        throw new UnsupportedOperationException("not yet implemented");
-    }
-
-    @Override
-    public Response<List<GeoRadiusResponse>> georadiusByMember(String arg0, String arg1, double arg2, GeoUnit arg3,
-            GeoRadiusParam arg4) {
-        throw new UnsupportedOperationException("not yet implemented");
-    }
-
-    @Override
-    public Response<Long> zadd(String arg0, Map<String, Double> arg1, ZAddParams arg2) {
-        throw new UnsupportedOperationException("not yet implemented");
-
-    }
-
-    @Override
-    public Response<Long> zadd(String arg0, double arg1, String arg2, ZAddParams arg3) {
-        throw new UnsupportedOperationException("not yet implemented");
-
-    }
-
-    @Override
-    public Response<Double> zincrby(String arg0, double arg1, String arg2, ZIncrByParams arg3) {
-        throw new UnsupportedOperationException("not yet implemented");
-    }
-
-    public void sync() {
-        long startTime = System.nanoTime() / 1000;
-        try {
-            jedisPipeline.sync();
-            opMonitor.recordPipelineSync();
-        } catch (JedisConnectionException jce) {
-            String msg = "Failed sync() to host: " + getHostInfo();
-            pipelineEx.set(new FatalConnectionException(msg, jce));
-            cpMonitor.incOperationFailure(connection == null ? null : connection.getHost(), jce);
-            throw jce;
-        } finally {
-            long duration = System.nanoTime() / 1000 - startTime;
-            opMonitor.recordLatency(duration, TimeUnit.MICROSECONDS);
-            discardPipeline(false);
-            releaseConnection();
-        }
-    }
-
-    public List<Object> syncAndReturnAll() {
-        long startTime = System.nanoTime() / 1000;
-        try {
-            List<Object> result = jedisPipeline.syncAndReturnAll();
-            opMonitor.recordPipelineSync();
-            return result;
-        } catch (JedisConnectionException jce) {
-            String msg = "Failed syncAndReturnAll() to host: " + getHostInfo();
-            pipelineEx.set(new FatalConnectionException(msg, jce));
-            cpMonitor.incOperationFailure(connection == null ? null : connection.getHost(), jce);
-            throw jce;
-        } finally {
-            long duration = System.nanoTime() / 1000 - startTime;
-            opMonitor.recordLatency(duration, TimeUnit.MICROSECONDS);
-            discardPipeline(false);
-            releaseConnection();
-        }
-    }
-
-    private void discardPipeline(boolean recordLatency) {
-        try {
-            if (jedisPipeline != null) {
-                long startTime = System.nanoTime() / 1000;
-                jedisPipeline.sync();
-                if (recordLatency) {
-                    long duration = System.nanoTime() / 1000 - startTime;
-                    opMonitor.recordLatency(duration, TimeUnit.MICROSECONDS);
-                }
-                jedisPipeline = null;
-            }
-        } catch (Exception e) {
-            Logger.warn(String.format("Failed to discard jedis pipeline, %s", getHostInfo()), e);
-        }
-    }
-
-    private void releaseConnection() {
-        if (connection != null) {
-            try {
-                connection.getContext().reset();
-                connection.getParentConnectionPool().returnConnection(connection);
-                if (pipelineEx.get() != null) {
-                    connPool.getHealthTracker().trackConnectionError(connection.getParentConnectionPool(),
-                            pipelineEx.get());
-                    pipelineEx.set(null);
-                }
-                connection = null;
-            } catch (Exception e) {
-                Logger.warn(String.format("Failed to return connection in Dyno Jedis Pipeline, %s", getHostInfo()), e);
-            }
-        }
-    }
-
-    public void discardPipelineAndReleaseConnection() {
-        opMonitor.recordPipelineDiscard();
-        discardPipeline(true);
-        releaseConnection();
-    }
-
-    @Override
-    public void close() throws Exception {
-        discardPipelineAndReleaseConnection();
-    }
-
-    private String getHostInfo() {
-        if (connection != null && connection.getHost() != null) {
-            return connection.getHost().toString();
-        }
-
-        return "unknown";
-    }
+public class DynoJedisPipeline implements RedisPipeline, BinaryRedisPipeline, AutoCloseable {
+
+	private static final Logger Logger = LoggerFactory.getLogger(DynoJedisPipeline.class);
+
+	// ConnPool and connection to exec the pipeline
+	private final ConnectionPoolImpl<Jedis> connPool;
+	private volatile Connection<Jedis> connection;
+	private final DynoJedisPipelineMonitor opMonitor;
+	private final ConnectionPoolMonitor cpMonitor;
+
+	// the cached pipeline
+	private volatile Pipeline jedisPipeline = null;
+	// the cached row key for the pipeline. all subsequent requests to pipeline
+	// must be the same. this is used to check that.
+	private final AtomicReference<String> theKey = new AtomicReference<String>(null);
+	private final AtomicReference<byte[]> theBinaryKey = new AtomicReference<byte[]>(null);
+	private final AtomicReference<String> hashtag = new AtomicReference<String>(null);
+	// used for tracking errors
+	private final AtomicReference<DynoException> pipelineEx = new AtomicReference<DynoException>(null);
+
+	private static final String DynoPipeline = "DynoPipeline";
+
+	DynoJedisPipeline(ConnectionPoolImpl<Jedis> cPool, DynoJedisPipelineMonitor operationMonitor,
+			ConnectionPoolMonitor connPoolMonitor) {
+		this.connPool = cPool;
+		this.opMonitor = operationMonitor;
+		this.cpMonitor = connPoolMonitor;
+	}
+
+	private void pipelined(final byte[] key) {
+		try {
+			try {
+				connection = connPool.getConnectionForOperation(new BaseOperation<Jedis, String>() {
+
+					@Override
+					public String getName() {
+						return DynoPipeline;
+					}
+
+					@Override
+					public String getStringKey() {// we do not use it in this context
+						return null;
+					}
+
+					@Override
+					public byte[] getBinaryKey() {
+						return key;
+					}
+
+				});
+			} catch (NoAvailableHostsException nahe) {
+				cpMonitor.incOperationFailure(connection != null ? connection.getHost() : null, nahe);
+				discardPipelineAndReleaseConnection();
+				throw nahe;
+			}
+		} catch (NoAvailableHostsException nahe) {
+			cpMonitor.incOperationFailure(connection != null ? connection.getHost() : null, nahe);
+			discardPipelineAndReleaseConnection();
+			throw nahe;
+		}
+		Jedis jedis = ((JedisConnection) connection).getClient();
+		jedisPipeline = jedis.pipelined();
+		cpMonitor.incOperationSuccess(connection.getHost(), 0);
+	}
+
+	private void pipelined(final String key) {
+		try {
+			try {
+				connection = connPool.getConnectionForOperation(new BaseOperation<Jedis, String>() {
+
+					@Override
+					public String getName() {
+						return DynoPipeline;
+					}
+
+					@Override
+					public String getStringKey() {
+						return key;
+					}
+
+					@Override
+					public byte[] getBinaryKey() { // we do not use it in this context
+						return null;
+					}
+
+				});
+			} catch (NoAvailableHostsException nahe) {
+				cpMonitor.incOperationFailure(connection != null ? connection.getHost() : null, nahe);
+				discardPipelineAndReleaseConnection();
+				throw nahe;
+			}
+		} catch (NoAvailableHostsException nahe) {
+			cpMonitor.incOperationFailure(connection != null ? connection.getHost() : null, nahe);
+			discardPipelineAndReleaseConnection();
+			throw nahe;
+		}
+		Jedis jedis = ((JedisConnection) connection).getClient();
+		jedisPipeline = jedis.pipelined();
+		cpMonitor.incOperationSuccess(connection.getHost(), 0);
+	}
+
+	private void checkHashtag(final String key, final String hashtagValue) {
+		if (this.hashtag.get() != null) {
+			verifyHashtagValue(hashtagValue);
+		} else {
+			boolean success = this.hashtag.compareAndSet(null, hashtagValue);
+			if (!success) {
+				verifyHashtagValue(hashtagValue);
+			} else {
+				pipelined(key);
+			}
+		}
+
+	}
+
+	/**
+	 * Checks that a pipeline is associated with a single key. Binary keys do not
+	 * support hashtags.
+	 * 
+	 * @param key
+	 */
+	private void checkKey(final byte[] key) {
+		if (theBinaryKey.get() != null) {
+			verifyKey(key);
+		} else {
+			boolean success = theBinaryKey.compareAndSet(null, key);
+			if (!success) {
+				// someone already beat us to it. that's fine, just verify
+				// that the key is the same
+				verifyKey(key);
+			} else {
+				pipelined(key);
+			}
+		}
+	}
+
+	/**
+	 * Checks that a pipeline is associated with a single key. If there is a hashtag
+	 * defined in the first host of the connectionpool then we check that first.
+	 * 
+	 * @param key
+	 */
+	private void checkKey(final String key) {
+
+		/*
+		 * Get hashtag from the first host of the active pool We cannot use the
+		 * connection object because as of now we have not selected a connection. A
+		 * connection is selected based on the key or hashtag respectively.
+		 */
+		String hashtag = connPool.getConfiguration().getHashtag();
+		if (hashtag == null || hashtag.isEmpty()) {
+			if (theKey.get() != null) {
+				verifyKey(key);
+			} else {
+				boolean success = theKey.compareAndSet(null, key);
+				if (!success) {
+					// someone already beat us to it. that's fine, just verify
+					// that the key is the same
+					verifyKey(key);
+				} else {
+					pipelined(key);
+				}
+			}
+		} else {
+			/*
+			 * We have a identified a hashtag in the Host object. That means Dynomite has a
+			 * defined hashtag. Producing the hashvalue out of the hashtag and using that as
+			 * a reference to the pipeline
+			 */
+			String hashValue = StringUtils.substringBetween(key, Character.toString(hashtag.charAt(0)),
+					Character.toString(hashtag.charAt(1)));
+			checkHashtag(key, hashValue);
+		}
+	}
+
+	/**
+	 * Verifies binary key with pipeline binary key
+	 */
+	private void verifyKey(final byte[] key) {
+		if (!theBinaryKey.get().equals(key)) {
+			try {
+				throw new RuntimeException("Must have same key for Redis Pipeline in Dynomite. This key: " + key);
+			} finally {
+				discardPipelineAndReleaseConnection();
+			}
+		}
+	}
+
+	/**
+	 * Verifies key with pipeline key
+	 */
+	private void verifyKey(final String key) {
+
+		if (!theKey.get().equals(key)) {
+			try {
+				throw new RuntimeException("Must have same key for Redis Pipeline in Dynomite. This key: " + key);
+			} finally {
+				discardPipelineAndReleaseConnection();
+			}
+		}
+	}
+
+	private void verifyHashtagValue(final String hashtagValue) {
+
+		if (!this.hashtag.get().equals(hashtagValue)) {
+			try {
+				throw new RuntimeException(
+						"Must have same hashtag for Redis Pipeline in Dynomite. This hashvalue: " + hashtagValue);
+			} finally {
+				discardPipelineAndReleaseConnection();
+			}
+		}
+	}
+
+	private String decompressValue(String value) {
+		try {
+			if (ZipUtils.isCompressed(value)) {
+				return ZipUtils.decompressFromBase64String(value);
+			}
+		} catch (IOException e) {
+			Logger.warn("Unable to decompress value [" + value + "]");
+		}
+
+		return value;
+	}
+
+	private byte[] decompressValue(byte[] value) {
+		try {
+			if (ZipUtils.isCompressed(value)) {
+				return ZipUtils.decompressBytesNonBase64(value);
+			}
+		} catch (IOException e) {
+			Logger.warn("Unable to decompress byte array value [" + value + "]");
+		}
+		return value;
+	}
+
+	/**
+	 * As long as jdk 7 and below is supported we need to define our own function
+	 * interfaces
+	 */
+	private interface Func0<R> {
+		R call();
+	}
+
+	public class PipelineResponse extends Response<String> {
+
+		private Response<String> response;
+
+		public PipelineResponse(Builder<String> b) {
+			super(BuilderFactory.STRING);
+		}
+
+		public PipelineResponse apply(Func0<? extends Response<String>> f) {
+			this.response = f.call();
+			return this;
+		}
+
+		@Override
+		public String get() {
+			return decompressValue(response.get());
+		}
+
+	}
+
+	public class PipelineLongResponse extends Response<Long> {
+		private Response<Long> response;
+
+		public PipelineLongResponse(Builder<Long> b) {
+			super(b);
+		}
+
+		public PipelineLongResponse apply(Func0<? extends Response<Long>> f) {
+			this.response = f.call();
+			return this;
+		}
+	}
+
+	public class PipelineListResponse extends Response<List<String>> {
+
+		private Response<List<String>> response;
+
+		public PipelineListResponse(Builder<List> b) {
+			super(BuilderFactory.STRING_LIST);
+		}
+
+		public PipelineListResponse apply(Func0<? extends Response<List<String>>> f) {
+			this.response = f.call();
+			return this;
+		}
+
+		@Override
+		public List<String> get() {
+			return new ArrayList<String>(
+					CollectionUtils.transform(response.get(), new CollectionUtils.Transform<String, String>() {
+						@Override
+						public String get(String s) {
+							return decompressValue(s);
+						}
+					}));
+		}
+	}
+
+	public class PipelineBinaryResponse extends Response<byte[]> {
+
+		private Response<byte[]> response;
+
+		public PipelineBinaryResponse(Builder<String> b) {
+			super(BuilderFactory.BYTE_ARRAY);
+		}
+
+		public PipelineBinaryResponse apply(Func0<? extends Response<byte[]>> f) {
+			this.response = f.call();
+			return this;
+		}
+
+		@Override
+		public byte[] get() {
+			return decompressValue(response.get());
+		}
+
+	}
+
+	public class PipelineMapResponse extends Response<Map<String, String>> {
+
+		private Response<Map<String, String>> response;
+
+		public PipelineMapResponse(Builder<Map<String, String>> b) {
+			super(BuilderFactory.STRING_MAP);
+		}
+
+		@Override
+		public Map<String, String> get() {
+			return CollectionUtils.transform(response.get(),
+					new CollectionUtils.MapEntryTransform<String, String, String>() {
+						@Override
+						public String get(String key, String val) {
+							return decompressValue(val);
+						}
+					});
+		}
+	}
+
+	public class PipelineBinaryMapResponse extends Response<Map<byte[], byte[]>> {
+
+		private Response<Map<byte[], byte[]>> response;
+
+		public PipelineBinaryMapResponse(Builder<Map<byte[], byte[]>> b) {
+			super(BuilderFactory.BYTE_ARRAY_MAP);
+		}
+
+		public PipelineBinaryMapResponse apply(Func0<? extends Response<Map<byte[], byte[]>>> f) {
+			this.response = f.call();
+			return this;
+		}
+
+		@Override
+		public Map<byte[], byte[]> get() {
+			return CollectionUtils.transform(response.get(),
+					new CollectionUtils.MapEntryTransform<byte[], byte[], byte[]>() {
+						@Override
+						public byte[] get(byte[] key, byte[] val) {
+							return decompressValue(val);
+						}
+					});
+		}
+
+	}
+
+	private abstract class PipelineOperation<R> {
+
+		abstract Response<R> execute(Pipeline jedisPipeline) throws DynoException;
+
+		Response<R> execute(final byte[] key, final OpName opName) {
+			checkKey(key);
+			return execute(key, opName);
+		}
+
+		Response<R> execute(final String key, final OpName opName) {
+			checkKey(key);
+			return executeOperation(opName);
+		}
+
+		Response<R> executeOperation(final OpName opName) {
+			try {
+				opMonitor.recordOperation(opName.name());
+				return execute(jedisPipeline);
+
+			} catch (JedisConnectionException ex) {
+				handleConnectionException(ex);
+				throw ex;
+			}
+		}
+
+		void handleConnectionException(JedisConnectionException ex) {
+			DynoException e = new FatalConnectionException(ex).setAttempt(1);
+			pipelineEx.set(e);
+			cpMonitor.incOperationFailure(connection.getHost(), e);
+		}
+	}
+
+	private abstract class PipelineCompressionOperation<R> extends PipelineOperation<R> {
+
+		/**
+		 * Compresses the value based on the threshold defined by
+		 * {@link ConnectionPoolConfiguration#getValueCompressionThreshold()}
+		 *
+		 * @param value
+		 * @return
+		 */
+		public String compressValue(String value) {
+			String result = value;
+			int thresholdBytes = connPool.getConfiguration().getValueCompressionThreshold();
+
+			try {
+				// prefer speed over accuracy here so rather than using
+				// getBytes() to get the actual size
+				// just estimate using 2 bytes per character
+				if ((2 * value.length()) > thresholdBytes) {
+					result = ZipUtils.compressStringToBase64String(value);
+				}
+			} catch (IOException e) {
+				Logger.warn("UNABLE to compress [" + value + "]; sending value uncompressed");
+			}
+
+			return result;
+		}
+
+		public byte[] compressValue(byte[] value) {
+			int thresholdBytes = connPool.getConfiguration().getValueCompressionThreshold();
+
+			if (value.length > thresholdBytes) {
+				try {
+					return ZipUtils.compressBytesNonBase64(value);
+				} catch (IOException e) {
+					Logger.warn("UNABLE to compress byte array [" + value + "]; sending value uncompressed");
+				}
+			}
+
+			return value;
+		}
+
+	}
+
+	@Override
+	public Response<Long> append(final String key, final String value) {
+
+		return new PipelineOperation<Long>() {
+
+			@Override
+			Response<Long> execute(Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.append(key, value);
+			}
+
+		}.execute(key, OpName.APPEND);
+	}
+
+	@Override
+	public Response<List<String>> blpop(final String arg) {
+
+		return new PipelineOperation<List<String>>() {
+
+			@Override
+			Response<List<String>> execute(Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.blpop(arg);
+			}
+		}.execute(arg, OpName.BLPOP);
+
+	}
+
+	@Override
+	public Response<List<String>> brpop(final String arg) {
+		return new PipelineOperation<List<String>>() {
+
+			@Override
+			Response<List<String>> execute(Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.brpop(arg);
+			}
+		}.execute(arg, OpName.BRPOP);
+
+	}
+
+	@Override
+	public Response<Long> decr(final String key) {
+		return new PipelineOperation<Long>() {
+
+			@Override
+			Response<Long> execute(Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.decr(key);
+			}
+		}.execute(key, OpName.DECR);
+	}
+
+	@Override
+	public Response<Long> decrBy(final String key, final long integer) {
+		return new PipelineOperation<Long>() {
+
+			@Override
+			Response<Long> execute(Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.decrBy(key, integer);
+			}
+		}.execute(key, OpName.DECRBY);
+	}
+
+	@Override
+	public Response<Long> del(final String key) {
+		return new PipelineOperation<Long>() {
+
+			@Override
+			Response<Long> execute(Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.del(key);
+			}
+		}.execute(key, OpName.DEL);
+
+	}
+
+	@Override
+	public Response<String> echo(final String string) {
+		return new PipelineOperation<String>() {
+
+			@Override
+			Response<String> execute(Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.echo(string);
+			}
+		}.execute(string, OpName.ECHO);
+
+	}
+
+	@Override
+	public Response<Boolean> exists(final String key) {
+		return new PipelineOperation<Boolean>() {
+
+			@Override
+			Response<Boolean> execute(final Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.exists(key);
+			}
+		}.execute(key, OpName.EXISTS);
+	}
+
+	@Override
+	public Response<Long> expire(final String key, final int seconds) {
+		return new PipelineOperation<Long>() {
+
+			@Override
+			Response<Long> execute(final Pipeline jedisPipeline) throws DynoException {
+				long startTime = System.nanoTime() / 1000;
+				try {
+					return jedisPipeline.expire(key, seconds);
+				} finally {
+					long duration = System.nanoTime() / 1000 - startTime;
+					opMonitor.recordSendLatency(OpName.EXPIRE.name(), duration, TimeUnit.MICROSECONDS);
+				}
+			}
+		}.execute(key, OpName.EXPIRE);
+
+	}
+
+	@Override
+	public Response<Long> pexpire(String key, long milliseconds) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Long> expireAt(final String key, final long unixTime) {
+		return new PipelineOperation<Long>() {
+
+			@Override
+			Response<Long> execute(final Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.expireAt(key, unixTime);
+			}
+		}.execute(key, OpName.EXPIREAT);
+
+	}
+
+	@Override
+	public Response<Long> pexpireAt(String key, long millisecondsTimestamp) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<String> get(final String key) {
+		if (CompressionStrategy.NONE == connPool.getConfiguration().getCompressionStrategy()) {
+			return new PipelineOperation<String>() {
+				@Override
+				Response<String> execute(Pipeline jedisPipeline) throws DynoException {
+					long startTime = System.nanoTime() / 1000;
+					try {
+						return jedisPipeline.get(key);
+					} finally {
+						long duration = System.nanoTime() / 1000 - startTime;
+						opMonitor.recordSendLatency(OpName.GET.name(), duration, TimeUnit.MICROSECONDS);
+					}
+				}
+			}.execute(key, OpName.GET);
+		} else {
+			return new PipelineCompressionOperation<String>() {
+				@Override
+				Response<String> execute(final Pipeline jedisPipeline) throws DynoException {
+					return new PipelineResponse(null).apply(new Func0<Response<String>>() {
+						@Override
+						public Response<String> call() {
+							return jedisPipeline.get(key);
+						}
+					});
+				}
+			}.execute(key, OpName.GET);
+		}
+
+	}
+
+	@Override
+	public Response<Boolean> getbit(final String key, final long offset) {
+		return new PipelineOperation<Boolean>() {
+
+			@Override
+			Response<Boolean> execute(Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.getbit(key, offset);
+			}
+		}.execute(key, OpName.GETBIT);
+
+	}
+
+	@Override
+	public Response<String> getrange(final String key, final long startOffset, final long endOffset) {
+		return new PipelineOperation<String>() {
+
+			@Override
+			Response<String> execute(Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.getrange(key, startOffset, endOffset);
+			}
+		}.execute(key, OpName.GETRANGE);
+
+	}
+
+	@Override
+	public Response<String> getSet(final String key, final String value) {
+		if (CompressionStrategy.NONE == connPool.getConfiguration().getCompressionStrategy()) {
+			return new PipelineOperation<String>() {
+				@Override
+				Response<String> execute(Pipeline jedisPipeline) throws DynoException {
+					return jedisPipeline.getSet(key, value);
+				}
+			}.execute(key, OpName.GETSET);
+		} else {
+			return new PipelineCompressionOperation<String>() {
+				@Override
+				Response<String> execute(final Pipeline jedisPipeline) throws DynoException {
+					return new PipelineResponse(null).apply(new Func0<Response<String>>() {
+						@Override
+						public Response<String> call() {
+							return jedisPipeline.getSet(key, compressValue(value));
+						}
+					});
+				}
+			}.execute(key, OpName.GETSET);
+		}
+	}
+
+	@Override
+	public Response<Long> hdel(final String key, final String... field) {
+		return new PipelineOperation<Long>() {
+
+			@Override
+			Response<Long> execute(Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.hdel(key, field);
+			}
+		}.execute(key, OpName.HDEL);
+
+	}
+
+	@Override
+	public Response<Boolean> hexists(final String key, final String field) {
+		return new PipelineOperation<Boolean>() {
+
+			@Override
+			Response<Boolean> execute(Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.hexists(key, field);
+			}
+		}.execute(key, OpName.HEXISTS);
+
+	}
+
+	@Override
+	public Response<String> hget(final String key, final String field) {
+		if (CompressionStrategy.NONE == connPool.getConfiguration().getCompressionStrategy()) {
+			return new PipelineOperation<String>() {
+				@Override
+				Response<String> execute(Pipeline jedisPipeline) throws DynoException {
+					return jedisPipeline.hget(key, field);
+				}
+			}.execute(key, OpName.HGET);
+		} else {
+			return new PipelineCompressionOperation<String>() {
+				@Override
+				Response<String> execute(final Pipeline jedisPipeline) throws DynoException {
+					return new PipelineResponse(null).apply(new Func0<Response<String>>() {
+						@Override
+						public Response<String> call() {
+							return jedisPipeline.hget(key, field);
+						}
+					});
+				}
+			}.execute(key, OpName.HGET);
+		}
+
+	}
+
+	/**
+	 * This method is a BinaryRedisPipeline command which dyno does not yet properly
+	 * support, therefore the interface is not yet implemented.
+	 */
+	public Response<byte[]> hget(final byte[] key, final byte[] field) {
+		if (CompressionStrategy.NONE == connPool.getConfiguration().getCompressionStrategy()) {
+			return new PipelineOperation<byte[]>() {
+				@Override
+				Response<byte[]> execute(Pipeline jedisPipeline) throws DynoException {
+					return jedisPipeline.hget(key, field);
+				}
+			}.execute(key, OpName.HGET);
+		} else {
+			return new PipelineCompressionOperation<byte[]>() {
+				@Override
+				Response<byte[]> execute(final Pipeline jedisPipeline) throws DynoException {
+					return new PipelineBinaryResponse(null).apply(new Func0<Response<byte[]>>() {
+						@Override
+						public Response<byte[]> call() {
+							return jedisPipeline.hget(key, field);
+						}
+					});
+				}
+			}.execute(key, OpName.HGET);
+		}
+	}
+
+	@Override
+	public Response<Map<String, String>> hgetAll(final String key) {
+
+		return new PipelineOperation<Map<String, String>>() {
+
+			@Override
+			Response<Map<String, String>> execute(Pipeline jedisPipeline) throws DynoException {
+				long startTime = System.nanoTime() / 1000;
+				try {
+					return jedisPipeline.hgetAll(key);
+				} finally {
+					long duration = System.nanoTime() / 1000 - startTime;
+					opMonitor.recordSendLatency(OpName.HGETALL.name(), duration, TimeUnit.MICROSECONDS);
+				}
+			}
+
+		}.execute(key, OpName.HGETALL);
+
+	}
+
+	/**
+	 * This method is a BinaryRedisPipeline command which dyno does not yet properly
+	 * support, therefore the interface is not yet implemented.
+	 */
+	public Response<Map<byte[], byte[]>> hgetAll(final byte[] key) {
+		if (CompressionStrategy.NONE == connPool.getConfiguration().getCompressionStrategy()) {
+			return new PipelineOperation<Map<byte[], byte[]>>() {
+				@Override
+				Response<Map<byte[], byte[]>> execute(Pipeline jedisPipeline) throws DynoException {
+					long startTime = System.nanoTime() / 1000;
+					try {
+						return jedisPipeline.hgetAll(key);
+					} finally {
+						long duration = System.nanoTime() / 1000 - startTime;
+						opMonitor.recordSendLatency(OpName.HGETALL.name(), duration, TimeUnit.MICROSECONDS);
+					}
+				}
+			}.execute(key, OpName.HGETALL);
+		} else {
+			return new PipelineCompressionOperation<Map<byte[], byte[]>>() {
+				@Override
+				Response<Map<byte[], byte[]>> execute(final Pipeline jedisPipeline) throws DynoException {
+					return new PipelineBinaryMapResponse(null).apply(new Func0<Response<Map<byte[], byte[]>>>() {
+						@Override
+						public Response<Map<byte[], byte[]>> call() {
+							return jedisPipeline.hgetAll(key);
+						}
+					});
+				}
+			}.execute(key, OpName.HGETALL);
+		}
+	}
+
+	@Override
+	public Response<Long> hincrBy(final String key, final String field, final long value) {
+		return new PipelineOperation<Long>() {
+
+			@Override
+			Response<Long> execute(Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.hincrBy(key, field, value);
+			}
+		}.execute(key, OpName.HINCRBY);
+	}
+
+	/* not supported by RedisPipeline 2.7.3 */
+	public Response<Double> hincrByFloat(final String key, final String field, final double value) {
+		return new PipelineOperation<Double>() {
+
+			@Override
+			Response<Double> execute(Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.hincrByFloat(key, field, value);
+			}
+		}.execute(key, OpName.HINCRBYFLOAT);
+	}
+
+	@Override
+	public Response<Set<String>> hkeys(final String key) {
+		return new PipelineOperation<Set<String>>() {
+
+			@Override
+			Response<Set<String>> execute(Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.hkeys(key);
+			}
+		}.execute(key, OpName.HKEYS);
+
+	}
+
+	public Response<ScanResult<Map.Entry<String, String>>> hscan(final String key, int cursor) {
+		throw new UnsupportedOperationException("'HSCAN' cannot be called in pipeline");
+	}
+
+	@Override
+	public Response<Long> hlen(final String key) {
+		return new PipelineOperation<Long>() {
+
+			@Override
+			Response<Long> execute(Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.hlen(key);
+			}
+		}.execute(key, OpName.HLEN);
+
+	}
+
+	/**
+	 * This method is a BinaryRedisPipeline command which dyno does not yet properly
+	 * support, therefore the interface is not yet implemented.
+	 */
+	public Response<List<byte[]>> hmget(final byte[] key, final byte[]... fields) {
+		return new PipelineOperation<List<byte[]>>() {
+
+			@Override
+			Response<List<byte[]>> execute(Pipeline jedisPipeline) throws DynoException {
+				long startTime = System.nanoTime() / 1000;
+				try {
+					return jedisPipeline.hmget(key, fields);
+				} finally {
+					long duration = System.nanoTime() / 1000 - startTime;
+					opMonitor.recordSendLatency(OpName.HMGET.name(), duration, TimeUnit.MICROSECONDS);
+				}
+			}
+		}.execute(key, OpName.HMGET);
+	}
+
+	@Override
+	public Response<List<String>> hmget(final String key, final String... fields) {
+		if (CompressionStrategy.NONE == connPool.getConfiguration().getCompressionStrategy()) {
+			return new PipelineOperation<List<String>>() {
+				@Override
+				Response<List<String>> execute(Pipeline jedisPipeline) throws DynoException {
+					long startTime = System.nanoTime() / 1000;
+					try {
+						return jedisPipeline.hmget(key, fields);
+					} finally {
+						long duration = System.nanoTime() / 1000 - startTime;
+						opMonitor.recordSendLatency(OpName.HMGET.name(), duration, TimeUnit.MICROSECONDS);
+					}
+				}
+			}.execute(key, OpName.HMGET);
+		} else {
+			return new PipelineCompressionOperation<List<String>>() {
+				@Override
+				Response<List<String>> execute(final Pipeline jedisPipeline) throws DynoException {
+					long startTime = System.nanoTime() / 1000;
+					try {
+						return new PipelineListResponse(null).apply(new Func0<Response<List<String>>>() {
+							@Override
+							public Response<List<String>> call() {
+								return jedisPipeline.hmget(key, fields);
+							}
+						});
+					} finally {
+						long duration = System.nanoTime() / 1000 - startTime;
+						opMonitor.recordSendLatency(OpName.HMGET.name(), duration, TimeUnit.MICROSECONDS);
+					}
+				}
+			}.execute(key, OpName.HGET);
+		}
+	}
+
+	/**
+	 * This method is a BinaryRedisPipeline command which dyno does not yet properly
+	 * support, therefore the interface is not yet implemented since only a few
+	 * binary commands are present.
+	 */
+	public Response<String> hmset(final byte[] key, final Map<byte[], byte[]> hash) {
+		if (CompressionStrategy.NONE == connPool.getConfiguration().getCompressionStrategy()) {
+			return new PipelineOperation<String>() {
+				@Override
+				Response<String> execute(Pipeline jedisPipeline) throws DynoException {
+					long startTime = System.nanoTime() / 1000;
+					try {
+						return jedisPipeline.hmset(key, hash);
+					} finally {
+						long duration = System.nanoTime() / 1000 - startTime;
+						opMonitor.recordSendLatency(OpName.HMSET.name(), duration, TimeUnit.MICROSECONDS);
+					}
+				}
+			}.execute(key, OpName.HMSET);
+		} else {
+			return new PipelineCompressionOperation<String>() {
+				@Override
+				Response<String> execute(final Pipeline jedisPipeline) throws DynoException {
+					return new PipelineResponse(null).apply(new Func0<Response<String>>() {
+						@Override
+						public Response<String> call() {
+							return jedisPipeline.hmset(key, CollectionUtils.transform(hash,
+									new CollectionUtils.MapEntryTransform<byte[], byte[], byte[]>() {
+										@Override
+										public byte[] get(byte[] key, byte[] val) {
+											return compressValue(val);
+										}
+									}));
+						}
+					});
+				}
+			}.execute(key, OpName.HMSET);
+		}
+	}
+
+	@Override
+	public Response<String> hmset(final String key, final Map<String, String> hash) {
+		if (CompressionStrategy.NONE == connPool.getConfiguration().getCompressionStrategy()) {
+			return new PipelineOperation<String>() {
+				@Override
+				Response<String> execute(Pipeline jedisPipeline) throws DynoException {
+					long startTime = System.nanoTime() / 1000;
+					try {
+						return jedisPipeline.hmset(key, hash);
+					} finally {
+						long duration = System.nanoTime() / 1000 - startTime;
+						opMonitor.recordSendLatency(OpName.HMSET.name(), duration, TimeUnit.MICROSECONDS);
+					}
+				}
+			}.execute(key, OpName.HMSET);
+		} else {
+			return new PipelineCompressionOperation<String>() {
+				@Override
+				Response<String> execute(final Pipeline jedisPipeline) throws DynoException {
+					return new PipelineResponse(null).apply(new Func0<Response<String>>() {
+						@Override
+						public Response<String> call() {
+							return jedisPipeline.hmset(key, CollectionUtils.transform(hash,
+									new CollectionUtils.MapEntryTransform<String, String, String>() {
+										@Override
+										public String get(String key, String val) {
+											return compressValue(val);
+										}
+									}));
+						}
+					});
+				}
+			}.execute(key, OpName.HMSET);
+		}
+
+	}
+
+	@Override
+	public Response<Long> hset(final String key, final String field, final String value) {
+		if (CompressionStrategy.NONE == connPool.getConfiguration().getCompressionStrategy()) {
+			return new PipelineOperation<Long>() {
+				@Override
+				Response<Long> execute(Pipeline jedisPipeline) throws DynoException {
+					return jedisPipeline.hset(key, field, value);
+				}
+			}.execute(key, OpName.HSET);
+		} else {
+			return new PipelineCompressionOperation<Long>() {
+				@Override
+				Response<Long> execute(final Pipeline jedisPipeline) throws DynoException {
+					return new PipelineLongResponse(null).apply(new Func0<Response<Long>>() {
+						@Override
+						public Response<Long> call() {
+							return jedisPipeline.hset(key, field, compressValue(value));
+						}
+					});
+				}
+			}.execute(key, OpName.HSET);
+		}
+	}
+
+	/**
+	 * This method is a BinaryRedisPipeline command which dyno does not yet properly
+	 * support, therefore the interface is not yet implemented.
+	 */
+	public Response<Long> hset(final byte[] key, final byte[] field, final byte[] value) {
+		if (CompressionStrategy.NONE == connPool.getConfiguration().getCompressionStrategy()) {
+			return new PipelineOperation<Long>() {
+				@Override
+				Response<Long> execute(Pipeline jedisPipeline) throws DynoException {
+					return jedisPipeline.hset(key, field, value);
+				}
+			}.execute(key, OpName.HSET);
+		} else {
+			return new PipelineCompressionOperation<Long>() {
+				@Override
+				Response<Long> execute(final Pipeline jedisPipeline) throws DynoException {
+					return new PipelineLongResponse(null).apply(new Func0<Response<Long>>() {
+						@Override
+						public Response<Long> call() {
+							return jedisPipeline.hset(key, field, compressValue(value));
+						}
+					});
+				}
+			}.execute(key, OpName.HSET);
+		}
+	}
+
+	@Override
+	public Response<Long> hsetnx(final String key, final String field, final String value) {
+		if (CompressionStrategy.NONE == connPool.getConfiguration().getCompressionStrategy()) {
+			return new PipelineOperation<Long>() {
+				@Override
+				Response<Long> execute(Pipeline jedisPipeline) throws DynoException {
+					return jedisPipeline.hsetnx(key, field, value);
+				}
+			}.execute(key, OpName.HSETNX);
+		} else {
+			return new PipelineCompressionOperation<Long>() {
+				@Override
+				Response<Long> execute(final Pipeline jedisPipeline) throws DynoException {
+					return new PipelineLongResponse(null).apply(new Func0<Response<Long>>() {
+						@Override
+						public Response<Long> call() {
+							return jedisPipeline.hsetnx(key, field, compressValue(value));
+						}
+					});
+				}
+			}.execute(key, OpName.HSETNX);
+		}
+	}
+
+	@Override
+	public Response<List<String>> hvals(final String key) {
+		if (CompressionStrategy.NONE == connPool.getConfiguration().getCompressionStrategy()) {
+			return new PipelineOperation<List<String>>() {
+				@Override
+				Response<List<String>> execute(Pipeline jedisPipeline) throws DynoException {
+					return jedisPipeline.hvals(key);
+				}
+			}.execute(key, OpName.HVALS);
+		} else {
+			return new PipelineCompressionOperation<List<String>>() {
+				@Override
+				Response<List<String>> execute(final Pipeline jedisPipeline) throws DynoException {
+					return new PipelineListResponse(null).apply(new Func0<Response<List<String>>>() {
+						@Override
+						public Response<List<String>> call() {
+							return jedisPipeline.hvals(key);
+						}
+					});
+				}
+			}.execute(key, OpName.HVALS);
+		}
+
+	}
+
+	@Override
+	public Response<Long> incr(final String key) {
+		return new PipelineOperation<Long>() {
+
+			@Override
+			Response<Long> execute(Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.incr(key);
+			}
+
+		}.execute(key, OpName.INCR);
+
+	}
+
+	@Override
+	public Response<Long> incrBy(final String key, final long integer) {
+		return new PipelineOperation<Long>() {
+
+			@Override
+			Response<Long> execute(Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.incrBy(key, integer);
+			}
+
+		}.execute(key, OpName.INCRBY);
+
+	}
+
+	/* not supported by RedisPipeline 2.7.3 */
+	public Response<Double> incrByFloat(final String key, final double increment) {
+		return new PipelineOperation<Double>() {
+
+			@Override
+			Response<Double> execute(Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.incrByFloat(key, increment);
+			}
+
+		}.execute(key, OpName.INCRBYFLOAT);
+
+	}
+
+	@Override
+	public Response<String> lindex(final String key, final long index) {
+		return new PipelineOperation<String>() {
+
+			@Override
+			Response<String> execute(Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.lindex(key, index);
+			}
+
+		}.execute(key, OpName.LINDEX);
+
+	}
+
+	@Override
+	public Response<Long> linsert(final String key, final LIST_POSITION where, final String pivot, final String value) {
+		return new PipelineOperation<Long>() {
+
+			@Override
+			Response<Long> execute(Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.linsert(key, where, pivot, value);
+			}
+
+		}.execute(key, OpName.LINSERT);
+
+	}
+
+	@Override
+	public Response<Long> llen(final String key) {
+		return new PipelineOperation<Long>() {
+
+			@Override
+			Response<Long> execute(Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.llen(key);
+			}
+
+		}.execute(key, OpName.LLEN);
+
+	}
+
+	@Override
+	public Response<String> lpop(final String key) {
+		return new PipelineOperation<String>() {
+
+			@Override
+			Response<String> execute(Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.lpop(key);
+			}
+
+		}.execute(key, OpName.LPOP);
+
+	}
+
+	@Override
+	public Response<Long> lpush(final String key, final String... string) {
+		return new PipelineOperation<Long>() {
+
+			@Override
+			Response<Long> execute(Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.lpush(key, string);
+			}
+
+		}.execute(key, OpName.LPUSH);
+
+	}
+
+	@Override
+	public Response<Long> lpushx(final String key, final String... string) {
+		return new PipelineOperation<Long>() {
+
+			@Override
+			Response<Long> execute(Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.lpushx(key, string);
+			}
+
+		}.execute(key, OpName.LPUSHX);
+
+	}
+
+	@Override
+	public Response<List<String>> lrange(final String key, final long start, final long end) {
+		return new PipelineOperation<List<String>>() {
+
+			@Override
+			Response<List<String>> execute(Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.lrange(key, start, end);
+			}
+
+		}.execute(key, OpName.LRANGE);
+
+	}
+
+	@Override
+	public Response<Long> lrem(final String key, final long count, final String value) {
+		return new PipelineOperation<Long>() {
+
+			@Override
+			Response<Long> execute(Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.lrem(key, count, value);
+			}
+
+		}.execute(key, OpName.LREM);
+
+	}
+
+	@Override
+	public Response<String> lset(final String key, final long index, final String value) {
+		return new PipelineOperation<String>() {
+
+			@Override
+			Response<String> execute(Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.lset(key, index, value);
+			}
+
+		}.execute(key, OpName.LSET);
+
+	}
+
+	@Override
+	public Response<String> ltrim(final String key, final long start, final long end) {
+		return new PipelineOperation<String>() {
+
+			@Override
+			Response<String> execute(Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.ltrim(key, start, end);
+			}
+
+		}.execute(key, OpName.LTRIM);
+
+	}
+
+	@Override
+	public Response<Long> move(final String key, final int dbIndex) {
+		return new PipelineOperation<Long>() {
+
+			@Override
+			Response<Long> execute(Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.move(key, dbIndex);
+			}
+
+		}.execute(key, OpName.MOVE);
+
+	}
+
+	@Override
+	public Response<Long> persist(final String key) {
+		return new PipelineOperation<Long>() {
+
+			@Override
+			Response<Long> execute(Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.persist(key);
+			}
+
+		}.execute(key, OpName.PERSIST);
+
+	}
+
+	/* not supported by RedisPipeline 2.7.3 */
+	public Response<String> rename(final String oldkey, final String newkey) {
+		return new PipelineOperation<String>() {
+
+			@Override
+			Response<String> execute(Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.rename(oldkey, newkey);
+			}
+		}.execute(oldkey, OpName.RENAME);
+
+	}
+
+	/* not supported by RedisPipeline 2.7.3 */
+	public Response<Long> renamenx(final String oldkey, final String newkey) {
+		return new PipelineOperation<Long>() {
+
+			@Override
+			Response<Long> execute(Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.renamenx(oldkey, newkey);
+			}
+		}.execute(oldkey, OpName.RENAMENX);
+
+	}
+
+	@Override
+	public Response<String> rpop(final String key) {
+		return new PipelineOperation<String>() {
+
+			@Override
+			Response<String> execute(Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.rpop(key);
+			}
+
+		}.execute(key, OpName.RPOP);
+
+	}
+
+	@Override
+	public Response<Long> rpush(final String key, final String... string) {
+		return new PipelineOperation<Long>() {
+
+			@Override
+			Response<Long> execute(Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.rpush(key, string);
+			}
+
+		}.execute(key, OpName.RPUSH);
+
+	}
+
+	@Override
+	public Response<Long> rpushx(final String key, final String... string) {
+		return new PipelineOperation<Long>() {
+
+			@Override
+			Response<Long> execute(Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.rpushx(key, string);
+			}
+
+		}.execute(key, OpName.RPUSHX);
+
+	}
+
+	@Override
+	public Response<Long> sadd(final String key, final String... member) {
+		return new PipelineOperation<Long>() {
+
+			@Override
+			Response<Long> execute(Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.sadd(key, member);
+			}
+
+		}.execute(key, OpName.SADD);
+
+	}
+
+	@Override
+	public Response<Long> scard(final String key) {
+		return new PipelineOperation<Long>() {
+
+			@Override
+			Response<Long> execute(Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.scard(key);
+			}
+
+		}.execute(key, OpName.SCARD);
+
+	}
+
+	@Override
+	public Response<Boolean> sismember(final String key, final String member) {
+		return new PipelineOperation<Boolean>() {
+
+			@Override
+			Response<Boolean> execute(Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.sismember(key, member);
+			}
+
+		}.execute(key, OpName.SISMEMBER);
+	}
+
+	@Override
+	public Response<String> set(final String key, final String value) {
+		if (CompressionStrategy.NONE == connPool.getConfiguration().getCompressionStrategy()) {
+			return new PipelineOperation<String>() {
+				@Override
+				Response<String> execute(Pipeline jedisPipeline) throws DynoException {
+					long startTime = System.nanoTime() / 1000;
+					try {
+						return jedisPipeline.set(key, value);
+					} finally {
+						long duration = System.nanoTime() / 1000 - startTime;
+						opMonitor.recordSendLatency(OpName.SET.name(), duration, TimeUnit.MICROSECONDS);
+					}
+				}
+
+			}.execute(key, OpName.SET);
+		} else {
+			return new PipelineCompressionOperation<String>() {
+				@Override
+				Response<String> execute(final Pipeline jedisPipeline) throws DynoException {
+					long startTime = System.nanoTime() / 1000;
+					try {
+						return new PipelineResponse(null).apply(new Func0<Response<String>>() {
+							@Override
+							public Response<String> call() {
+								return jedisPipeline.set(key, compressValue(value));
+							}
+						});
+					} finally {
+						long duration = System.nanoTime() / 1000 - startTime;
+						opMonitor.recordSendLatency(OpName.SET.name(), duration, TimeUnit.MICROSECONDS);
+					}
+				}
+			}.execute(key, OpName.SET);
+		}
+	}
+
+	@Override
+	public Response<Boolean> setbit(final String key, final long offset, final boolean value) {
+		return new PipelineOperation<Boolean>() {
+
+			@Override
+			Response<Boolean> execute(Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.setbit(key, offset, value);
+			}
+
+		}.execute(key, OpName.SETBIT);
+
+	}
+
+	@Override
+	public Response<String> setex(final String key, final int seconds, final String value) {
+		if (CompressionStrategy.NONE == connPool.getConfiguration().getCompressionStrategy()) {
+			return new PipelineOperation<String>() {
+				@Override
+				Response<String> execute(Pipeline jedisPipeline) throws DynoException {
+					return jedisPipeline.setex(key, seconds, value);
+				}
+			}.execute(key, OpName.SETEX);
+		} else {
+			return new PipelineCompressionOperation<String>() {
+				@Override
+				Response<String> execute(final Pipeline jedisPipeline) throws DynoException {
+					return new PipelineResponse(null).apply(new Func0<Response<String>>() {
+						@Override
+						public Response<String> call() {
+							return jedisPipeline.setex(key, seconds, compressValue(value));
+						}
+					});
+				}
+			}.execute(key, OpName.SETEX);
+		}
+
+	}
+
+	@Override
+	public Response<Long> setnx(final String key, final String value) {
+		return new PipelineOperation<Long>() {
+			@Override
+			Response<Long> execute(Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.setnx(key, value);
+			}
+		}.execute(key, OpName.SETNX);
+	}
+
+	@Override
+	public Response<Long> setrange(final String key, final long offset, final String value) {
+		return new PipelineOperation<Long>() {
+
+			@Override
+			Response<Long> execute(Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.setrange(key, offset, value);
+			}
+
+		}.execute(key, OpName.SETRANGE);
+
+	}
+
+	@Override
+	public Response<Set<String>> smembers(final String key) {
+		return new PipelineOperation<Set<String>>() {
+
+			@Override
+			Response<Set<String>> execute(Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.smembers(key);
+			}
+
+		}.execute(key, OpName.SMEMBERS);
+
+	}
+
+	@Override
+	public Response<List<String>> sort(final String key) {
+		return new PipelineOperation<List<String>>() {
+
+			@Override
+			Response<List<String>> execute(Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.sort(key);
+			}
+
+		}.execute(key, OpName.SORT);
+
+	}
+
+	@Override
+	public Response<List<String>> sort(final String key, final SortingParams sortingParameters) {
+		return new PipelineOperation<List<String>>() {
+
+			@Override
+			Response<List<String>> execute(Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.sort(key, sortingParameters);
+			}
+
+		}.execute(key, OpName.SORT);
+
+	}
+
+	@Override
+	public Response<String> spop(final String key) {
+		return new PipelineOperation<String>() {
+
+			@Override
+			Response<String> execute(Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.spop(key);
+			}
+
+		}.execute(key, OpName.SPOP);
+
+	}
+
+	@Override
+	public Response<Set<String>> spop(final String key, final long count) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<String> srandmember(final String key) {
+		return new PipelineOperation<String>() {
+
+			@Override
+			Response<String> execute(Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.srandmember(key);
+			}
+
+		}.execute(key, OpName.SRANDMEMBER);
+
+	}
+
+	@Override
+	public Response<Long> srem(final String key, final String... member) {
+		return new PipelineOperation<Long>() {
+
+			@Override
+			Response<Long> execute(Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.srem(key, member);
+			}
+
+		}.execute(key, OpName.SREM);
+
+	}
+
+	/**
+	 * This method is not supported by the BinaryRedisPipeline interface.
+	 */
+	public Response<ScanResult<String>> sscan(final String key, final int cursor) {
+		throw new UnsupportedOperationException("'SSCAN' cannot be called in pipeline");
+	}
+
+	/**
+	 * This method is not supported by the BinaryRedisPipeline interface.
+	 */
+	public Response<ScanResult<String>> sscan(final String key, final String cursor) {
+		throw new UnsupportedOperationException("'SSCAN' cannot be called in pipeline");
+	}
+
+	@Override
+	public Response<Long> strlen(final String key) {
+		return new PipelineOperation<Long>() {
+
+			@Override
+			Response<Long> execute(Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.strlen(key);
+			}
+
+		}.execute(key, OpName.STRLEN);
+
+	}
+
+	@Override
+	public Response<String> substr(final String key, final int start, final int end) {
+		return new PipelineOperation<String>() {
+
+			@Override
+			Response<String> execute(Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.substr(key, start, end);
+			}
+
+		}.execute(key, OpName.SUBSTR);
+
+	}
+
+	@Override
+	public Response<Long> ttl(final String key) {
+		return new PipelineOperation<Long>() {
+
+			@Override
+			Response<Long> execute(Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.ttl(key);
+			}
+
+		}.execute(key, OpName.TTL);
+
+	}
+
+	@Override
+	public Response<String> type(final String key) {
+		return new PipelineOperation<String>() {
+
+			@Override
+			Response<String> execute(Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.type(key);
+			}
+
+		}.execute(key, OpName.TYPE);
+
+	}
+
+	@Override
+	public Response<Long> zadd(final String key, final double score, final String member) {
+		return new PipelineOperation<Long>() {
+
+			@Override
+			Response<Long> execute(Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.zadd(key, score, member);
+			}
+
+		}.execute(key, OpName.ZADD);
+
+	}
+
+	@Override
+	public Response<Long> zadd(final String key, final Map<String, Double> scoreMembers) {
+		return new PipelineOperation<Long>() {
+
+			@Override
+			Response<Long> execute(Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.zadd(key, scoreMembers);
+			}
+
+		}.execute(key, OpName.ZADD);
+
+	}
+
+	@Override
+	public Response<Long> zcard(final String key) {
+		return new PipelineOperation<Long>() {
+
+			@Override
+			Response<Long> execute(Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.zcard(key);
+			}
+
+		}.execute(key, OpName.ZCARD);
+
+	}
+
+	@Override
+	public Response<Long> zcount(final String key, final double min, final double max) {
+		return new PipelineOperation<Long>() {
+
+			@Override
+			Response<Long> execute(Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.zcount(key, min, max);
+			}
+
+		}.execute(key, OpName.ZCOUNT);
+
+	}
+
+	@Override
+	public Response<Double> zincrby(final String key, final double score, final String member) {
+		return new PipelineOperation<Double>() {
+
+			@Override
+			Response<Double> execute(Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.zincrby(key, score, member);
+			}
+
+		}.execute(key, OpName.ZINCRBY);
+
+	}
+
+	@Override
+	public Response<Set<String>> zrange(final String key, final long start, final long end) {
+		return new PipelineOperation<Set<String>>() {
+
+			@Override
+			Response<Set<String>> execute(Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.zrange(key, start, end);
+			}
+
+		}.execute(key, OpName.ZRANGE);
+
+	}
+
+	@Override
+	public Response<Set<String>> zrangeByScore(final String key, final double min, final double max) {
+		return new PipelineOperation<Set<String>>() {
+
+			@Override
+			Response<Set<String>> execute(Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.zrangeByScore(key, min, max);
+			}
+
+		}.execute(key, OpName.ZRANGEBYSCORE);
+
+	}
+
+	@Override
+	public Response<Set<String>> zrangeByScore(final String key, final String min, final String max) {
+		return new PipelineOperation<Set<String>>() {
+
+			@Override
+			Response<Set<String>> execute(Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.zrangeByScore(key, min, max);
+			}
+
+		}.execute(key, OpName.ZRANGEBYSCORE);
+
+	}
+
+	@Override
+	public Response<Set<String>> zrangeByScore(final String key, final double min, final double max, final int offset,
+			final int count) {
+		return new PipelineOperation<Set<String>>() {
+
+			@Override
+			Response<Set<String>> execute(Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.zrangeByScore(key, min, max, offset, count);
+			}
+
+		}.execute(key, OpName.ZRANGEBYSCORE);
+
+	}
+
+	@Override
+	public Response<Set<Tuple>> zrangeByScoreWithScores(final String key, final double min, final double max) {
+		return new PipelineOperation<Set<Tuple>>() {
+
+			@Override
+			Response<Set<Tuple>> execute(Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.zrangeByScoreWithScores(key, min, max);
+			}
+
+		}.execute(key, OpName.ZRANGEBYSCOREWITHSCORES);
+
+	}
+
+	@Override
+	public Response<Set<Tuple>> zrangeByScoreWithScores(final String key, final double min, final double max,
+			final int offset, final int count) {
+		return new PipelineOperation<Set<Tuple>>() {
+
+			@Override
+			Response<Set<Tuple>> execute(Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.zrangeByScoreWithScores(key, min, max, offset, count);
+			}
+
+		}.execute(key, OpName.ZRANGEBYSCOREWITHSCORES);
+
+	}
+
+	@Override
+	public Response<Set<String>> zrevrangeByScore(final String key, final double max, final double min) {
+		return new PipelineOperation<Set<String>>() {
+
+			@Override
+			Response<Set<String>> execute(Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.zrevrangeByScore(key, max, min);
+			}
+
+		}.execute(key, OpName.ZREVRANGEBYSCORE);
+
+	}
+
+	@Override
+	public Response<Set<String>> zrevrangeByScore(final String key, final String max, final String min) {
+		return new PipelineOperation<Set<String>>() {
+
+			@Override
+			Response<Set<String>> execute(Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.zrevrangeByScore(key, max, min);
+			}
+
+		}.execute(key, OpName.ZREVRANGEBYSCORE);
+
+	}
+
+	@Override
+	public Response<Set<String>> zrevrangeByScore(final String key, final double max, final double min,
+			final int offset, final int count) {
+		return new PipelineOperation<Set<String>>() {
+
+			@Override
+			Response<Set<String>> execute(Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.zrevrangeByScore(key, max, min, offset, count);
+			}
+
+		}.execute(key, OpName.ZREVRANGEBYSCORE);
+
+	}
+
+	@Override
+	public Response<Set<Tuple>> zrevrangeByScoreWithScores(final String key, final double max, final double min) {
+		return new PipelineOperation<Set<Tuple>>() {
+
+			@Override
+			Response<Set<Tuple>> execute(Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.zrevrangeByScoreWithScores(key, max, min);
+			}
+
+		}.execute(key, OpName.ZREVRANGEBYSCOREWITHSCORES);
+
+	}
+
+	@Override
+	public Response<Set<Tuple>> zrevrangeByScoreWithScores(final String key, final double max, final double min,
+			final int offset, final int count) {
+		return new PipelineOperation<Set<Tuple>>() {
+
+			@Override
+			Response<Set<Tuple>> execute(Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.zrevrangeByScoreWithScores(key, max, min, offset, count);
+			}
+
+		}.execute(key, OpName.ZREVRANGEBYSCOREWITHSCORES);
+
+	}
+
+	@Override
+	public Response<Set<Tuple>> zrangeWithScores(final String key, final long start, final long end) {
+		return new PipelineOperation<Set<Tuple>>() {
+
+			@Override
+			Response<Set<Tuple>> execute(Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.zrangeWithScores(key, start, end);
+			}
+
+		}.execute(key, OpName.ZRANGEWITHSCORES);
+
+	}
+
+	@Override
+	public Response<Long> zrank(final String key, final String member) {
+		return new PipelineOperation<Long>() {
+
+			@Override
+			Response<Long> execute(Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.zrank(key, member);
+			}
+
+		}.execute(key, OpName.ZRANK);
+
+	}
+
+	@Override
+	public Response<Long> zrem(final String key, final String... member) {
+		return new PipelineOperation<Long>() {
+
+			@Override
+			Response<Long> execute(Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.zrem(key, member);
+			}
+
+		}.execute(key, OpName.ZREM);
+
+	}
+
+	@Override
+	public Response<Long> zremrangeByRank(final String key, final long start, final long end) {
+		return new PipelineOperation<Long>() {
+
+			@Override
+			Response<Long> execute(Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.zremrangeByRank(key, start, end);
+			}
+
+		}.execute(key, OpName.ZREMRANGEBYRANK);
+
+	}
+
+	@Override
+	public Response<Long> zremrangeByScore(final String key, final double start, final double end) {
+		return new PipelineOperation<Long>() {
+
+			@Override
+			Response<Long> execute(Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.zremrangeByScore(key, start, end);
+			}
+
+		}.execute(key, OpName.ZREMRANGEBYSCORE);
+
+	}
+
+	@Override
+	public Response<Set<String>> zrevrange(final String key, final long start, final long end) {
+		return new PipelineOperation<Set<String>>() {
+
+			@Override
+			Response<Set<String>> execute(Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.zrevrange(key, start, end);
+			}
+
+		}.execute(key, OpName.ZREVRANGE);
+
+	}
+
+	@Override
+	public Response<Set<Tuple>> zrevrangeWithScores(final String key, final long start, final long end) {
+		return new PipelineOperation<Set<Tuple>>() {
+
+			@Override
+			Response<Set<Tuple>> execute(Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.zrevrangeWithScores(key, start, end);
+			}
+
+		}.execute(key, OpName.ZREVRANGEWITHSCORES);
+
+	}
+
+	@Override
+	public Response<Long> zrevrank(final String key, final String member) {
+		return new PipelineOperation<Long>() {
+
+			@Override
+			Response<Long> execute(Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.zrevrank(key, member);
+			}
+
+		}.execute(key, OpName.ZREVRANK);
+
+	}
+
+	@Override
+	public Response<Double> zscore(final String key, final String member) {
+		return new PipelineOperation<Double>() {
+
+			@Override
+			Response<Double> execute(Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.zscore(key, member);
+			}
+
+		}.execute(key, OpName.ZSCORE);
+
+	}
+
+	/**
+	 * This method is not supported by the BinaryRedisPipeline interface.
+	 */
+	public Response<ScanResult<Tuple>> zscan(final String key, final int cursor) {
+		throw new UnsupportedOperationException("'ZSCAN' cannot be called in pipeline");
+	}
+
+	@Override
+	public Response<Long> zlexcount(String key, String min, String max) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Set<String>> zrangeByLex(String key, String min, String max) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Set<String>> zrangeByLex(String key, String min, String max, int offset, int count) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Long> zremrangeByLex(String key, String start, String end) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Long> bitcount(final String key) {
+		return new PipelineOperation<Long>() {
+
+			@Override
+			Response<Long> execute(Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.bitcount(key);
+			}
+
+		}.execute(key, OpName.BITCOUNT);
+
+	}
+
+	@Override
+	public Response<Long> bitcount(final String key, final long start, final long end) {
+		return new PipelineOperation<Long>() {
+
+			@Override
+			Response<Long> execute(Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.bitcount(key, start, end);
+			}
+
+		}.execute(key, OpName.BITCOUNT);
+
+	}
+
+	/**** Binary Operations ****/
+	@Override
+	public Response<String> set(final byte[] key, final byte[] value) {
+		return new PipelineOperation<String>() {
+			@Override
+			Response<String> execute(Pipeline jedisPipeline) throws DynoException {
+				long startTime = System.nanoTime() / 1000;
+				try {
+					return jedisPipeline.set(key, value);
+				} finally {
+					long duration = System.nanoTime() / 1000 - startTime;
+					opMonitor.recordSendLatency(OpName.SET.name(), duration, TimeUnit.MICROSECONDS);
+				}
+			}
+
+		}.execute(key, OpName.SET);
+	}
+
+	@Override
+	public Response<Long> pfadd(String key, String... elements) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Long> pfcount(String key) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<List<Long>> bitfield(String key, String... arguments) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Set<String>> zrevrangeByLex(String key, String max, String min) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Set<String>> zrevrangeByLex(String key, String max, String min, int offset, int count) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Long> geoadd(String arg0, Map<String, GeoCoordinate> arg1) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Long> geoadd(String arg0, double arg1, double arg2, String arg3) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Double> geodist(String arg0, String arg1, String arg2) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Double> geodist(String arg0, String arg1, String arg2, GeoUnit arg3) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<List<String>> geohash(String arg0, String... arg1) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<List<GeoCoordinate>> geopos(String arg0, String... arg1) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<List<GeoRadiusResponse>> georadius(String arg0, double arg1, double arg2, double arg3,
+			GeoUnit arg4) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<List<GeoRadiusResponse>> georadius(String arg0, double arg1, double arg2, double arg3, GeoUnit arg4,
+			GeoRadiusParam arg5) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<List<GeoRadiusResponse>> georadiusByMember(String arg0, String arg1, double arg2, GeoUnit arg3) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<List<GeoRadiusResponse>> georadiusByMember(String arg0, String arg1, double arg2, GeoUnit arg3,
+			GeoRadiusParam arg4) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Long> zadd(String arg0, Map<String, Double> arg1, ZAddParams arg2) {
+		throw new UnsupportedOperationException("not yet implemented");
+
+	}
+
+	@Override
+	public Response<Long> zadd(String arg0, double arg1, String arg2, ZAddParams arg3) {
+		throw new UnsupportedOperationException("not yet implemented");
+
+	}
+
+	@Override
+	public Response<Double> zincrby(String arg0, double arg1, String arg2, ZIncrByParams arg3) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	public void sync() {
+		long startTime = System.nanoTime() / 1000;
+		try {
+			jedisPipeline.sync();
+			opMonitor.recordPipelineSync();
+		} catch (JedisConnectionException jce) {
+			String msg = "Failed sync() to host: " + getHostInfo();
+			pipelineEx.set(new FatalConnectionException(msg, jce));
+			cpMonitor.incOperationFailure(connection == null ? null : connection.getHost(), jce);
+			throw jce;
+		} finally {
+			long duration = System.nanoTime() / 1000 - startTime;
+			opMonitor.recordLatency(duration, TimeUnit.MICROSECONDS);
+			discardPipeline(false);
+			releaseConnection();
+		}
+	}
+
+	public List<Object> syncAndReturnAll() {
+		long startTime = System.nanoTime() / 1000;
+		try {
+			List<Object> result = jedisPipeline.syncAndReturnAll();
+			opMonitor.recordPipelineSync();
+			return result;
+		} catch (JedisConnectionException jce) {
+			String msg = "Failed syncAndReturnAll() to host: " + getHostInfo();
+			pipelineEx.set(new FatalConnectionException(msg, jce));
+			cpMonitor.incOperationFailure(connection == null ? null : connection.getHost(), jce);
+			throw jce;
+		} finally {
+			long duration = System.nanoTime() / 1000 - startTime;
+			opMonitor.recordLatency(duration, TimeUnit.MICROSECONDS);
+			discardPipeline(false);
+			releaseConnection();
+		}
+	}
+
+	private void discardPipeline(boolean recordLatency) {
+		try {
+			if (jedisPipeline != null) {
+				long startTime = System.nanoTime() / 1000;
+				jedisPipeline.sync();
+				if (recordLatency) {
+					long duration = System.nanoTime() / 1000 - startTime;
+					opMonitor.recordLatency(duration, TimeUnit.MICROSECONDS);
+				}
+				jedisPipeline = null;
+			}
+		} catch (Exception e) {
+			Logger.warn(String.format("Failed to discard jedis pipeline, %s", getHostInfo()), e);
+		}
+	}
+
+	private void releaseConnection() {
+		if (connection != null) {
+			try {
+				connection.getContext().reset();
+				connection.getParentConnectionPool().returnConnection(connection);
+				if (pipelineEx.get() != null) {
+					connPool.getHealthTracker().trackConnectionError(connection.getParentConnectionPool(),
+							pipelineEx.get());
+					pipelineEx.set(null);
+				}
+				connection = null;
+			} catch (Exception e) {
+				Logger.warn(String.format("Failed to return connection in Dyno Jedis Pipeline, %s", getHostInfo()), e);
+			}
+		}
+	}
+
+	public void discardPipelineAndReleaseConnection() {
+		opMonitor.recordPipelineDiscard();
+		discardPipeline(true);
+		releaseConnection();
+	}
+
+	@Override
+	public void close() throws Exception {
+		discardPipelineAndReleaseConnection();
+	}
+
+	private String getHostInfo() {
+		if (connection != null && connection.getHost() != null) {
+			return connection.getHost().toString();
+		}
+
+		return "unknown";
+	}
+
+	@Override
+	public Response<Long> append(byte[] key, byte[] value) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<List<byte[]>> blpop(byte[] arg) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<List<byte[]>> brpop(byte[] arg) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Long> decr(byte[] key) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Long> decrBy(final byte[] key, final long integer) {
+		return new PipelineOperation<Long>() {
+
+			@Override
+			Response<Long> execute(Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.decrBy(key, integer);
+			}
+		}.execute(key, OpName.DECRBY);	}
+
+	@Override
+	public Response<Long> del(final byte[] key) {
+		return new PipelineOperation<Long>() {
+
+			@Override
+			Response<Long> execute(Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.del(key);
+			}
+		}.execute(key, OpName.DEL);
+	}
+
+	@Override
+	public Response<byte[]> echo(byte[] string) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Boolean> exists(final byte[] key) {
+		return new PipelineOperation<Boolean>() {
+
+			@Override
+			Response<Boolean> execute(final Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.exists(key);
+			}
+		}.execute(key, OpName.EXISTS);	
+	}
+
+	@Override
+	public Response<Long> expire(byte[] key, int seconds) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Long> pexpire(byte[] key, long milliseconds) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Long> expireAt(byte[] key, long unixTime) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Long> pexpireAt(byte[] key, long millisecondsTimestamp) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<byte[]> get(final byte[] key) {
+		return new PipelineOperation<byte[]>() {
+			@Override
+			Response<byte[]> execute(Pipeline jedisPipeline) throws DynoException {
+				long startTime = System.nanoTime() / 1000;
+				try {
+					return jedisPipeline.get(key);
+				} finally {
+					long duration = System.nanoTime() / 1000 - startTime;
+					opMonitor.recordSendLatency(OpName.GET.name(), duration, TimeUnit.MICROSECONDS);
+				}
+			}
+		}.execute(key, OpName.GET);	
+	}
+
+	@Override
+	public Response<Boolean> getbit(byte[] key, long offset) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<byte[]> getSet(final byte[] key, final byte[] value) {
+		return new PipelineOperation<byte[]>() {
+			@Override
+			Response<byte[]> execute(Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.getSet(key, value);
+			}
+		}.execute(key, OpName.GETSET);	}
+
+	@Override
+	public Response<Long> getrange(byte[] key, long startOffset, long endOffset) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Long> hdel(byte[] key, byte[]... field) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Boolean> hexists(byte[] key, byte[] field) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Long> hincrBy(byte[] key, byte[] field, long value) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Set<byte[]>> hkeys(byte[] key) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Long> hlen(byte[] key) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Long> hsetnx(byte[] key, byte[] field, byte[] value) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<List<byte[]>> hvals(byte[] key) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Long> incr(byte[] key) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Long> incrBy(byte[] key, long integer) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<byte[]> lindex(byte[] key, long index) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Long> linsert(byte[] key, LIST_POSITION where, byte[] pivot, byte[] value) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Long> llen(byte[] key) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<byte[]> lpop(byte[] key) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Long> lpush(byte[] key, byte[]... string) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Long> lpushx(byte[] key, byte[]... bytes) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<List<byte[]>> lrange(byte[] key, long start, long end) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Long> lrem(byte[] key, long count, byte[] value) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<String> lset(byte[] key, long index, byte[] value) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<String> ltrim(byte[] key, long start, long end) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Long> move(byte[] key, int dbIndex) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Long> persist(byte[] key) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<byte[]> rpop(byte[] key) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Long> rpush(byte[] key, byte[]... string) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Long> rpushx(byte[] key, byte[]... string) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Long> sadd(byte[] key, byte[]... member) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Long> scard(byte[] key) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Boolean> setbit(byte[] key, long offset, byte[] value) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Long> setrange(byte[] key, long offset, byte[] value) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<String> setex(final byte[] key, final int seconds, final byte[] value) {
+		return new PipelineOperation<String>() {
+			@Override
+			Response<String> execute(Pipeline jedisPipeline) throws DynoException {
+				return jedisPipeline.setex(key, seconds, value);
+			}
+		}.execute(key, OpName.SETEX);	}
+
+	@Override
+	public Response<Long> setnx(byte[] key, byte[] value) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Set<byte[]>> smembers(byte[] key) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Boolean> sismember(byte[] key, byte[] member) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<List<byte[]>> sort(byte[] key) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<List<byte[]>> sort(byte[] key, SortingParams sortingParameters) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<byte[]> spop(byte[] key) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Set<byte[]>> spop(byte[] key, long count) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<byte[]> srandmember(byte[] key) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Long> srem(byte[] key, byte[]... member) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Long> strlen(byte[] key) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<String> substr(byte[] key, int start, int end) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Long> ttl(byte[] key) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<String> type(byte[] key) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Long> zadd(byte[] key, double score, byte[] member) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Long> zadd(byte[] key, double score, byte[] member, ZAddParams params) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Long> zadd(byte[] key, Map<byte[], Double> scoreMembers) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Long> zadd(byte[] key, Map<byte[], Double> scoreMembers, ZAddParams params) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Long> zcard(byte[] key) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Long> zcount(byte[] key, double min, double max) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Double> zincrby(byte[] key, double score, byte[] member) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Double> zincrby(byte[] key, double score, byte[] member, ZIncrByParams params) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Set<byte[]>> zrange(byte[] key, long start, long end) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Set<byte[]>> zrangeByScore(byte[] key, double min, double max) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Set<byte[]>> zrangeByScore(byte[] key, byte[] min, byte[] max) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Set<byte[]>> zrangeByScore(byte[] key, double min, double max, int offset, int count) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Set<byte[]>> zrangeByScore(byte[] key, byte[] min, byte[] max, int offset, int count) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Set<Tuple>> zrangeByScoreWithScores(byte[] key, double min, double max) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Set<Tuple>> zrangeByScoreWithScores(byte[] key, byte[] min, byte[] max) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Set<Tuple>> zrangeByScoreWithScores(byte[] key, double min, double max, int offset, int count) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Set<Tuple>> zrangeByScoreWithScores(byte[] key, byte[] min, byte[] max, int offset, int count) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Set<byte[]>> zrevrangeByScore(byte[] key, double max, double min) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Set<byte[]>> zrevrangeByScore(byte[] key, byte[] max, byte[] min) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Set<byte[]>> zrevrangeByScore(byte[] key, double max, double min, int offset, int count) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Set<byte[]>> zrevrangeByScore(byte[] key, byte[] max, byte[] min, int offset, int count) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Set<Tuple>> zrevrangeByScoreWithScores(byte[] key, double max, double min) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Set<Tuple>> zrevrangeByScoreWithScores(byte[] key, byte[] max, byte[] min) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Set<Tuple>> zrevrangeByScoreWithScores(byte[] key, double max, double min, int offset, int count) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Set<Tuple>> zrevrangeByScoreWithScores(byte[] key, byte[] max, byte[] min, int offset, int count) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Set<Tuple>> zrangeWithScores(byte[] key, long start, long end) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Long> zrank(byte[] key, byte[] member) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Long> zrem(byte[] key, byte[]... member) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Long> zremrangeByRank(byte[] key, long start, long end) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Long> zremrangeByScore(byte[] key, double start, double end) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Long> zremrangeByScore(byte[] key, byte[] start, byte[] end) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Set<byte[]>> zrevrange(byte[] key, long start, long end) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Set<Tuple>> zrevrangeWithScores(byte[] key, long start, long end) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Long> zrevrank(byte[] key, byte[] member) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Double> zscore(byte[] key, byte[] member) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Long> zlexcount(byte[] key, byte[] min, byte[] max) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Set<byte[]>> zrangeByLex(byte[] key, byte[] min, byte[] max) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Set<byte[]>> zrangeByLex(byte[] key, byte[] min, byte[] max, int offset, int count) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Set<byte[]>> zrevrangeByLex(byte[] key, byte[] max, byte[] min) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Set<byte[]>> zrevrangeByLex(byte[] key, byte[] max, byte[] min, int offset, int count) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Long> zremrangeByLex(byte[] key, byte[] min, byte[] max) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Long> bitcount(byte[] key) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Long> bitcount(byte[] key, long start, long end) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Long> pfadd(byte[] key, byte[]... elements) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Long> pfcount(byte[] key) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Long> geoadd(byte[] key, double longitude, double latitude, byte[] member) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Long> geoadd(byte[] key, Map<byte[], GeoCoordinate> memberCoordinateMap) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Double> geodist(byte[] key, byte[] member1, byte[] member2) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<Double> geodist(byte[] key, byte[] member1, byte[] member2, GeoUnit unit) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<List<byte[]>> geohash(byte[] key, byte[]... members) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<List<GeoCoordinate>> geopos(byte[] key, byte[]... members) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<List<GeoRadiusResponse>> georadius(byte[] key, double longitude, double latitude, double radius,
+			GeoUnit unit) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<List<GeoRadiusResponse>> georadius(byte[] key, double longitude, double latitude, double radius,
+			GeoUnit unit, GeoRadiusParam param) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<List<GeoRadiusResponse>> georadiusByMember(byte[] key, byte[] member, double radius, GeoUnit unit) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<List<GeoRadiusResponse>> georadiusByMember(byte[] key, byte[] member, double radius, GeoUnit unit,
+			GeoRadiusParam param) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+
+	@Override
+	public Response<List<Long>> bitfield(byte[] key, byte[]... elements) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
 
 }

--- a/dyno-jedis/src/main/java/com/netflix/dyno/jedis/DynoJedisPipeline.java
+++ b/dyno-jedis/src/main/java/com/netflix/dyno/jedis/DynoJedisPipeline.java
@@ -89,7 +89,7 @@ public class DynoJedisPipeline implements RedisPipeline, AutoCloseable {
                     }
 
                     @Override
-                    public String getKey() {
+                    public String getStringKey() {
                         return key;
                     }
 

--- a/dyno-redisson/src/main/java/com/netflix/dyno/redisson/DynoRedissonClient.java
+++ b/dyno-redisson/src/main/java/com/netflix/dyno/redisson/DynoRedissonClient.java
@@ -68,6 +68,11 @@ public class DynoRedissonClient {
                     throws DynoException {
                 return new DecoratingListenableFuture<String>((client.get(key)));
             }
+
+			@Override
+			public byte[] getBinaryKey() {
+				return null;
+			}
         });
     }
 
@@ -90,6 +95,11 @@ public class DynoRedissonClient {
                     throws DynoException {
                 return new DecoratingListenableFuture<String>((client.get(key)));
             }
+
+			@Override
+			public byte[] getBinaryKey() {
+				return null;
+			}
         });
     }
 
@@ -112,6 +122,11 @@ public class DynoRedissonClient {
                     throws DynoException {
                 return new DecoratingListenableFuture<String>((client.set(key, value)));
             }
+
+			@Override
+			public byte[] getBinaryKey() {
+				return null;
+			}
         });
     }
     
@@ -135,6 +150,11 @@ public class DynoRedissonClient {
                     throws DynoException {
                 return new DecoratingListenableFuture<String>((client.set(key, value)));
             }
+
+			@Override
+			public byte[] getBinaryKey() {
+				return null;
+			}
         });
     }
 

--- a/dyno-redisson/src/main/java/com/netflix/dyno/redisson/DynoRedissonClient.java
+++ b/dyno-redisson/src/main/java/com/netflix/dyno/redisson/DynoRedissonClient.java
@@ -59,7 +59,7 @@ public class DynoRedissonClient {
             }
 
             @Override
-            public String getKey() {
+            public String getStringKey() {
                 return key;
             }
 
@@ -81,7 +81,7 @@ public class DynoRedissonClient {
             }
 
             @Override
-            public String getKey() {
+            public String getStringKey() {
                 return key;
             }
 
@@ -103,7 +103,7 @@ public class DynoRedissonClient {
             }
 
             @Override
-            public String getKey() {
+            public String getStringKey() {
                 return key;
             }
 
@@ -126,7 +126,7 @@ public class DynoRedissonClient {
             }
 
             @Override
-            public String getKey() {
+            public String getStringKey() {
                 return key;
             }
             

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.3.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-bin.zip


### PR DESCRIPTION
* Adding support for binary commands in Dyno.
* Binary commands under pipelines are also supported.

Limitations: The binary support does not include compression and does not support hashtags. The latter requires a string key. Not all APIs have been added. We can add them gradually based on customer usage.