### PR TITLE
Use Hosts from Token Map Supplier

### DIFF
--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/Host.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/Host.java
@@ -150,7 +150,7 @@ public class Host implements Comparable<Host> {
     /**
      * Equality checks will fail in collections between Host objects created
      * from the HostSupplier, which may not know the Dynomite port, and the Host
-     * objects created by the load balancer.
+     * objects created by the token map supplier.
      */
     @Override
     public int hashCode() {

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/HostSupplier.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/HostSupplier.java
@@ -15,7 +15,7 @@
  ******************************************************************************/
 package com.netflix.dyno.connectionpool;
 
-import java.util.Collection;
+import java.util.List;
 
 /**
  * Interface for a supplier of host objects that map to the dynomite cluster. The {@link ConnectionPool} object can use this to 
@@ -30,5 +30,5 @@ public interface HostSupplier {
 	 * Return a collection of dynomite hosts for the connection pool
 	 * @return Collection<Host>
 	 */
-	public Collection<Host> getHosts();
+	public List<Host> getHosts();
 }

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/HostSupplier.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/HostSupplier.java
@@ -27,8 +27,8 @@ import java.util.List;
 public interface HostSupplier {
 	
 	/**
-	 * Return a collection of dynomite hosts for the connection pool
-	 * @return Collection<Host>
+	 * Return a list of dynomite hosts for the connection pool
+	 * @return List<Host>
 	 */
 	public List<Host> getHosts();
 }

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolImpl.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolImpl.java
@@ -125,7 +125,7 @@ public class ConnectionPoolImpl<CL> implements ConnectionPool<CL>, TopologyView 
 	}
 	;
 
