### PR TITLE
Fix List to Array Conversion in Eval

### DIFF
--- a/dyno-demo/src/main/java/com/netflix/dyno/demo/redis/DynoJedisDemo.java
+++ b/dyno-demo/src/main/java/com/netflix/dyno/demo/redis/DynoJedisDemo.java
@@ -33,6 +33,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
 
+import com.google.common.collect.Lists;
 import com.netflix.dyno.connectionpool.*;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
@@ -894,13 +895,14 @@ public class DynoJedisDemo {
 		public List<Map<String, String>> getList() {
 			return list;
 		}
-	};
+	}
 
 	public void runEvalTest() throws Exception {
 
 		client.set("EvalTest", "true");
-		List<String> keys = Arrays.asList("EvalTest");
-		List<String> args = Arrays.asList("true");
+
+		List<String> keys = Lists.newArrayList("EvalTest");
+		List<String> args = Lists.newArrayList("true");
 		Object obj = client.eval(
 				"if redis.call('get', KEYS[1]) == ARGV[1] then return redis.call('del', KEYS[1]) else return 0 end",
 				keys, args);

--- a/dyno-jedis/src/main/java/com/netflix/dyno/jedis/DynoJedisClient.java
+++ b/dyno-jedis/src/main/java/com/netflix/dyno/jedis/DynoJedisClient.java
@@ -462,7 +462,7 @@ public class DynoJedisClient implements JedisCommands, BinaryJedisCommands, Mult
 
     @Override
     public Object eval(String script, List<String> keys, List<String> args) {
-        String[] params = (String[])ArrayUtils.addAll(keys.toArray(), args.toArray());
+        String[] params = ArrayUtils.addAll(keys.toArray(new String[0]), args.toArray(new String[0]));
         return eval(script, keys.size(), params);
     }
 

--- a/dyno-jedis/src/main/java/com/netflix/dyno/jedis/JedisConnectionFactory.java
+++ b/dyno-jedis/src/main/java/com/netflix/dyno/jedis/JedisConnectionFactory.java
@@ -108,13 +108,13 @@ public class JedisConnectionFactory implements ConnectionFactory<Jedis> {
 			} catch (JedisConnectionException ex) {
                 Logger.warn("Caught JedisConnectionException: " + ex.getMessage());
 				opMonitor.recordFailure(opName, ex.getMessage());
-				lastDynoException = (DynoConnectException) new FatalConnectionException(ex).setAttempt(1);
+				lastDynoException = (DynoConnectException) new FatalConnectionException(ex).setAttempt(1).setHost(this.getHost());
 				throw lastDynoException;
 
 			} catch (RuntimeException ex) {
                 Logger.warn("Caught RuntimeException: " + ex.getMessage());
 				opMonitor.recordFailure(opName, ex.getMessage());
-				lastDynoException = (DynoConnectException) new FatalConnectionException(ex).setAttempt(1);
+				lastDynoException = (DynoConnectException) new FatalConnectionException(ex).setAttempt(1).setHost(this.getHost());
 				throw lastDynoException;
 
 			} finally {


### PR DESCRIPTION
We were using toArray which was converting the list to a array of Objects instead of array of Strings and forgetting about the underlying type.
Use a different toArray to preserve type information in the arrays.

Also add the host information in the DynoException