### PR TITLE
Unify Host from the two sources

### DIFF
--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/HostsUpdater.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/HostsUpdater.java
@@ -103,11 +103,19 @@ public class HostsUpdater {
 		hostsUp.clear();
 		hostsDown.clear();
 
-		for (Host host : allHosts) {
-			if (host.isUp()) {
-				hostsUp.add(allHostSetFromTokenMapSupplier.get(host));
+		for (Host hostFromHostSupplier : allHosts) {
+			if (hostFromHostSupplier.isUp()) {
+				Host hostFromTokenMapSupplier = allHostSetFromTokenMapSupplier.get(hostFromHostSupplier);
+
+				hostsUp.add(new Host(hostFromHostSupplier.getHostName(), hostFromHostSupplier.getIpAddress(),
+									 hostFromTokenMapSupplier.getPort(), hostFromTokenMapSupplier.getRack(),
+									 hostFromTokenMapSupplier.getDatacenter(), Host.Status.Up, hostFromTokenMapSupplier.getHashtag()));
 			} else {
-				hostsDown.add(allHostSetFromTokenMapSupplier.get(host));
+				Host hostFromTokenMapSupplier = allHostSetFromTokenMapSupplier.get(hostFromHostSupplier);
+
+				hostsDown.add(new Host(hostFromHostSupplier.getHostName(), hostFromHostSupplier.getIpAddress(),
+						hostFromTokenMapSupplier.getPort(), hostFromTokenMapSupplier.getRack(),
+						hostFromTokenMapSupplier.getDatacenter(), Host.Status.Down, hostFromTokenMapSupplier.getHashtag()));
 			}
 		}
 


### PR DESCRIPTION
Host from token map supplier typically has a public IP address.
Host from Host Supplier has a private IP Address. We really need
to unify the two objects picking the right information from each one.