-	this.hostsUpdater = new HostsUpdater(cpConfiguration.getHostSupplier());
+	this.hostsUpdater = new HostsUpdater(cpConfiguration.getHostSupplier(), cpConfiguration.getTokenSupplier());
 
     }
 

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/HostsUpdater.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/HostsUpdater.java
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
 
 public class HostsUpdater {
 
-	private static final org.slf4j.Logger Logger = LoggerFactory.getLogger(ConnectionPoolImpl.class);
+	private static final Logger Logger = LoggerFactory.getLogger(ConnectionPoolImpl.class);
 
 	private final HostSupplier hostSupplier;
 	private final TokenMapSupplier tokenMapSupplier;
@@ -73,8 +73,8 @@ public class HostsUpdater {
 		}
 
 		/**
-		 * HostTracker should return the hosts that we get from TMS.
-		 * Hence get the hosts from HostSupplier and map them to TMS
+		 * HostTracker should return the hosts that we get from TokenMapSupplier.
+		 * Hence get the hosts from HostSupplier and map them to TokenMapSupplier
 		 * and return them.
 		 */
 		Collections.sort(allHosts);
@@ -82,7 +82,7 @@ public class HostsUpdater {
 		// Create a list of host/Tokens
 		List<HostToken> hostTokens;
 		if (tokenMapSupplier != null) {
-			Logger.info("Getting Hosts from TMS");
+			Logger.info("Getting Hosts from TokenMapSupplier");
 			hostTokens = tokenMapSupplier.getTokens(hostSet);
 
 			if (hostTokens.isEmpty()) {
@@ -92,9 +92,12 @@ public class HostsUpdater {
 			throw new DynoException("TokenMapSupplier not provided");
 		}
 
-		Map<Host, Host> allHostSetFromTMS = new HashMap<>();
+		// The key here really needs to be a object that is overlapping between
+		// the host from HostSupplier and TokenMapSupplier. Since that is a
+		// subset of the Host object itself, Host is the key as well as value here.
+		Map<Host, Host> allHostSetFromTokenMapSupplier = new HashMap<>();
 		for (HostToken ht : hostTokens) {
-			allHostSetFromTMS.put(ht.getHost(), ht.getHost());
+			allHostSetFromTokenMapSupplier.put(ht.getHost(), ht.getHost());
 		}
 
 		hostsUp.clear();
@@ -102,9 +105,9 @@ public class HostsUpdater {
 
 		for (Host host : allHosts) {
 			if (host.isUp()) {
-				hostsUp.add(allHostSetFromTMS.get(host));
+				hostsUp.add(allHostSetFromTokenMapSupplier.get(host));
 			} else {
-				hostsDown.add(allHostSetFromTMS.get(host));
+				hostsDown.add(allHostSetFromTokenMapSupplier.get(host));
 			}
 		}
 

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolImplTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolImplTest.java
@@ -163,7 +163,7 @@ public class ConnectionPoolImplTest {
 		cpConfig.withHostSupplier(new HostSupplier() {
 			
 			@Override
-			public Collection<Host> getHosts() {
+			public List<Host> getHosts() {
 				return hostSupplierHosts;
 			}
 		});

--- a/dyno-demo/src/main/java/com/netflix/dyno/demo/redis/CustomTokenSupplierExample.java
+++ b/dyno-demo/src/main/java/com/netflix/dyno/demo/redis/CustomTokenSupplierExample.java
@@ -54,7 +54,7 @@ public class CustomTokenSupplierExample {
         final HostSupplier localHostSupplier = new HostSupplier() {
 
             @Override
-            public Collection<Host> getHosts() {
+            public List<Host> getHosts() {
                 return Collections.singletonList(localHost);
             }
         };

--- a/dyno-demo/src/main/java/com/netflix/dyno/demo/redis/DynoJedisDemo.java
+++ b/dyno-demo/src/main/java/com/netflix/dyno/demo/redis/DynoJedisDemo.java
@@ -73,19 +73,20 @@ public class DynoJedisDemo {
 
 		final int port = 6379;
 
-		final Host localHost = new Host("localhost", port, "localrack", Status.Up);
 
 		final HostSupplier localHostSupplier = new HostSupplier() {
+			final Host hostSupplierHost = new Host("localhost", localRack, Status.Up);
 
 			@Override
-			public Collection<Host> getHosts() {
-				return Collections.singletonList(localHost);
+			public List<Host> getHosts() {
+				return Collections.singletonList(hostSupplierHost);
 			}
 		};
 
 		final TokenMapSupplier tokenSupplier = new TokenMapSupplier() {
 
-			final HostToken localHostToken = new HostToken(100000L, localHost);
+			final Host tokenHost = new Host("localhost", port, localRack, Status.Up);
+			final HostToken localHostToken = new HostToken(100000L, tokenHost);
 
 			@Override
 			public List<HostToken> getTokens(Set<Host> activeHosts) {
@@ -105,7 +106,7 @@ public class DynoJedisDemo {
 		final HostSupplier clusterHostSupplier = new HostSupplier() {
 
 			@Override
-			public Collection<Host> getHosts() {
+			public List<Host> getHosts() {
 				return hosts;
 			}
 		};
@@ -125,6 +126,7 @@ public class DynoJedisDemo {
 
 		client = new DynoJedisClient.Builder().withApplicationName("demo").withDynomiteClusterName("dyno_dev")
 				.withHostSupplier(hostSupplier)
+				.withTokenMapSupplier(tokenSupplier)
 				// .withCPConfig(
 				// new ConnectionPoolConfigurationImpl("demo")
 				// .setCompressionStrategy(ConnectionPoolConfiguration.CompressionStrategy.THRESHOLD)
@@ -956,6 +958,7 @@ public class DynoJedisDemo {
 			} else {
 				demo.initWithRemoteClusterFromEurekaUrl(clusterName, port);
 			}
+//			demo.initWithLocalHost();
 
 			System.out.println("Connected");
 

--- a/dyno-jedis/src/test/java/com/netflix/dyno/jedis/JedisConnectionFactoryIntegrationTest.java
+++ b/dyno-jedis/src/test/java/com/netflix/dyno/jedis/JedisConnectionFactoryIntegrationTest.java
@@ -39,12 +39,14 @@ public class JedisConnectionFactoryIntegrationTest {
 
     private final String rack = "rack1";
 
+    private final String datacenter = "rack";
+
     private final Host localHost = new Host("localhost", port, rack, Host.Status.Up);
 
     private final HostSupplier localHostSupplier = new HostSupplier() {
 
         @Override
-        public Collection<Host> getHosts() {
+        public List<Host> getHosts() {
             return Collections.singletonList(localHost);
         }
     };
@@ -115,6 +117,7 @@ public class JedisConnectionFactoryIntegrationTest {
         final ConnectionPoolConfigurationImpl connectionPoolConfiguration = new ConnectionPoolConfigurationImpl(rack);
         connectionPoolConfiguration.withTokenSupplier(supplier);
         connectionPoolConfiguration.setLocalRack(rack);
+        connectionPoolConfiguration.setLocalDataCenter(datacenter);
 
         final SSLContext sslContext = createAndInitSSLContext("client.jks");
 


### PR DESCRIPTION
Previously we were taking the hosts from the HostSupplier and then using them to prime connections.
The hosts from the tokenMapSupplier were only used later to initialize the selection strategy.
However, the token map supplier is the real source of truth for all the information about hosts
like its port, secure port (coming up feature), peer port, token etc.

This change does the right thing by using hosts from HostSupplier only to determine the up and down hosts.
And uses the hosts from the TokenMapSupplier to prime connections since the Hosts from the
TokenMapSupplier has the port information.

Ideally we want to differentiate the Host object from the HostSupplier and TokenMapSupplier by
creating different classes for these two purposes.