### PR TITLE
Migrate Secure port from TokenMapSupplier

### DIFF
--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/HostsUpdater.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/HostsUpdater.java
@@ -108,13 +108,13 @@ public class HostsUpdater {
 				Host hostFromTokenMapSupplier = allHostSetFromTokenMapSupplier.get(hostFromHostSupplier);
 
 				hostsUp.add(new Host(hostFromHostSupplier.getHostName(), hostFromHostSupplier.getIpAddress(),
-									 hostFromTokenMapSupplier.getPort(), hostFromTokenMapSupplier.getRack(),
+									 hostFromTokenMapSupplier.getPort(), hostFromTokenMapSupplier.getSecurePort(), hostFromTokenMapSupplier.getRack(),
 									 hostFromTokenMapSupplier.getDatacenter(), Host.Status.Up, hostFromTokenMapSupplier.getHashtag()));
 			} else {
 				Host hostFromTokenMapSupplier = allHostSetFromTokenMapSupplier.get(hostFromHostSupplier);
 
 				hostsDown.add(new Host(hostFromHostSupplier.getHostName(), hostFromHostSupplier.getIpAddress(),
-						hostFromTokenMapSupplier.getPort(), hostFromTokenMapSupplier.getRack(),
+						hostFromTokenMapSupplier.getPort(), hostFromTokenMapSupplier.getSecurePort(), hostFromTokenMapSupplier.getRack(),
 						hostFromTokenMapSupplier.getDatacenter(), Host.Status.Down, hostFromTokenMapSupplier.getHashtag()));
 			}
 		}


### PR DESCRIPTION
This is getting more error prone, every time we add a new property to Host Object, it needs to be hand crafted carefully at many places.