### PR TITLE
use Secure port for SSL given by TokenMapSupplier

### DIFF
--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/Host.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/Host.java
@@ -39,6 +39,7 @@ public class Host implements Comparable<Host> {
     private final String hostname;
     private final String ipAddress;
     private final int port;
+    private final int securePort;
     private final InetSocketAddress socketAddress;
     private final String rack;
     private final String datacenter;
@@ -50,42 +51,47 @@ public class Host implements Comparable<Host> {
     }
 
     public Host(String hostname, int port, String rack) {
-        this(hostname, null, port, rack, ConfigUtils.getDataCenterFromRack(rack), Status.Down, null);
+        this(hostname, null, port, port, rack, ConfigUtils.getDataCenterFromRack(rack), Status.Down, null);
     }
 
     public Host(String hostname, String rack, Status status) {
-        this(hostname, null, DEFAULT_PORT, rack, ConfigUtils.getDataCenterFromRack(rack), status, null);
+        this(hostname, null, DEFAULT_PORT, DEFAULT_PORT, rack, ConfigUtils.getDataCenterFromRack(rack), status, null);
     }
 
     public Host(String hostname, int port, String rack, Status status) {
-        this(hostname, null, port, rack, ConfigUtils.getDataCenterFromRack(rack), status, null);
+        this(hostname, null, port, port, rack, ConfigUtils.getDataCenterFromRack(rack), status, null);
     }
 
     public Host(String hostname, int port, String rack, Status status, String hashtag) {
-        this(hostname, null, port, rack, ConfigUtils.getDataCenterFromRack(rack), status, hashtag);
+        this(hostname, null, port, port, rack, ConfigUtils.getDataCenterFromRack(rack), status, hashtag);
     }
 
     public Host(String hostname, String ipAddress, int port, String rack) {
-        this(hostname, ipAddress, port, rack, ConfigUtils.getDataCenterFromRack(rack), Status.Down, null);
+        this(hostname, ipAddress, port, port, rack, ConfigUtils.getDataCenterFromRack(rack), Status.Down, null);
     }
 
     public Host(String hostname, String ipAddress, String rack, Status status) {
-        this(hostname, ipAddress, DEFAULT_PORT, rack, ConfigUtils.getDataCenterFromRack(rack), status, null);
+        this(hostname, ipAddress, DEFAULT_PORT, DEFAULT_PORT, rack, ConfigUtils.getDataCenterFromRack(rack), status, null);
     }
 
     public Host(String hostname, String ipAddress, String rack, Status status, String hashtag) {
-        this(hostname, ipAddress, DEFAULT_PORT, rack, ConfigUtils.getDataCenterFromRack(rack), status, hashtag);
+        this(hostname, ipAddress, DEFAULT_PORT, DEFAULT_PORT, rack, ConfigUtils.getDataCenterFromRack(rack), status, hashtag);
     }
 
     public Host(String hostname, String ipAddress, int port, String rack, String datacenter, Status status) {
-        this(hostname, ipAddress, port, rack, datacenter, status, null);
+        this(hostname, ipAddress, port, port, rack, datacenter, status, null);
     }
 
     public Host(String name, String ipAddress, int port, String rack, String datacenter, Status status,
             String hashtag) {
+        this(name, ipAddress, port, port, rack, datacenter, status, hashtag);
+    }
+
+    public Host(String name, String ipAddress, int port, int securePort, String rack, String datacenter, Status status, String hashtag) {
         this.hostname = name;
         this.ipAddress = ipAddress;
         this.port = port;
+        this.securePort = securePort;
         this.rack = rack;
         this.status = status;
         this.datacenter = datacenter;
@@ -116,6 +122,10 @@ public class Host implements Comparable<Host> {
 
     public int getPort() {
         return port;
+    }
+
+    public int getSecurePort() {
+        return securePort;
     }
 
     public String getDatacenter() {

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/lb/AbstractTokenMapSupplier.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/lb/AbstractTokenMapSupplier.java
@@ -227,13 +227,19 @@ public abstract class AbstractTokenMapSupplier implements TokenMapSupplier {
                 String zone = (String) jItem.get("zone");
                 String datacenter = (String) jItem.get("dc");
                 String portStr = (String) jItem.get("port");
+                String securePortStr = (String) jItem.get("secure_port");
                 String hashtag = (String) jItem.get("hashtag");
                 int port = Host.DEFAULT_PORT;
                 if (portStr != null) {
                     port = Integer.valueOf(portStr);
                 }
 
-                Host host = new Host(hostname, ipAddress, port, zone, datacenter, Status.Up, hashtag);
+                int securePort = port;
+                if (securePortStr != null) {
+                    securePort = Integer.valueOf(securePortStr);
+                }
+
+                Host host = new Host(hostname, ipAddress, port, securePort, zone, datacenter, Status.Up, hashtag);
 
                 if (isLocalDatacenterHost(host)) {
                     HostToken hostToken = new HostToken(token, host);

--- a/dyno-jedis/src/main/java/com/netflix/dyno/jedis/JedisConnectionFactory.java
+++ b/dyno-jedis/src/main/java/com/netflix/dyno/jedis/JedisConnectionFactory.java
@@ -81,7 +81,7 @@ public class JedisConnectionFactory implements ConnectionFactory<Jedis> {
 						hostPool.getSocketTimeout());
 			}
 			else {
-				jedisClient = new Jedis(host.getHostAddress(), host.getPort(), hostPool.getConnectionTimeout(),
+				jedisClient = new Jedis(host.getHostAddress(), host.getSecurePort(), hostPool.getConnectionTimeout(),
 						hostPool.getSocketTimeout(), true, sslSocketFactory,  new SSLParameters(), null);
 			}
 		}


### PR DESCRIPTION
By default, secure port is the same as the dynomite listening port. This way, current OSS users using SSL will not break.
If the tokenMapSupplier provides a secure_port in the cluster_describe, that one will be used with SSL.