### PR TITLE
Avoid reading binary keys when not needed

### DIFF
--- a/dyno-jedis/src/main/java/com/netflix/dyno/jedis/DynoJedisClient.java
+++ b/dyno-jedis/src/main/java/com/netflix/dyno/jedis/DynoJedisClient.java
@@ -145,7 +145,10 @@ public class DynoJedisClient implements JedisCommands, BinaryJedisCommands, Mult
         }
 
         public byte[] getBinaryKey() {
-            return this.binaryKeys.get(0);
+            if (binaryKeys != null)
+                return binaryKeys.get(0);
+            else
+                return null;
         }
 
     }


### PR DESCRIPTION
We are trying to get binary keys even when its not needed. And in some cases like mget and binary keys being null, get(0) will throw exception