### PR TITLE
Support for configurable Dynomite port

### DIFF
--- a/dyno-contrib/src/main/java/com/netflix/dyno/contrib/ArchaiusConnectionPoolConfiguration.java
+++ b/dyno-contrib/src/main/java/com/netflix/dyno/contrib/ArchaiusConnectionPoolConfiguration.java
@@ -36,7 +36,7 @@ public class ArchaiusConnectionPoolConfiguration extends ConnectionPoolConfigura
 	
 	private static final String DynoPrefix = "dyno.";
 	
-	//private final DynamicIntProperty port;
+	private final DynamicIntProperty port;
 	private final DynamicIntProperty maxConnsPerHost;
 	private final DynamicIntProperty maxTimeoutWhenExhausted;
 	private final DynamicIntProperty maxFailoverCount;
@@ -60,8 +60,10 @@ public class ArchaiusConnectionPoolConfiguration extends ConnectionPoolConfigura
 	public ArchaiusConnectionPoolConfiguration(String name) {
 		super(name);
 		
-		String propertyPrefix = DynoPrefix + name; 
-		
+		String propertyPrefix = DynoPrefix + name;
+
+		port = DynamicPropertyFactory.getInstance().getIntProperty(propertyPrefix + ".connection.port", super.getPort());
+
 		maxConnsPerHost = DynamicPropertyFactory.getInstance().getIntProperty(propertyPrefix + ".connection.maxConnsPerHost", super.getMaxConnsPerHost());
 		maxTimeoutWhenExhausted = DynamicPropertyFactory.getInstance().getIntProperty(propertyPrefix + ".connection.maxTimeoutWhenExhausted", super.getMaxTimeoutWhenExhausted());
 		maxFailoverCount = DynamicPropertyFactory.getInstance().getIntProperty(propertyPrefix + ".connection.maxFailoverCount", super.getMaxFailoverCount());
@@ -89,6 +91,10 @@ public class ArchaiusConnectionPoolConfiguration extends ConnectionPoolConfigura
 		return super.getName();
 	}
 
+	@Override
+	public int getPort() {
+		return super.getPort();
+	}
 
 	@Override
 	public int getMaxConnsPerHost() {

--- a/dyno-contrib/src/main/java/com/netflix/dyno/contrib/EurekaHostsSupplier.java
+++ b/dyno-contrib/src/main/java/com/netflix/dyno/contrib/EurekaHostsSupplier.java
@@ -51,20 +51,19 @@ public class EurekaHostsSupplier implements HostSupplier {
 	// The Dynomite cluster name for discovering nodes
 	private final String applicationName;
 	private final EurekaClient discoveryClient;
+	private final int dynomitePort;
 	
 	@Deprecated
-    public EurekaHostsSupplier(String applicationName, DiscoveryClient dClient) {
+    public EurekaHostsSupplier(String applicationName, DiscoveryClient dClient, int dynomitePort) {
         this.applicationName = applicationName.toUpperCase();
         this.discoveryClient = dClient;
-    }
+        this.dynomitePort = dynomitePort;
+	}
     
-    public EurekaHostsSupplier(String applicationName, EurekaClient dClient) {
+    public EurekaHostsSupplier(String applicationName, EurekaClient dClient, int dynomitePort) {
         this.applicationName = applicationName.toUpperCase();
-        this.discoveryClient = dClient;
-    }
-
-	public static EurekaHostsSupplier newInstance(String applicationName, EurekaHostsSupplier hostsSupplier) {
-        return new EurekaHostsSupplier(applicationName, hostsSupplier.getDiscoveryClient());
+		this.discoveryClient = dClient;
+		this.dynomitePort = dynomitePort;
     }
 
 	@Override
@@ -115,7 +114,7 @@ public class EurekaHostsSupplier implements HostSupplier {
 						if(rack == null) {
 						    Logger.error("Rack wasn't found for host:" + info.getHostName() + " there may be issues matching it up to the token map");
 						}
-						Host host = new Host(info.getHostName(), info.getIPAddr(), rack, status);
+						Host host = new Host(info.getHostName(), info.getIPAddr(), dynomitePort, rack, status);
 						return host;
 					}
 				}));

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/ConnectionPoolConfiguration.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/ConnectionPoolConfiguration.java
@@ -41,6 +41,12 @@ public interface ConnectionPoolConfiguration {
     String getName();
 
     /**
+     * @return Data port to be used when no port is specified to a list of seeds or when
+     * doing a ring describe since the ring describe does not include a host
+     */
+    int getPort();
+
+    /**
      * Returns the maximum number of connections to allocate to each Dynomite host. Note that at startup exactly this
      * number of connections will be established prior to serving requests.
      */

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/Host.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/Host.java
@@ -33,7 +33,6 @@ import com.netflix.dyno.connectionpool.impl.utils.ConfigUtils;
  */
 public class Host implements Comparable<Host> {
 
-    public static final int DEFAULT_PORT = 8102;
     public static final Host NO_HOST = new Host("UNKNOWN", "UNKNOWN", 0, "UNKNOWN");
 
     private final String hostname;
@@ -53,10 +52,6 @@ public class Host implements Comparable<Host> {
         this(hostname, null, port, rack, ConfigUtils.getDataCenterFromRack(rack), Status.Down, null);
     }
 
-    public Host(String hostname, String rack, Status status) {
-        this(hostname, null, DEFAULT_PORT, rack, ConfigUtils.getDataCenterFromRack(rack), status, null);
-    }
-
     public Host(String hostname, int port, String rack, Status status) {
         this(hostname, null, port, rack, ConfigUtils.getDataCenterFromRack(rack), status, null);
     }
@@ -69,12 +64,12 @@ public class Host implements Comparable<Host> {
         this(hostname, ipAddress, port, rack, ConfigUtils.getDataCenterFromRack(rack), Status.Down, null);
     }
 
-    public Host(String hostname, String ipAddress, String rack, Status status) {
-        this(hostname, ipAddress, DEFAULT_PORT, rack, ConfigUtils.getDataCenterFromRack(rack), status, null);
+    public Host(String hostname, String ipAddress, int port, String rack, Status status) {
+        this(hostname, ipAddress, port, rack, ConfigUtils.getDataCenterFromRack(rack), status, null);
     }
 
-    public Host(String hostname, String ipAddress, String rack, Status status, String hashtag) {
-        this(hostname, ipAddress, DEFAULT_PORT, rack, ConfigUtils.getDataCenterFromRack(rack), status, hashtag);
+    public Host(String hostname, String ipAddress, int port, String rack, Status status, String hashtag) {
+        this(hostname, ipAddress, port, rack, ConfigUtils.getDataCenterFromRack(rack), status, hashtag);
     }
 
     public Host(String hostname, String ipAddress, int port, String rack, String datacenter, Status status) {
@@ -158,6 +153,7 @@ public class Host implements Comparable<Host> {
         int result = 1;
         result = prime * result + ((hostname == null) ? 0 : hostname.hashCode());
         result = prime * result + ((rack == null) ? 0 : rack.hashCode());
+        result = prime * result + port;
 
         return result;
     }
@@ -178,6 +174,7 @@ public class Host implements Comparable<Host> {
 
         equals &= (hostname != null) ? hostname.equals(other.hostname) : other.hostname == null;
         equals &= (rack != null) ? rack.equals(other.rack) : other.rack == null;
+        equals &= (port == other.port);
 
         return equals;
     }
@@ -188,7 +185,11 @@ public class Host implements Comparable<Host> {
         if (compared != 0) {
             return compared;
         }
-        return this.rack.compareTo(o.rack);
+        compared = this.rack.compareTo(o.rack);
+        if (compared != 0) {
+            return compared;
+        }
+        return Integer.compare(this.port, o.port);
     }
 
     @Override

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolConfigurationImpl.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolConfigurationImpl.java
@@ -31,7 +31,8 @@ import com.netflix.dyno.connectionpool.impl.utils.ConfigUtils;
 
 public class ConnectionPoolConfigurationImpl implements ConnectionPoolConfiguration {
 	
-	// DEFAULTS 
+	// DEFAULTS
+	public static final int DEFAULT_DYNOMITE_PORT = 8102;
 	private static final int DEFAULT_MAX_CONNS_PER_HOST = 3;
 	private static final int DEFAULT_MAX_TIMEOUT_WHEN_EXHAUSTED = 800;
 	private static final int DEFAULT_MAX_FAILOVER_COUNT = 3; 
@@ -56,6 +57,7 @@ public class ConnectionPoolConfigurationImpl implements ConnectionPoolConfigurat
   private HashPartitioner hashPartitioner;
 	private String hashtag;
 	private final String name;
+	private int port = DEFAULT_DYNOMITE_PORT;
 	private int maxConnsPerHost = DEFAULT_MAX_CONNS_PER_HOST; 
 	private int maxTimeoutWhenExhausted = DEFAULT_MAX_TIMEOUT_WHEN_EXHAUSTED; 
 	private int maxFailoverCount = DEFAULT_MAX_FAILOVER_COUNT; 
@@ -113,6 +115,7 @@ public class ConnectionPoolConfigurationImpl implements ConnectionPoolConfigurat
         this.localDataCenter = config.getLocalDataCenter();
         this.localRack = config.getLocalRack();
         this.localZoneAffinity = config.localZoneAffinity;
+		this.port = config.getPort();
         this.maxConnsPerHost = config.getMaxConnsPerHost();
         this.maxFailoverCount = config.getMaxFailoverCount();
         this.maxTimeoutWhenExhausted = config.getMaxTimeoutWhenExhausted();
@@ -133,6 +136,10 @@ public class ConnectionPoolConfigurationImpl implements ConnectionPoolConfigurat
 		return name;
 	}
 
+	@Override
+	public int getPort() {
+		return port;
+	}
 
 	@Override
 	public int getMaxConnsPerHost() {
@@ -247,6 +254,7 @@ public class ConnectionPoolConfigurationImpl implements ConnectionPoolConfigurat
 				", tokenSupplier=" + tokenSupplier +
 				", hostConnectionPoolFactory=" + hostConnectionPoolFactory +
 				", name='" + name + '\'' +
+				", port=" + port +
 				", maxConnsPerHost=" + maxConnsPerHost +
 				", maxTimeoutWhenExhausted=" + maxTimeoutWhenExhausted +
 				", maxFailoverCount=" + maxFailoverCount +
@@ -274,6 +282,11 @@ public class ConnectionPoolConfigurationImpl implements ConnectionPoolConfigurat
 	}
 
 	// ALL SETTERS
+	public ConnectionPoolConfigurationImpl setPort(int port) {
+		this.port = port;
+		return this;
+	}
+
 	public ConnectionPoolConfigurationImpl setMaxConnsPerHost(int maxConnsPerHost) {
 		this.maxConnsPerHost = maxConnsPerHost;
 		return this;

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolConfigurationImpl.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolConfigurationImpl.java
@@ -115,7 +115,7 @@ public class ConnectionPoolConfigurationImpl implements ConnectionPoolConfigurat
         this.localDataCenter = config.getLocalDataCenter();
         this.localRack = config.getLocalRack();
         this.localZoneAffinity = config.localZoneAffinity;
-		this.port = config.getPort();
+        this.port = config.getPort();
         this.maxConnsPerHost = config.getMaxConnsPerHost();
         this.maxFailoverCount = config.getMaxFailoverCount();
         this.maxTimeoutWhenExhausted = config.getMaxTimeoutWhenExhausted();

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/lb/AbstractTokenMapSupplier.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/lb/AbstractTokenMapSupplier.java
@@ -109,28 +109,20 @@ public abstract class AbstractTokenMapSupplier implements TokenMapSupplier {
     private static final Logger Logger = LoggerFactory.getLogger(AbstractTokenMapSupplier.class);
     private final String localZone;
     private final String localDatacenter;
-    private int unsuppliedPort = -1;
+    private final int dynomitePort;
 
-    public AbstractTokenMapSupplier(String localRack) {
+    public AbstractTokenMapSupplier(String localRack, int dynomitePort) {
+        this(localRack, ConfigUtils.getDataCenter(), dynomitePort);
+    }
+
+    public AbstractTokenMapSupplier(int dynomitePort) {
+        this(ConfigUtils.getLocalZone(), ConfigUtils.getDataCenter(), dynomitePort);
+    }
+
+    public AbstractTokenMapSupplier(String localRack, String localDatacenter, int dynomitePort) {
         this.localZone = localRack;
-        localDatacenter = ConfigUtils.getDataCenter();
-    }
-
-    public AbstractTokenMapSupplier(String localRack, int port) {
-        this.localZone = localRack;
-        localDatacenter = ConfigUtils.getDataCenter();
-        unsuppliedPort = port;
-    }
-
-    public AbstractTokenMapSupplier() {
-        localZone = ConfigUtils.getLocalZone();
-        localDatacenter = ConfigUtils.getDataCenter();
-    }
-
-    public AbstractTokenMapSupplier(int port) {
-        localZone = ConfigUtils.getLocalZone();
-        localDatacenter = ConfigUtils.getDataCenter();
-        unsuppliedPort = port;
+        this.localDatacenter = localDatacenter;
+        this.dynomitePort = dynomitePort;
     }
 
     public abstract String getTopologyJsonPayload(Set<Host> activeHosts);
@@ -228,7 +220,7 @@ public abstract class AbstractTokenMapSupplier implements TokenMapSupplier {
                 String datacenter = (String) jItem.get("dc");
                 String portStr = (String) jItem.get("port");
                 String hashtag = (String) jItem.get("hashtag");
-                int port = Host.DEFAULT_PORT;
+                int port = dynomitePort;
                 if (portStr != null) {
                     port = Integer.valueOf(portStr);
                 }

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/lb/HttpEndpointBasedTokenMapSupplier.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/lb/HttpEndpointBasedTokenMapSupplier.java
@@ -44,26 +44,26 @@ public class HttpEndpointBasedTokenMapSupplier extends AbstractTokenMapSupplier 
     private static final String DefaultServerUrl = "http://{hostname}:{port}/REST/v1/admin/cluster_describe";
     private static final Integer NUM_RETRIES_PER_NODE = 2;
     private static final Integer NUM_RETRIER_ACROSS_NODES = 2;
-    private static final Integer defaultPort = 8080;
+    private static final Integer defaultHttpPort = 8080;
 
     private final String serverUrl;
 
-    public HttpEndpointBasedTokenMapSupplier() {
-        this(DefaultServerUrl, defaultPort);
+    public HttpEndpointBasedTokenMapSupplier(int dynomitePort) {
+        this(DefaultServerUrl, defaultHttpPort, dynomitePort);
     }
     
-    public HttpEndpointBasedTokenMapSupplier(int port) {
-	this(DefaultServerUrl, port);
+    public HttpEndpointBasedTokenMapSupplier(int httpPort, int dynomitePort) {
+	this(DefaultServerUrl, httpPort, dynomitePort);
     }
 
-    public HttpEndpointBasedTokenMapSupplier(String url, int port) {
-	super(port);
+    public HttpEndpointBasedTokenMapSupplier(String url, int httpPort, int dynomitePort) {
+	super(dynomitePort);
 
 	/**
 	 * If no port is passed means -1 then we will substitute to defaultPort
 	 * else the passed one.
 	 */
-	url = url.replace("{port}", (port > -1) ? Integer.toString(port) : Integer.toString(defaultPort));
+	url = url.replace("{port}", (httpPort > -1) ? Integer.toString(httpPort) : Integer.toString(defaultHttpPort));
 	serverUrl = url;
     }
 

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/health/ConnectionPoolHealthTrackerTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/health/ConnectionPoolHealthTrackerTest.java
@@ -27,6 +27,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import com.netflix.dyno.connectionpool.ConnectionPool;
 import org.apache.log4j.BasicConfigurator;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -66,7 +67,7 @@ public class ConnectionPoolHealthTrackerTest {
 		ConnectionPoolHealthTracker<Integer> tracker = new ConnectionPoolHealthTracker<Integer>(config, threadPool, 1000, -1);
 		tracker.start();
 
-		Host h1 = new Host("h1", "r1", Status.Up);
+		Host h1 = new Host("h1", ConnectionPoolConfigurationImpl.DEFAULT_DYNOMITE_PORT,"r1", Status.Up);
 		AtomicBoolean poolStatus = new AtomicBoolean(false); 
 		HostConnectionPool<Integer> hostPool = getMockConnectionPool(h1, poolStatus);
 
@@ -94,7 +95,7 @@ public class ConnectionPoolHealthTrackerTest {
 		ConnectionPoolHealthTracker<Integer> tracker = new ConnectionPoolHealthTracker<Integer>(config, threadPool, 1000, -1);
 		tracker.start();
 
-		Host h1 = new Host("h1", "r1", Status.Up);
+		Host h1 = new Host("h1", ConnectionPoolConfigurationImpl.DEFAULT_DYNOMITE_PORT,"r1", Status.Up);
 		AtomicBoolean poolStatus = new AtomicBoolean(false); 
 		HostConnectionPool<Integer> hostPool = getMockConnectionPool(h1, poolStatus, true);
 

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/lb/AbstractTokenMapSupplierTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/lb/AbstractTokenMapSupplierTest.java
@@ -26,16 +26,18 @@ import com.netflix.dyno.connectionpool.Host.Status;
 
 public class AbstractTokenMapSupplierTest {
 
-	final String json = "[{\"token\":\"3051939411\",\"hostname\":\"ec2-54-237-143-4.compute-1.amazonaws.com\",\"port\":\"8102\",\"dc\":\"us-east-1\",\"ip\":\"54.237.143.4\",\"zone\":\"us-east-1d\"}\"," +
-			"\"{\"token\":\"188627880\",\"hostname\":\"ec2-50-17-65-2.compute-1.amazonaws.com\",\"port\":\"8102\",\"dc\":\"us-east-1\",\"ip\":\"50.17.65.2\",\"zone\":\"us-east-1d\"},\"" +
-			"\"{\"token\":\"2019187467\",\"hostname\":\"ec2-54-83-87-174.compute-1.amazonaws.com\",\"port\":\"8102\",\"dc\":\"us-east-1\",\"ip\":\"54.83.87.174\",\"zone\":\"us-east-1c\" },\"" +
-			"\"{\"token\":\"3450843231\",\"hostname\":\"ec2-54-81-138-73.compute-1.amazonaws.com\",\"port\":\"8102\",\"dc\":\"us-east-1\",\"ip\":\"54.81.138.73\",\"zone\":\"us-east-1c\"},\""+
-			"\"{\"token\":\"587531700\",\"hostname\":\"ec2-54-82-176-215.compute-1.amazonaws.com\",\"port\":\"8102\",\"dc\":\"us-east-1\",\"ip\":\"54.82.176.215\",\"zone\":\"us-east-1c\"},\"" +
-			"\"{\"token\":\"3101134286\",\"hostname\":\"ec2-54-82-83-115.compute-1.amazonaws.com\",\"port\":\"8102\",\"dc\":\"us-east-1\",\"ip\":\"54.82.83.115\",\"zone\":\"us-east-1e\"},\"" +
-			"\"{\"token\":\"237822755\",\"hostname\":\"ec2-54-211-220-55.compute-1.amazonaws.com\",\"port\":\"8102\",\"dc\":\"us-east-1\",\"ip\":\"54.211.220.55\",\"zone\":\"us-east-1e\"},\"" +
-			"\"{\"token\":\"1669478519\",\"hostname\":\"ec2-54-80-65-203.compute-1.amazonaws.com\",\"port\":\"8102\",\"dc\":\"us-east-1\",\"ip\":\"54.80.65.203\",\"zone\":\"us-east-1e\"}]\"";
+	// For some negative test cases, let the json payload have some nodes with wrong port
+	final String json = "[{\"token\":\"3051939411\",\"hostname\":\"ec2-54-237-143-4.compute-1.amazonaws.com\",\"port\":\"22123\",\"dc\":\"us-east-1\",\"ip\":\"54.237.143.4\",\"zone\":\"us-east-1d\"}\"," +
+			"\"{\"token\":\"188627880\",\"hostname\":\"ec2-50-17-65-2.compute-1.amazonaws.com\",\"port\":\"22122\",\"dc\":\"us-east-1\",\"ip\":\"50.17.65.2\",\"zone\":\"us-east-1d\"},\"" +
+			"\"{\"token\":\"2019187467\",\"hostname\":\"ec2-54-83-87-174.compute-1.amazonaws.com\",\"port\":\"22122\",\"dc\":\"us-east-1\",\"ip\":\"54.83.87.174\",\"zone\":\"us-east-1c\" },\"" +
+			// TEST WRONG RACK here.
+			"\"{\"token\":\"3450843231\",\"hostname\":\"ec2-54-81-138-73.compute-1.amazonaws.com\",\"port\":\"22122\",\"dc\":\"us-east-1\",\"ip\":\"54.81.138.73\",\"zone\":\"us-east-1d\"},\""+
+			"\"{\"token\":\"587531700\",\"hostname\":\"ec2-54-82-176-215.compute-1.amazonaws.com\",\"port\":\"22122\",\"dc\":\"us-east-1\",\"ip\":\"54.82.176.215\",\"zone\":\"us-east-1c\"},\"" +
+			"\"{\"token\":\"3101134286\",\"hostname\":\"ec2-54-82-83-115.compute-1.amazonaws.com\",\"port\":\"22123\",\"dc\":\"us-east-1\",\"ip\":\"54.82.83.115\",\"zone\":\"us-east-1e\"},\"" +
+			"\"{\"token\":\"237822755\",\"hostname\":\"ec2-54-211-220-55.compute-1.amazonaws.com\",\"port\":\"22122\",\"dc\":\"us-east-1\",\"ip\":\"54.211.220.55\",\"zone\":\"us-east-1e\"},\"" +
+			"\"{\"token\":\"1669478519\",\"hostname\":\"ec2-54-80-65-203.compute-1.amazonaws.com\",\"port\":\"22122\",\"dc\":\"us-east-1\",\"ip\":\"54.80.65.203\",\"zone\":\"us-east-1e\"}]\"";
 
-	private TokenMapSupplier testTokenMapSupplier = new AbstractTokenMapSupplier(8102) {
+	private TokenMapSupplier testTokenMapSupplier = new AbstractTokenMapSupplier(22122) {
 
         @Override
         public String getTopologyJsonPayload(Set<Host> activeHosts) {
@@ -51,18 +53,21 @@ public class AbstractTokenMapSupplierTest {
 	@Test
 	public void testParseJson() throws Exception {
 
-		List<Host> hostList = new ArrayList<>();
+		// Create a dummy host list that one would get from teh host supplier.
+		Map<String, Host> hosts = Collections.synchronizedMap(new HashMap());
 
-		hostList.add(new Host("ec2-54-237-143-4.compute-1.amazonaws.com", 8102,"rack",  Status.Up));
-		hostList.add(new Host("ec2-50-17-65-2.compute-1.amazonaws.com", 8102,"rack" , Status.Up));
-		hostList.add(new Host("ec2-54-83-87-174.compute-1.amazonaws.com", 8102, "rack", Status.Up));
-		hostList.add(new Host("ec2-54-81-138-73.compute-1.amazonaws.com", 8102,"rack", Status.Up));
-		hostList.add(new Host("ec2-54-82-176-215.compute-1.amazonaws.com", 8102,"rack", Status.Up));
-		hostList.add(new Host("ec2-54-82-83-115.compute-1.amazonaws.com", 8102, "rack", Status.Up));
-		hostList.add(new Host("ec2-54-211-220-55.compute-1.amazonaws.com", 8102,"rack", Status.Up));
-		hostList.add(new Host("ec2-54-80-65-203.compute-1.amazonaws.com", 8102,"rack", Status.Up));
+		hosts.put("ec2-54-237-143-4.compute-1.amazonaws.com", new Host("ec2-54-237-143-4.compute-1.amazonaws.com", 22122,"us-east-1d",  Status.Up));
+		hosts.put("ec2-50-17-65-2.compute-1.amazonaws.com", new Host("ec2-50-17-65-2.compute-1.amazonaws.com", 22122,"us-east-1d" , Status.Up));
+		hosts.put("ec2-54-83-87-174.compute-1.amazonaws.com", new Host("ec2-54-83-87-174.compute-1.amazonaws.com", 22122, "us-east-1c", Status.Up));
+		hosts.put("ec2-54-81-138-73.compute-1.amazonaws.com", new Host("ec2-54-81-138-73.compute-1.amazonaws.com", 22122,"us-east-1c", Status.Up));
+		hosts.put("ec2-54-82-176-215.compute-1.amazonaws.com", new Host("ec2-54-82-176-215.compute-1.amazonaws.com", 22122,"us-east-1c", Status.Up));
+		hosts.put("ec2-54-82-83-115.compute-1.amazonaws.com", new Host("ec2-54-82-83-115.compute-1.amazonaws.com", 22122, "us-east-1e", Status.Up));
+		hosts.put("ec2-54-211-220-55.compute-1.amazonaws.com", new Host("ec2-54-211-220-55.compute-1.amazonaws.com", 22122,"us-east-1e", Status.Up));
+		hosts.put("ec2-54-80-65-203.compute-1.amazonaws.com", new Host("ec2-54-80-65-203.compute-1.amazonaws.com", 22122,"us-east-1e", Status.Up));
 
-		List<HostToken> hTokens = testTokenMapSupplier.getTokens(new HashSet<>(hostList));
+		// Get the list of token to host map that one would get from the TokenMapSupplier.
+		List<HostToken> hTokens = testTokenMapSupplier.getTokens(new HashSet<>(hosts.values()));
+
 		Collections.sort(hTokens, new Comparator<HostToken>() {
 			@Override
 			public int compare(HostToken o1, HostToken o2) {
@@ -70,22 +75,21 @@ public class AbstractTokenMapSupplierTest {
 			}
 		});
 
-        Assert.assertTrue(validateHostToken(hTokens.get(0), 188627880L, "ec2-50-17-65-2.compute-1.amazonaws.com", "50.17.65.2", 8102, "us-east-1d", "us-east-1"));
-        Assert.assertTrue(validateHostToken(hTokens.get(1), 237822755L, "ec2-54-211-220-55.compute-1.amazonaws.com", "54.211.220.55", 8102, "us-east-1e", "us-east-1"));
-        Assert.assertTrue(validateHostToken(hTokens.get(2), 587531700L, "ec2-54-82-176-215.compute-1.amazonaws.com", "54.82.176.215", 8102, "us-east-1c", "us-east-1"));
-        Assert.assertTrue(validateHostToken(hTokens.get(3), 1669478519L, "ec2-54-80-65-203.compute-1.amazonaws.com", "54.80.65.203", 8102, "us-east-1e", "us-east-1"));
-        Assert.assertTrue(validateHostToken(hTokens.get(4), 2019187467L, "ec2-54-83-87-174.compute-1.amazonaws.com", "54.83.87.174", 8102, "us-east-1c", "us-east-1"));
-        Assert.assertTrue(validateHostToken(hTokens.get(5), 3051939411L, "ec2-54-237-143-4.compute-1.amazonaws.com", "54.237.143.4", 8102, "us-east-1d", "us-east-1"));
-        Assert.assertTrue(validateHostToken(hTokens.get(6), 3101134286L, "ec2-54-82-83-115.compute-1.amazonaws.com", "54.82.83.115", 8102, "us-east-1e", "us-east-1"));
-        Assert.assertTrue(validateHostToken(hTokens.get(7), 3450843231L, "ec2-54-81-138-73.compute-1.amazonaws.com", "54.81.138.73", 8102, "us-east-1c", "us-east-1"));
+
+		// Assert that the host object from host supplier and from the token map supplier match.
+        Assert.assertTrue(validateHostToken(hTokens.get(0), 188627880L, hosts.get(hTokens.get(0).getHost().getHostName())));
+        Assert.assertTrue(validateHostToken(hTokens.get(1), 237822755L, hosts.get(hTokens.get(1).getHost().getHostName())));
+        Assert.assertTrue(validateHostToken(hTokens.get(2), 587531700L, hosts.get(hTokens.get(2).getHost().getHostName())));
+        Assert.assertTrue(validateHostToken(hTokens.get(3), 1669478519L, hosts.get(hTokens.get(3).getHost().getHostName())));
+        Assert.assertTrue(validateHostToken(hTokens.get(4), 2019187467L, hosts.get(hTokens.get(4).getHost().getHostName())));
+		// Assert that the host object from host supplier and from the token map supplier DO NOT match.
+        Assert.assertFalse(validateHostToken(hTokens.get(5), 3051939411L, hosts.get(hTokens.get(5).getHost().getHostName())));
+        Assert.assertFalse(validateHostToken(hTokens.get(6), 3101134286L, hosts.get(hTokens.get(6).getHost().getHostName())));
+        Assert.assertFalse(validateHostToken(hTokens.get(7), 3450843231L, hosts.get(hTokens.get(7).getHost().getHostName())));
     }
 
-    private boolean validateHostToken(HostToken hostToken, Long token, String hostname, String ipAddress, int port, String rack, String datacenter) {
+    private boolean validateHostToken(HostToken hostToken, Long token, Host hostFromHostSupplier) {
         return Objects.equals(hostToken.getToken(), token) &&
-                hostToken.getHost().getHostName().equals(hostname) &&
-                hostToken.getHost().getHostAddress().equals(ipAddress) &&
-                hostToken.getHost().getPort() == port &&
-                hostToken.getHost().getRack().equals(rack) &&
-                hostToken.getHost().getDatacenter().equals(datacenter);
+                hostToken.getHost().equals(hostFromHostSupplier);
     }
 }

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/lb/AbstractTokenMapSupplierTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/lb/AbstractTokenMapSupplierTest.java
@@ -26,16 +26,16 @@ import com.netflix.dyno.connectionpool.Host.Status;
 
 public class AbstractTokenMapSupplierTest {
 
-	final String json = "[{\"token\":\"3051939411\",\"hostname\":\"ec2-54-237-143-4.compute-1.amazonaws.com\",\"port\":\"11211\",\"dc\":\"us-east-1\",\"ip\":\"54.237.143.4\",\"zone\":\"us-east-1d\"}\"," +
-			"\"{\"token\":\"188627880\",\"hostname\":\"ec2-50-17-65-2.compute-1.amazonaws.com\",\"port\":\"11211\",\"dc\":\"us-east-1\",\"ip\":\"50.17.65.2\",\"zone\":\"us-east-1d\"},\"" +
-			"\"{\"token\":\"2019187467\",\"hostname\":\"ec2-54-83-87-174.compute-1.amazonaws.com\",\"port\":\"11211\",\"dc\":\"us-east-1\",\"ip\":\"54.83.87.174\",\"zone\":\"us-east-1c\" },\"" +
-			"\"{\"token\":\"3450843231\",\"hostname\":\"ec2-54-81-138-73.compute-1.amazonaws.com\",\"port\":\"11211\",\"dc\":\"us-east-1\",\"ip\":\"54.81.138.73\",\"zone\":\"us-east-1c\"},\""+
-			"\"{\"token\":\"587531700\",\"hostname\":\"ec2-54-82-176-215.compute-1.amazonaws.com\",\"port\":\"11211\",\"dc\":\"us-east-1\",\"ip\":\"54.82.176.215\",\"zone\":\"us-east-1c\"},\"" +
-			"\"{\"token\":\"3101134286\",\"hostname\":\"ec2-54-82-83-115.compute-1.amazonaws.com\",\"port\":\"11211\",\"dc\":\"us-east-1\",\"ip\":\"54.82.83.115\",\"zone\":\"us-east-1e\"},\"" +
-			"\"{\"token\":\"237822755\",\"hostname\":\"ec2-54-211-220-55.compute-1.amazonaws.com\",\"port\":\"11211\",\"dc\":\"us-east-1\",\"ip\":\"54.211.220.55\",\"zone\":\"us-east-1e\"},\"" +
-			"\"{\"token\":\"1669478519\",\"hostname\":\"ec2-54-80-65-203.compute-1.amazonaws.com\",\"port\":\"11211\",\"dc\":\"us-east-1\",\"ip\":\"54.80.65.203\",\"zone\":\"us-east-1e\"}]\"";
+	final String json = "[{\"token\":\"3051939411\",\"hostname\":\"ec2-54-237-143-4.compute-1.amazonaws.com\",\"port\":\"8102\",\"dc\":\"us-east-1\",\"ip\":\"54.237.143.4\",\"zone\":\"us-east-1d\"}\"," +
+			"\"{\"token\":\"188627880\",\"hostname\":\"ec2-50-17-65-2.compute-1.amazonaws.com\",\"port\":\"8102\",\"dc\":\"us-east-1\",\"ip\":\"50.17.65.2\",\"zone\":\"us-east-1d\"},\"" +
+			"\"{\"token\":\"2019187467\",\"hostname\":\"ec2-54-83-87-174.compute-1.amazonaws.com\",\"port\":\"8102\",\"dc\":\"us-east-1\",\"ip\":\"54.83.87.174\",\"zone\":\"us-east-1c\" },\"" +
+			"\"{\"token\":\"3450843231\",\"hostname\":\"ec2-54-81-138-73.compute-1.amazonaws.com\",\"port\":\"8102\",\"dc\":\"us-east-1\",\"ip\":\"54.81.138.73\",\"zone\":\"us-east-1c\"},\""+
+			"\"{\"token\":\"587531700\",\"hostname\":\"ec2-54-82-176-215.compute-1.amazonaws.com\",\"port\":\"8102\",\"dc\":\"us-east-1\",\"ip\":\"54.82.176.215\",\"zone\":\"us-east-1c\"},\"" +
+			"\"{\"token\":\"3101134286\",\"hostname\":\"ec2-54-82-83-115.compute-1.amazonaws.com\",\"port\":\"8102\",\"dc\":\"us-east-1\",\"ip\":\"54.82.83.115\",\"zone\":\"us-east-1e\"},\"" +
+			"\"{\"token\":\"237822755\",\"hostname\":\"ec2-54-211-220-55.compute-1.amazonaws.com\",\"port\":\"8102\",\"dc\":\"us-east-1\",\"ip\":\"54.211.220.55\",\"zone\":\"us-east-1e\"},\"" +
+			"\"{\"token\":\"1669478519\",\"hostname\":\"ec2-54-80-65-203.compute-1.amazonaws.com\",\"port\":\"8102\",\"dc\":\"us-east-1\",\"ip\":\"54.80.65.203\",\"zone\":\"us-east-1e\"}]\"";
 
-	private TokenMapSupplier testTokenMapSupplier = new AbstractTokenMapSupplier() {
+	private TokenMapSupplier testTokenMapSupplier = new AbstractTokenMapSupplier(8102) {
 
         @Override
         public String getTopologyJsonPayload(Set<Host> activeHosts) {
@@ -53,14 +53,14 @@ public class AbstractTokenMapSupplierTest {
 
 		List<Host> hostList = new ArrayList<>();
 
-		hostList.add(new Host("ec2-54-237-143-4.compute-1.amazonaws.com", "rack",  Status.Up));
-		hostList.add(new Host("ec2-50-17-65-2.compute-1.amazonaws.com", "rack" , Status.Up));
-		hostList.add(new Host("ec2-54-83-87-174.compute-1.amazonaws.com", "rack", Status.Up));
-		hostList.add(new Host("ec2-54-81-138-73.compute-1.amazonaws.com", "rack", Status.Up));
-		hostList.add(new Host("ec2-54-82-176-215.compute-1.amazonaws.com", "rack", Status.Up));
-		hostList.add(new Host("ec2-54-82-83-115.compute-1.amazonaws.com", "rack", Status.Up));
-		hostList.add(new Host("ec2-54-211-220-55.compute-1.amazonaws.com", "rack", Status.Up));
-		hostList.add(new Host("ec2-54-80-65-203.compute-1.amazonaws.com", "rack", Status.Up));
+		hostList.add(new Host("ec2-54-237-143-4.compute-1.amazonaws.com", 8102,"rack",  Status.Up));
+		hostList.add(new Host("ec2-50-17-65-2.compute-1.amazonaws.com", 8102,"rack" , Status.Up));
+		hostList.add(new Host("ec2-54-83-87-174.compute-1.amazonaws.com", 8102, "rack", Status.Up));
+		hostList.add(new Host("ec2-54-81-138-73.compute-1.amazonaws.com", 8102,"rack", Status.Up));
+		hostList.add(new Host("ec2-54-82-176-215.compute-1.amazonaws.com", 8102,"rack", Status.Up));
+		hostList.add(new Host("ec2-54-82-83-115.compute-1.amazonaws.com", 8102, "rack", Status.Up));
+		hostList.add(new Host("ec2-54-211-220-55.compute-1.amazonaws.com", 8102,"rack", Status.Up));
+		hostList.add(new Host("ec2-54-80-65-203.compute-1.amazonaws.com", 8102,"rack", Status.Up));
 
 		List<HostToken> hTokens = testTokenMapSupplier.getTokens(new HashSet<>(hostList));
 		Collections.sort(hTokens, new Comparator<HostToken>() {
@@ -70,14 +70,14 @@ public class AbstractTokenMapSupplierTest {
 			}
 		});
 
-        Assert.assertTrue(validateHostToken(hTokens.get(0), 188627880L, "ec2-50-17-65-2.compute-1.amazonaws.com", "50.17.65.2", 11211, "us-east-1d", "us-east-1"));
-        Assert.assertTrue(validateHostToken(hTokens.get(1), 237822755L, "ec2-54-211-220-55.compute-1.amazonaws.com", "54.211.220.55", 11211, "us-east-1e", "us-east-1"));
-        Assert.assertTrue(validateHostToken(hTokens.get(2), 587531700L, "ec2-54-82-176-215.compute-1.amazonaws.com", "54.82.176.215", 11211, "us-east-1c", "us-east-1"));
-        Assert.assertTrue(validateHostToken(hTokens.get(3), 1669478519L, "ec2-54-80-65-203.compute-1.amazonaws.com", "54.80.65.203", 11211, "us-east-1e", "us-east-1"));
-        Assert.assertTrue(validateHostToken(hTokens.get(4), 2019187467L, "ec2-54-83-87-174.compute-1.amazonaws.com", "54.83.87.174", 11211, "us-east-1c", "us-east-1"));
-        Assert.assertTrue(validateHostToken(hTokens.get(5), 3051939411L, "ec2-54-237-143-4.compute-1.amazonaws.com", "54.237.143.4", 11211, "us-east-1d", "us-east-1"));
-        Assert.assertTrue(validateHostToken(hTokens.get(6), 3101134286L, "ec2-54-82-83-115.compute-1.amazonaws.com", "54.82.83.115", 11211, "us-east-1e", "us-east-1"));
-        Assert.assertTrue(validateHostToken(hTokens.get(7), 3450843231L, "ec2-54-81-138-73.compute-1.amazonaws.com", "54.81.138.73", 11211, "us-east-1c", "us-east-1"));
+        Assert.assertTrue(validateHostToken(hTokens.get(0), 188627880L, "ec2-50-17-65-2.compute-1.amazonaws.com", "50.17.65.2", 8102, "us-east-1d", "us-east-1"));
+        Assert.assertTrue(validateHostToken(hTokens.get(1), 237822755L, "ec2-54-211-220-55.compute-1.amazonaws.com", "54.211.220.55", 8102, "us-east-1e", "us-east-1"));
+        Assert.assertTrue(validateHostToken(hTokens.get(2), 587531700L, "ec2-54-82-176-215.compute-1.amazonaws.com", "54.82.176.215", 8102, "us-east-1c", "us-east-1"));
+        Assert.assertTrue(validateHostToken(hTokens.get(3), 1669478519L, "ec2-54-80-65-203.compute-1.amazonaws.com", "54.80.65.203", 8102, "us-east-1e", "us-east-1"));
+        Assert.assertTrue(validateHostToken(hTokens.get(4), 2019187467L, "ec2-54-83-87-174.compute-1.amazonaws.com", "54.83.87.174", 8102, "us-east-1c", "us-east-1"));
+        Assert.assertTrue(validateHostToken(hTokens.get(5), 3051939411L, "ec2-54-237-143-4.compute-1.amazonaws.com", "54.237.143.4", 8102, "us-east-1d", "us-east-1"));
+        Assert.assertTrue(validateHostToken(hTokens.get(6), 3101134286L, "ec2-54-82-83-115.compute-1.amazonaws.com", "54.82.83.115", 8102, "us-east-1e", "us-east-1"));
+        Assert.assertTrue(validateHostToken(hTokens.get(7), 3450843231L, "ec2-54-81-138-73.compute-1.amazonaws.com", "54.81.138.73", 8102, "us-east-1c", "us-east-1"));
     }
 
     private boolean validateHostToken(HostToken hostToken, Long token, String hostname, String ipAddress, int port, String rack, String datacenter) {

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/lb/AbstractTokenMapSupplierTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/lb/AbstractTokenMapSupplierTest.java
@@ -26,11 +26,11 @@ import com.netflix.dyno.connectionpool.Host.Status;
 
 public class AbstractTokenMapSupplierTest {
 
-	// For some negative test cases, let the json payload have some nodes with wrong port
+	// For some negative test cases, let the json payload have some nodes with wrong port, and some with wrong rack. The assert statements
+	// below reflect the right results expected (assertTrue vs assertFalse)
 	final String json = "[{\"token\":\"3051939411\",\"hostname\":\"ec2-54-237-143-4.compute-1.amazonaws.com\",\"port\":\"22123\",\"dc\":\"us-east-1\",\"ip\":\"54.237.143.4\",\"zone\":\"us-east-1d\"}\"," +
 			"\"{\"token\":\"188627880\",\"hostname\":\"ec2-50-17-65-2.compute-1.amazonaws.com\",\"port\":\"22122\",\"dc\":\"us-east-1\",\"ip\":\"50.17.65.2\",\"zone\":\"us-east-1d\"},\"" +
 			"\"{\"token\":\"2019187467\",\"hostname\":\"ec2-54-83-87-174.compute-1.amazonaws.com\",\"port\":\"22122\",\"dc\":\"us-east-1\",\"ip\":\"54.83.87.174\",\"zone\":\"us-east-1c\" },\"" +
-			// TEST WRONG RACK here.
 			"\"{\"token\":\"3450843231\",\"hostname\":\"ec2-54-81-138-73.compute-1.amazonaws.com\",\"port\":\"22122\",\"dc\":\"us-east-1\",\"ip\":\"54.81.138.73\",\"zone\":\"us-east-1d\"},\""+
 			"\"{\"token\":\"587531700\",\"hostname\":\"ec2-54-82-176-215.compute-1.amazonaws.com\",\"port\":\"22122\",\"dc\":\"us-east-1\",\"ip\":\"54.82.176.215\",\"zone\":\"us-east-1c\"},\"" +
 			"\"{\"token\":\"3101134286\",\"hostname\":\"ec2-54-82-83-115.compute-1.amazonaws.com\",\"port\":\"22123\",\"dc\":\"us-east-1\",\"ip\":\"54.82.83.115\",\"zone\":\"us-east-1e\"},\"" +

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/lb/HostSelectionWithFallbackTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/lb/HostSelectionWithFallbackTest.java
@@ -78,12 +78,12 @@ public class HostSelectionWithFallbackTest {
 	private final ConnectionPoolConfigurationImpl cpConfig = new ConnectionPoolConfigurationImpl("test");
 	private final ConnectionPoolMonitor cpMonitor = new CountingConnectionPoolMonitor();
 
-	Host h1 = new Host("h1", "localTestRack", Status.Up);
-	Host h2 = new Host("h2", "localTestRack", Status.Up);
-	Host h3 = new Host("h3", "remoteRack1", Status.Up);
-	Host h4 = new Host("h4", "remoteRack1", Status.Up);
-	Host h5 = new Host("h5", "remoteRack2", Status.Up);
-	Host h6 = new Host("h6", "remoteRack2", Status.Up);
+	Host h1 = new Host("h1", 8102,"localTestRack", Status.Up);
+	Host h2 = new Host("h2", 8102, "localTestRack", Status.Up);
+	Host h3 = new Host("h3", 8102,"remoteRack1", Status.Up);
+	Host h4 = new Host("h4", 8102,"remoteRack1", Status.Up);
+	Host h5 = new Host("h5", 8102, "remoteRack2", Status.Up);
+	Host h6 = new Host("h6", 8102, "remoteRack2", Status.Up);
 
 	Host[] arr = {h1, h2, h3, h4, h5, h6};
 	List<Host> hosts = Arrays.asList(arr);

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/lb/TokenMapSupplierTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/lb/TokenMapSupplierTest.java
@@ -18,6 +18,7 @@ package com.netflix.dyno.connectionpool.impl.lb;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.netflix.dyno.connectionpool.impl.ConnectionPoolConfigurationImpl;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -49,7 +50,7 @@ public class TokenMapSupplierTest {
         hostList.add(new Host("ec2-54-211-220-55.compute-1.amazonaws.com", 11211, "us-east-1e", Status.Up));
         hostList.add(new Host("ec2-54-80-65-203.compute-1.amazonaws.com", 11211, "us-east-1e", Status.Up));
 
-        HttpEndpointBasedTokenMapSupplier tokenSupplier = new HttpEndpointBasedTokenMapSupplier("us-east-1d", 11211);
+        HttpEndpointBasedTokenMapSupplier tokenSupplier = new HttpEndpointBasedTokenMapSupplier("us-east-1d", 8080,11211);
 
         List<HostToken> hTokens = tokenSupplier.parseTokenListFromJson(json);
 
@@ -94,7 +95,7 @@ public class TokenMapSupplierTest {
         hostList.add(new Host("ec2-54-211-220-55.compute-1.amazonaws.com", 11217, "us-east-1e", Status.Up));
         hostList.add(new Host("ec2-54-80-65-203.compute-1.amazonaws.com", 11218, "us-east-1e", Status.Up));
 
-        HttpEndpointBasedTokenMapSupplier tokenSupplier = new HttpEndpointBasedTokenMapSupplier("us-east-1d", 11211);
+        HttpEndpointBasedTokenMapSupplier tokenSupplier = new HttpEndpointBasedTokenMapSupplier("us-east-1d", 8080, 11211);
 
         List<HostToken> hTokens = tokenSupplier.parseTokenListFromJson(json);
 
@@ -154,7 +155,7 @@ public class TokenMapSupplierTest {
         hostList.add(new Host("ec2-54-211-220-55.compute-1.amazonaws.com", 11211, "us-east-1e", Status.Up));
         hostList.add(new Host("ec2-54-80-65-203.compute-1.amazonaws.com", 11211, "us-east-1e", Status.Up));
 
-        HttpEndpointBasedTokenMapSupplier tokenSupplier = new HttpEndpointBasedTokenMapSupplier("us-east-1d", 11211);
+        HttpEndpointBasedTokenMapSupplier tokenSupplier = new HttpEndpointBasedTokenMapSupplier("us-east-1d", 8080,11211);
 
         List<HostToken> hTokens = tokenSupplier.parseTokenListFromJson(json);
 

--- a/dyno-demo/src/main/java/com/netflix/dyno/demo/redis/DynoJedisDemo.java
+++ b/dyno-demo/src/main/java/com/netflix/dyno/demo/redis/DynoJedisDemo.java
@@ -34,6 +34,7 @@ import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
 
 import com.netflix.dyno.connectionpool.*;
+import com.netflix.dyno.connectionpool.impl.ConnectionPoolConfigurationImpl;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
@@ -71,9 +72,9 @@ public class DynoJedisDemo {
 
 	public void initWithLocalHost() throws Exception {
 
-		final int port = 6379;
+		final int port = ConnectionPoolConfigurationImpl.DEFAULT_DYNOMITE_PORT;
 
-		final Host localHost = new Host("localhost", port, "localrack", Status.Up);
+		final Host localHost = new Host("localhost", port, "us-east-1e", Status.Up);
 
 		final HostSupplier localHostSupplier = new HostSupplier() {
 
@@ -123,8 +124,10 @@ public class DynoJedisDemo {
 
 	public void init(HostSupplier hostSupplier, int port, TokenMapSupplier tokenSupplier) throws Exception {
 
-		client = new DynoJedisClient.Builder().withApplicationName("demo").withDynomiteClusterName("dyno_dev")
+		client = new DynoJedisClient.Builder().withApplicationName("demo").withDynomiteClusterName(this.clusterName)
 				.withHostSupplier(hostSupplier)
+				.withPort(port)
+				.withTokenMapSupplier(tokenSupplier)
 				// .withCPConfig(
 				// new ConnectionPoolConfigurationImpl("demo")
 				// .setCompressionStrategy(ConnectionPoolConfiguration.CompressionStrategy.THRESHOLD)
@@ -774,7 +777,7 @@ public class DynoJedisDemo {
 			for (Map<String, String> map : handler.getList()) {
 				String rack = map.get("availability-zone");
 				Status status = map.get("status").equalsIgnoreCase("UP") ? Status.Up : Status.Down;
-				Host host = new Host(map.get("public-hostname"), map.get("local-ipv4"), rack, status);
+				Host host = new Host(map.get("public-hostname"), map.get("local-ipv4"), ConnectionPoolConfigurationImpl.DEFAULT_DYNOMITE_PORT, rack, status);
 				hosts.add(host);
 				System.out.println("Host: " + host);
 			}
@@ -951,6 +954,7 @@ public class DynoJedisDemo {
 		DynoJedisDemo demo = new DynoJedisDemo(clusterName, rack);
 
 		try {
+//		    demo.initWithLocalHost();
 			if (hostsFile != null) {
 				demo.initWithRemoteClusterFromFile(hostsFile, port);
 			} else {

--- a/dyno-jedis/src/main/java/com/netflix/dyno/jedis/DynoJedisClient.java
+++ b/dyno-jedis/src/main/java/com/netflix/dyno/jedis/DynoJedisClient.java
@@ -3961,7 +3961,6 @@ public class DynoJedisClient implements JedisCommands, BinaryJedisCommands, Mult
 
             try {
                 Logger.info("Starting connection pool for app " + appName);
-                Logger.info("Starting connection pool for app " + appName);
 
                 pool.start().get();
 

--- a/dyno-jedis/src/main/java/com/netflix/dyno/jedis/DynoJedisClient.java
+++ b/dyno-jedis/src/main/java/com/netflix/dyno/jedis/DynoJedisClient.java
@@ -3673,12 +3673,12 @@ public class DynoJedisClient implements JedisCommands, BinaryJedisCommands, Mult
     }
 
     /**
-     * NOT SUPPORTED ! Use {@link #dyno_scan(CursorBasedResult, String...)}
+     * NOT SUPPORTED ! Use {@link #dyno_scan(CursorBasedResult, int, String...)}
      * instead.
      *
      * @param cursor
      * @return nothing -- throws UnsupportedOperationException when invoked
-     * @see #dyno_scan(CursorBasedResult, String...)
+     * @see #dyno_scan(CursorBasedResult, int, String...)
      */
     @Override
     public ScanResult<String> scan(int cursor) {
@@ -3686,12 +3686,12 @@ public class DynoJedisClient implements JedisCommands, BinaryJedisCommands, Mult
     }
 
     /**
-     * NOT SUPPORTED ! Use {@link #dyno_scan(CursorBasedResult, String...)}
+     * NOT SUPPORTED ! Use {@link #dyno_scan(CursorBasedResult, int, String...)}
      * instead.
      *
      * @param cursor
      * @return nothing -- throws UnsupportedOperationException when invoked
-     * @see #dyno_scan(CursorBasedResult, String...)
+     * @see #dyno_scan(CursorBasedResult, int, String...)
      */
     @Override
     public ScanResult<String> scan(String cursor) {
@@ -3758,8 +3758,12 @@ public class DynoJedisClient implements JedisCommands, BinaryJedisCommands, Mult
 
         private String appName;
         private String clusterName;
+
+        private int port = -1;
         private ConnectionPoolConfigurationImpl cpConfig;
         private HostSupplier hostSupplier;
+        private TokenMapSupplier tokenMapSupplier;
+
         private EurekaClient discoveryClient;
         private String dualWriteClusterName;
         private HostSupplier dualWriteHostSupplier;
@@ -3787,6 +3791,11 @@ public class DynoJedisClient implements JedisCommands, BinaryJedisCommands, Mult
 
         public Builder withHostSupplier(HostSupplier hSupplier) {
             hostSupplier = hSupplier;
+            return this;
+        }
+
+        public Builder withTokenMapSupplier(TokenMapSupplier tokenMapSupplier) {
+            this.tokenMapSupplier = tokenMapSupplier;
             return this;
         }
 
@@ -3826,10 +3835,15 @@ public class DynoJedisClient implements JedisCommands, BinaryJedisCommands, Mult
             return this;
         }
 
+        public Builder withPort(int suppliedPort) {
+            Logger.info("Will use port" + suppliedPort);
+            this.port = suppliedPort;
+            return this;
+        }
+
         public DynoJedisClient build() {
             assert (appName != null);
             assert (clusterName != null);
-
             if (cpConfig == null) {
                 cpConfig = new ArchaiusConnectionPoolConfiguration(appName);
                 Logger.info("Dyno Client runtime properties: " + cpConfig.toString());
@@ -3850,14 +3864,18 @@ public class DynoJedisClient implements JedisCommands, BinaryJedisCommands, Mult
             // client application startup
             shadowConfig.setFailOnStartupIfNoHosts(false);
 
+            if (port != -1) {
+                shadowConfig.setPort(port);
+            }
+
             HostSupplier shadowSupplier = null;
             if (dualWriteHostSupplier == null) {
                 if (hostSupplier != null && hostSupplier instanceof EurekaHostsSupplier) {
                     EurekaHostsSupplier eurekaSupplier = (EurekaHostsSupplier) hostSupplier;
-                    shadowSupplier = EurekaHostsSupplier.newInstance(shadowConfig.getDualWriteClusterName(),
-                            eurekaSupplier);
+                    shadowSupplier = new EurekaHostsSupplier(shadowConfig.getDualWriteClusterName(),
+                            eurekaSupplier.getDiscoveryClient(), shadowConfig.getPort());
                 } else if (discoveryClient != null) {
-                    shadowSupplier = new EurekaHostsSupplier(shadowConfig.getDualWriteClusterName(), discoveryClient);
+                    shadowSupplier = new EurekaHostsSupplier(shadowConfig.getDualWriteClusterName(), discoveryClient, shadowConfig.getPort());
                 } else {
                     throw new DynoConnectException("HostSupplier for DualWrite cluster is REQUIRED if you are not "
                             + "using EurekaHostsSupplier implementation or using a EurekaClient");
@@ -3869,7 +3887,7 @@ public class DynoJedisClient implements JedisCommands, BinaryJedisCommands, Mult
             shadowConfig.withHostSupplier(shadowSupplier);
 
             setLoadBalancingStrategy(shadowConfig);
-            setHashtagConnectionPool(shadowSupplier, shadowConfig);
+            setHashtagConnectionPool(shadowConfig);
 
             String shadowAppName = shadowConfig.getName();
             DynoCPMonitor shadowCPMonitor = new DynoCPMonitor(shadowAppName);
@@ -3903,6 +3921,9 @@ public class DynoJedisClient implements JedisCommands, BinaryJedisCommands, Mult
         }
 
         private DynoJedisClient buildDynoJedisClient() {
+            if (port != -1) {
+                cpConfig.setPort(port);
+            }
             DynoOPMonitor opMonitor = new DynoOPMonitor(appName);
             ConnectionPoolMonitor cpMonitor = (this.cpMonitor == null) ? new DynoCPMonitor(appName) : this.cpMonitor;
 
@@ -3919,13 +3940,15 @@ public class DynoJedisClient implements JedisCommands, BinaryJedisCommands, Mult
                     throw new DynoConnectException("HostSupplier not provided. Cannot initialize EurekaHostsSupplier "
                             + "which requires a DiscoveryClient");
                 } else {
-                    hostSupplier = new EurekaHostsSupplier(clusterName, discoveryClient);
+                    hostSupplier = new EurekaHostsSupplier(clusterName, discoveryClient, cpConfig.getPort());
                 }
             }
 
             cpConfig.withHostSupplier(hostSupplier);
+            if (tokenMapSupplier != null)
+                cpConfig.withTokenSupplier(tokenMapSupplier);
             setLoadBalancingStrategy(cpConfig);
-            setHashtagConnectionPool(hostSupplier, cpConfig);
+            setHashtagConnectionPool(cpConfig);
             JedisConnectionFactory connFactory = new JedisConnectionFactory(opMonitor, sslSocketFactory);
 
             return startConnectionPool(appName, connFactory, cpConfig, cpMonitor);
@@ -3937,6 +3960,7 @@ public class DynoJedisClient implements JedisCommands, BinaryJedisCommands, Mult
             final ConnectionPoolImpl<Jedis> pool = new ConnectionPoolImpl<Jedis>(connFactory, cpConfig, cpMonitor);
 
             try {
+                Logger.info("Starting connection pool for app " + appName);
                 Logger.info("Starting connection pool for app " + appName);
 
                 pool.start().get();
@@ -3967,7 +3991,7 @@ public class DynoJedisClient implements JedisCommands, BinaryJedisCommands, Mult
                 if (config.getTokenSupplier() == null) {
                     Logger.warn(
                             "TOKEN AWARE selected and no token supplier found, using default HttpEndpointBasedTokenMapSupplier()");
-                    config.withTokenSupplier(new HttpEndpointBasedTokenMapSupplier());
+                    config.withTokenSupplier(new HttpEndpointBasedTokenMapSupplier(cpConfig.getPort()));
                 }
 
                 if (config.getLocalRack() == null && config.localZoneAffinity()) {
@@ -3986,10 +4010,11 @@ public class DynoJedisClient implements JedisCommands, BinaryJedisCommands, Mult
 
         /**
          * Set the hash to the connection pool if is provided by Dynomite
-         * @param hostSupplier
+         * @param config
          */
-        private void setHashtagConnectionPool(HostSupplier hostSupplier, ConnectionPoolConfigurationImpl config) {
+        private void setHashtagConnectionPool(ConnectionPoolConfigurationImpl config) {
             // Find the hosts from host supplier
+            HostSupplier hostSupplier = config.getHostSupplier();
             Collection<Host> hosts = hostSupplier.getHosts();
             // Convert the returned collection to an arraylist
             ArrayList<Host> arrayHosts = new ArrayList<Host>(hosts);

--- a/dyno-jedis/src/test/java/com/netflix/dyno/jedis/JedisConnectionFactoryIntegrationTest.java
+++ b/dyno-jedis/src/test/java/com/netflix/dyno/jedis/JedisConnectionFactoryIntegrationTest.java
@@ -39,6 +39,8 @@ public class JedisConnectionFactoryIntegrationTest {
 
     private final String rack = "rack1";
 
+    private final String datacenter = "rack";
+
     private final Host localHost = new Host("localhost", port, rack, Host.Status.Up);
 
     private final HostSupplier localHostSupplier = new HostSupplier() {
@@ -113,8 +115,8 @@ public class JedisConnectionFactoryIntegrationTest {
 
     private DynoJedisClient constructJedisClient(final boolean withSsl) throws Exception {
         final ConnectionPoolConfigurationImpl connectionPoolConfiguration = new ConnectionPoolConfigurationImpl(rack);
-        connectionPoolConfiguration.withTokenSupplier(supplier);
         connectionPoolConfiguration.setLocalRack(rack);
+        connectionPoolConfiguration.setLocalDataCenter(datacenter);
 
         final SSLContext sslContext = createAndInitSSLContext("client.jks");
 
@@ -122,6 +124,7 @@ public class JedisConnectionFactoryIntegrationTest {
                 .withApplicationName("appname")
                 .withDynomiteClusterName(rack)
                 .withHostSupplier(localHostSupplier)
+                .withTokenMapSupplier(supplier)
                 .withCPConfig(connectionPoolConfiguration);
 
         if (withSsl) {


### PR DESCRIPTION
Remove the Default port from host object and put it in connectionPoolConfiguration. The idea is to make the port configurable.
All constructors of Host class take a port as parameter making it mandatory for the user to provide one.
It is the responsibility of the HostSupplier and TokenMapSupplier to provide hosts with the correct port. Hence the Default implementations in the code now take port as a parameter.
I also attempted to fix the SSL test with the correct datacenter provided so that it doesn't fail in calculating replication factor.

The builder object was not taking the tokenMapSupplier so user would create a connectionPoolConfiguration and provide tokenMapSupplier via it, many times, not using the ArchaiusConnectionPoolConfiguration.