### PR TITLE
Improve Scan operation reliability

### DIFF
--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/ConnectionPool.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/ConnectionPool.java
@@ -101,7 +101,7 @@ public interface ConnectionPool<CL> {
      * @return Collection<OperationResult<R>>
      * @throws DynoException
      */
-    <R> Collection<OperationResult<R>> executeWithRing(CursorBasedResult<String> cursor, Operation<CL, R> op) throws DynoException;
+    <R> Collection<OperationResult<R>> executeWithRing(TokenRackMapper tokenRackMapper, Operation<CL, R> op) throws DynoException;
 
     /**
      * Execute an operation asynchronously.

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/ConnectionPool.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/ConnectionPool.java
@@ -101,7 +101,7 @@ public interface ConnectionPool<CL> {
      * @return Collection<OperationResult<R>>
      * @throws DynoException
      */
-    <R> Collection<OperationResult<R>> executeWithRing(Operation<CL, R> op) throws DynoException;
+    <R> Collection<OperationResult<R>> executeWithRing(CursorBasedResult<String> cursor, Operation<CL, R> op) throws DynoException;
 
     /**
      * Execute an operation asynchronously.

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/CursorBasedResult.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/CursorBasedResult.java
@@ -33,6 +33,7 @@ public interface CursorBasedResult<T> {
 
     String getRackForToken(Long Token);
 
+    //TODO:FixME: this should not be in the public interface
     void setRackForToken(Long token, String rack);
 
     boolean isComplete();

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/CursorBasedResult.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/CursorBasedResult.java
@@ -16,7 +16,6 @@
 package com.netflix.dyno.connectionpool;
 
 import java.util.List;
-import java.util.Map;
 
 /**
  * The result of performing a SCAN operation
@@ -27,14 +26,7 @@ public interface CursorBasedResult<T> {
 
     List<String> getStringResult();
 
-    Map<Long, String> getTokenRackMap();
-
     String getCursorForHost(String host);
-
-    String getRackForToken(Long Token);
-
-    //TODO:FixME: this should not be in the public interface
-    void setRackForToken(Long token, String rack);
 
     boolean isComplete();
 

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/CursorBasedResult.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/CursorBasedResult.java
@@ -16,6 +16,7 @@
 package com.netflix.dyno.connectionpool;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * The result of performing a SCAN operation
@@ -26,7 +27,13 @@ public interface CursorBasedResult<T> {
 
     List<String> getStringResult();
 
+    Map<Long, String> getTokenRackMap();
+
     String getCursorForHost(String host);
+
+    String getRackForToken(Long Token);
+
+    void setRackForToken(Long token, String rack);
 
     boolean isComplete();
 

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/TokenPoolTopology.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/TokenPoolTopology.java
@@ -15,14 +15,21 @@
  */
 package com.netflix.dyno.connectionpool;
 
+import com.netflix.dyno.connectionpool.impl.ConnectionPoolImpl;
+import org.slf4j.LoggerFactory;
+import sun.rmi.runtime.Log;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Logger;
 
 public class TokenPoolTopology {
+	private static final org.slf4j.Logger Logger = LoggerFactory.getLogger(TokenPoolTopology.class);
 
 	private final ConcurrentHashMap<String, List<TokenStatus>> map = new ConcurrentHashMap<String, List<TokenStatus>>();
+	private final ConcurrentHashMap<String, List<TokenHost>> rackTokenHostMap = new ConcurrentHashMap<String, List<TokenHost>>();
 	private final int replicationFactor;
 	
 	public TokenPoolTopology (int replicationFactor) {
@@ -39,6 +46,41 @@ public class TokenPoolTopology {
 		
 		list.add(new TokenStatus(token, hostPool));
 	}
+
+	public void addHostToken(String rack, Long token, Host host) {
+		Logger.info(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>Adding Host to Topology" + host);
+		List<TokenHost> list = rackTokenHostMap.get(rack);
+		if (list == null) {
+			list = new ArrayList<TokenHost>();
+			rackTokenHostMap.put(rack, list);
+		}
+		TokenHost insert = new TokenHost(token, host);
+		for (TokenHost th : list) {
+			if (th.compareTo(insert) == 0) {
+				th.setHost(host);
+				return;
+			}
+		}
+		list.add(insert);
+	}
+
+	public void removeHost(String rack, Long token, Host host) {
+		Logger.info(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>Removing Host from Topology" + host);
+
+		List<TokenHost> list = rackTokenHostMap.get(rack);
+		if (list == null) {
+			return;
+		}
+
+		TokenHost remove = new TokenHost(token, host);
+		for (TokenHost th : list) {
+			if (th.compareTo(remove) == 0) {
+				th.setHost(null);
+				return;
+			}
+		}
+		// TODO: FIXME: log that we didnt find the token.
+	}
 	
 	public ConcurrentHashMap<String, List<TokenStatus>> getAllTokens() {
 		return map;
@@ -51,6 +93,14 @@ public class TokenPoolTopology {
 	public List<TokenStatus> getTokensForRack(String rack) {
 		if (rack != null && map.containsKey(rack)) {
 			return map.get(rack);
+		}
+
+		return null;
+	}
+
+	public List<TokenHost> getTokenHostsForRack(String rack) {
+		if (rack != null && rackTokenHostMap.containsKey(rack)) {
+			return rackTokenHostMap.get(rack);
 		}
 
 		return null;
@@ -101,6 +151,37 @@ public class TokenPoolTopology {
 		
 		public String toString() {
 			return token + " ==> " + hostPool.toString();
+		}
+	}
+
+	public static class TokenHost implements Comparable<TokenHost> {
+
+		private Long token;
+		private Host host;
+
+		private TokenHost(Long t, Host host) {
+			this.token = t;
+			this.host = host;
+		}
+
+		public Long getToken() {
+			return token;
+		}
+
+		public Host getHost() {
+			return host;
+		}
+		public void setHost(Host host) {
+			this.host = host;
+		}
+
+		@Override
+		public int compareTo(TokenHost o) {
+			return this.token.compareTo(o.token);
+		}
+
+		public String toString() {
+			return token + " ==> " + ((host == null) ? "null" : host.toString());
 		}
 	}
 	

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/TokenPoolTopology.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/TokenPoolTopology.java
@@ -18,7 +18,6 @@ package com.netflix.dyno.connectionpool;
 import com.netflix.dyno.connectionpool.impl.ConnectionPoolImpl;
 import com.netflix.dyno.connectionpool.impl.utils.CollectionUtils;
 import org.slf4j.LoggerFactory;
-import sun.rmi.runtime.Log;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/TokenRackMapper.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/TokenRackMapper.java
@@ -1,0 +1,12 @@
+package com.netflix.dyno.connectionpool;
+
+import java.util.Map;
+
+public interface TokenRackMapper {
+    Map<Long, String> getTokenRackMap();
+
+    String getRackForToken(Long Token);
+
+    void setRackForToken(Long token, String rack);
+
+}

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolImpl.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolImpl.java
@@ -359,13 +359,13 @@ public class ConnectionPoolImpl<CL> implements ConnectionPool<CL>, TopologyView 
     }
 
     @Override
-	public <R> Collection<OperationResult<R>> executeWithRing(CursorBasedResult<String> cursor, Operation<CL, R> op) throws DynoException {
+	public <R> Collection<OperationResult<R>> executeWithRing(TokenRackMapper tokenRackMapper, Operation<CL, R> op) throws DynoException {
 
 		// Start recording the operation
 		long startTime = System.currentTimeMillis();
 
 		Collection<Connection<CL>> connections = selectionStrategy
-				.getConnectionsToRing(cursor, cpConfiguration.getMaxTimeoutWhenExhausted(), TimeUnit.MILLISECONDS);
+				.getConnectionsToRing(tokenRackMapper, cpConfiguration.getMaxTimeoutWhenExhausted(), TimeUnit.MILLISECONDS);
 
 		LinkedBlockingQueue<Connection<CL>> connQueue = new LinkedBlockingQueue<Connection<CL>>();
 		connQueue.addAll(connections);

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolImpl.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolImpl.java
@@ -207,6 +207,8 @@ public class ConnectionPoolImpl<CL> implements ConnectionPool<CL>, TopologyView 
     public boolean removeHost(Host host) {
 		Logger.info(String.format("Removing host %s from selectionStrategy, cpHealthTracker, cpMonitor",
 				host.getHostAddress()));
+		// Since there are multiple data structures of host, token, connection pool etc, call removehost even
+		// if it is not found in the cpMap
 		selectionStrategy.removeHost(host);
 		cpHealthTracker.removeHost(host);
 		cpMonitor.hostRemoved(host);
@@ -540,7 +542,7 @@ public class ConnectionPoolImpl<CL> implements ConnectionPool<CL>, TopologyView 
 				}
 			}
 
-				}, 15 * 1000, 10 * 1000, TimeUnit.MILLISECONDS);
+				}, 15 * 1000, 30 * 1000, TimeUnit.MILLISECONDS);
 
 			MonitorConsole.getInstance().registerConnectionPool(this);
 			registerMonitorConsoleMBean(MonitorConsole.getInstance());
@@ -696,12 +698,12 @@ public class ConnectionPoolImpl<CL> implements ConnectionPool<CL>, TopologyView 
     }
 
     public TokenPoolTopology getTopology() {
-	return selectionStrategy.getTokenPoolTopology();
+		return selectionStrategy.getTokenPoolTopology();
     }
 
     @Override
     public Map<String, List<TokenPoolTopology.TokenStatus>> getTopologySnapshot() {
-	return Collections.unmodifiableMap(selectionStrategy.getTokenPoolTopology().getAllTokens());
+		return Collections.unmodifiableMap(selectionStrategy.getTokenPoolTopology().getAllTokens());
     }
 
     @Override

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolImpl.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolImpl.java
@@ -148,82 +148,84 @@ public class ConnectionPoolImpl<CL> implements ConnectionPool<CL>, TopologyView 
 
     @Override
     public boolean addHost(Host host) {
-	return addHost(host, true);
+		return addHost(host, true);
     }
 
     public boolean addHost(Host host, boolean refreshLoadBalancer) {
 
-	//host.setPort(cpConfiguration.getPort());
+		//host.setPort(cpConfiguration.getPort());
 
-	HostConnectionPool<CL> connPool = cpMap.get(host);
+		HostConnectionPool<CL> connPool = cpMap.get(host);
 
-	if (connPool != null) {
-	    if (Logger.isDebugEnabled()) {
-		Logger.debug("HostConnectionPool already exists for host: " + host + ", ignoring addHost");
-	    }
-	    return false;
-	}
-
-
-	final HostConnectionPool<CL> hostPool = hostConnPoolFactory.createHostConnectionPool(host, this);
-
-	HostConnectionPool<CL> prevPool = cpMap.putIfAbsent(host, hostPool);
-	if (prevPool == null) {
-	    // This is the first time we are adding this pool.
-	    Logger.info("Adding host connection pool for host: " + host);
-
-	    try {
-		int primed = hostPool.primeConnections();
-		Logger.info("Successfully primed " + primed + " of " + cpConfiguration.getMaxConnsPerHost() + " to "
-			+ host);
-
-		if (hostPool.isActive()) {
-		    if (refreshLoadBalancer) {
-			selectionStrategy.addHost(host, hostPool);
-		    }
-
-		    cpHealthTracker.initializePingHealthchecksForPool(hostPool);
-
-		    cpMonitor.hostAdded(host, hostPool);
-
-		} else {
-		    Logger.info(
-			    "Failed to prime enough connections to host " + host + " for it take traffic; will retry");
-		    cpMap.remove(host);
+		if (connPool != null) {
+			if (Logger.isDebugEnabled()) {
+				Logger.debug("HostConnectionPool already exists for host: " + host + ", ignoring addHost");
+			}
+			return false;
 		}
 
-		return primed > 0;
-	    } catch (DynoException e) {
-		Logger.info("Failed to init host pool for host: " + host, e);
-		cpMap.remove(host);
-		return false;
-	    }
-	} else {
-	    return false;
-	}
+
+		final HostConnectionPool<CL> hostPool = hostConnPoolFactory.createHostConnectionPool(host, this);
+
+		HostConnectionPool<CL> prevPool = cpMap.putIfAbsent(host, hostPool);
+		if (prevPool == null) {
+			// This is the first time we are adding this pool.
+			Logger.info("Adding host connection pool for host: " + host);
+
+			try {
+				int primed = hostPool.primeConnections();
+				Logger.info("Successfully primed " + primed + " of " + cpConfiguration.getMaxConnsPerHost() + " to "
+					+ host);
+
+				if (hostPool.isActive()) {
+					if (refreshLoadBalancer) {
+						selectionStrategy.addHost(host, hostPool);
+					}
+
+					cpHealthTracker.initializePingHealthchecksForPool(hostPool);
+
+					cpMonitor.hostAdded(host, hostPool);
+
+				} else {
+					Logger.info(
+						"Failed to prime enough connections to host " + host + " for it take traffic; will retry");
+					cpMap.remove(host);
+				}
+
+				return primed > 0;
+			} catch (DynoException e) {
+				Logger.info("Failed to init host pool for host: " + host, e);
+				cpMap.remove(host);
+				return false;
+			}
+		} else {
+			return false;
+		}
     }
 
     @Override
     public boolean removeHost(Host host) {
-	HostConnectionPool<CL> hostPool = cpMap.remove(host);
-	if (hostPool != null) {
-	    selectionStrategy.removeHost(host, hostPool);
-	    cpHealthTracker.removeHost(host);
-	    cpMonitor.hostRemoved(host);
-	    hostPool.shutdown();
-	    Logger.info(String.format("Remove host: Successfully removed host %s from connection pool",
-		    host.getHostAddress()));
-	    return true;
-	} else {
-	    Logger.info(String.format("Remove host: Host %s NOT FOUND in the connection pool", host.getHostAddress()));
-	    return false;
-	}
+		Logger.info(String.format("Removing host %s from selectionStrategy, cpHealthTracker, cpMonitor",
+				host.getHostAddress()));
+		selectionStrategy.removeHost(host);
+		cpHealthTracker.removeHost(host);
+		cpMonitor.hostRemoved(host);
+		HostConnectionPool<CL> hostPool = cpMap.remove(host);
+		if (hostPool != null) {
+			hostPool.shutdown();
+			Logger.info(String.format("Remove host: Successfully removed hostPool for host %s from connection pool",
+				host.getHostAddress()));
+			return true;
+		} else {
+			Logger.info(String.format("Remove host: Host pool for host %s NOT FOUND in the connection pool", host.getHostAddress()));
+			return false;
+		}
     }
 
     @Override
     public boolean isHostUp(Host host) {
-	HostConnectionPool<CL> hostPool = cpMap.get(host);
-	return (hostPool != null) ? hostPool.isActive() : false;
+		HostConnectionPool<CL> hostPool = cpMap.get(host);
+		return (hostPool != null) ? hostPool.isActive() : false;
     }
 
     @Override
@@ -233,137 +235,135 @@ public class ConnectionPoolImpl<CL> implements ConnectionPool<CL>, TopologyView 
 
     @Override
     public List<HostConnectionPool<CL>> getActivePools() {
+		return new ArrayList<HostConnectionPool<CL>>(
+			CollectionUtils.filter(getPools(), new Predicate<HostConnectionPool<CL>>() {
 
-	return new ArrayList<HostConnectionPool<CL>>(
-		CollectionUtils.filter(getPools(), new Predicate<HostConnectionPool<CL>>() {
-
-		    @Override
-		    public boolean apply(HostConnectionPool<CL> hostPool) {
-			if (hostPool == null) {
-			    return false;
-			}
-			return hostPool.isActive();
-		    }
-		}));
+				@Override
+				public boolean apply(HostConnectionPool<CL> hostPool) {
+				if (hostPool == null) {
+					return false;
+				}
+				return hostPool.isActive();
+				}
+			}));
     }
 
     @Override
     public List<HostConnectionPool<CL>> getPools() {
-	return new ArrayList<HostConnectionPool<CL>>(cpMap.values());
+    	return new ArrayList<HostConnectionPool<CL>>(cpMap.values());
     }
 
     @Override
     public Future<Boolean> updateHosts(Collection<Host> hostsUp, Collection<Host> hostsDown) {
-	Logger.debug(String.format("Updating hosts: UP=%s, DOWN=%s", hostsUp, hostsDown));
-	boolean condition = false;
-	if (hostsUp != null && !hostsUp.isEmpty()) {
-	    for (Host hostUp : hostsUp) {
-		condition |= addHost(hostUp);
-	    }
-	}
-	if (hostsDown != null && !hostsDown.isEmpty()) {
-	    for (Host hostDown : hostsDown) {
-		condition |= removeHost(hostDown);
-	    }
-	}
-	return getEmptyFutureTask(condition);
+		Logger.debug(String.format("Updating hosts: UP=%s, DOWN=%s", hostsUp, hostsDown));
+		boolean condition = false;
+		if (hostsUp != null && !hostsUp.isEmpty()) {
+			for (Host hostUp : hostsUp) {
+				condition |= addHost(hostUp);
+			}
+		}
+		if (hostsDown != null && !hostsDown.isEmpty()) {
+			for (Host hostDown : hostsDown) {
+				condition |= removeHost(hostDown);
+			}
+		}
+		return getEmptyFutureTask(condition);
     }
 
     @Override
     public HostConnectionPool<CL> getHostPool(Host host) {
-	return cpMap.get(host);
+    	return cpMap.get(host);
     }
 
     @Override
     public <R> OperationResult<R> executeWithFailover(Operation<CL, R> op) throws DynoException {
 
-	// Start recording the operation
-	long startTime = System.currentTimeMillis();
+		// Start recording the operation
+		long startTime = System.currentTimeMillis();
 
-	RetryPolicy retry = cpConfiguration.getRetryPolicyFactory().getRetryPolicy();
-	retry.begin();
+		RetryPolicy retry = cpConfiguration.getRetryPolicyFactory().getRetryPolicy();
+		retry.begin();
 
-	DynoException lastException = null;
+		DynoException lastException = null;
 
-	do {
-	    Connection<CL> connection = null;
+		do {
+			Connection<CL> connection = null;
 
-	    try {
-		connection = selectionStrategy.getConnectionUsingRetryPolicy(op,
-			cpConfiguration.getMaxTimeoutWhenExhausted(), TimeUnit.MILLISECONDS, retry);
+			try {
+				connection = selectionStrategy.getConnectionUsingRetryPolicy(op,
+					cpConfiguration.getMaxTimeoutWhenExhausted(), TimeUnit.MILLISECONDS, retry);
 
-		connection.getContext().setMetadata("host", connection.getHost().getHostAddress());
-                connection.getContext().setMetadata("port", connection.getHost().getPort());
-                
-		OperationResult<R> result = connection.execute(op);
+				connection.getContext().setMetadata("host", connection.getHost().getHostAddress());
+						connection.getContext().setMetadata("port", connection.getHost().getPort());
 
-		// Add context to the result from the successful execution
-		result.setNode(connection.getHost()).addMetadata(connection.getContext().getAll());
+				OperationResult<R> result = connection.execute(op);
 
-		retry.success();
-		cpMonitor.incOperationSuccess(connection.getHost(), System.currentTimeMillis() - startTime);
+				// Add context to the result from the successful execution
+				result.setNode(connection.getHost()).addMetadata(connection.getContext().getAll());
 
-		return result;
+				retry.success();
+				cpMonitor.incOperationSuccess(connection.getHost(), System.currentTimeMillis() - startTime);
 
-	    } catch (NoAvailableHostsException e) {
-		cpMonitor.incOperationFailure(null, e);
+				return result;
 
-		throw e;
-	    } catch (PoolExhaustedException e) {
-		Logger.warn("Pool exhausted: " + e.getMessage());
-		cpMonitor.incOperationFailure(null, e);
-		cpHealthTracker.trackConnectionError(e.getHostConnectionPool(), e);
-	    } catch (DynoException e) {
+			} catch (NoAvailableHostsException e) {
+				cpMonitor.incOperationFailure(null, e);
 
-		retry.failure(e);
-		lastException = e;
+				throw e;
+			} catch (PoolExhaustedException e) {
+				Logger.warn("Pool exhausted: " + e.getMessage());
+				cpMonitor.incOperationFailure(null, e);
+				cpHealthTracker.trackConnectionError(e.getHostConnectionPool(), e);
+			} catch (DynoException e) {
 
-		if (connection != null) {
-		    cpMonitor.incOperationFailure(connection.getHost(), e);
+				retry.failure(e);
+				lastException = e;
 
-		    if (retry.allowRetry()) {
-			cpMonitor.incFailover(connection.getHost(), e);
-		    }
+				if (connection != null) {
+					cpMonitor.incOperationFailure(connection.getHost(), e);
 
-		    // Track the connection health so that the pool can be
-		    // purged at a later point
-		    cpHealthTracker.trackConnectionError(connection.getParentConnectionPool(), lastException);
-		} else {
-		    cpMonitor.incOperationFailure(null, e);
-		}
+					if (retry.allowRetry()) {
+						cpMonitor.incFailover(connection.getHost(), e);
+					}
 
-	    } catch (Throwable t) {
-		throw new RuntimeException(t);
-	    } finally {
-		if (connection != null) {
-		    if (connection.getLastException() != null
-			    && connection.getLastException() instanceof FatalConnectionException) {
-			Logger.warn("Received FatalConnectionException; closing connection "
-				+ connection.getContext().getAll() + " to host "
-				+ connection.getParentConnectionPool().getHost());
-			connection.getParentConnectionPool().closeConnection(connection);
-			// note - don't increment connection closed metric here;
-			// it's done in closeConnection
-		    } else {
-			connection.getContext().reset();
-			connection.getParentConnectionPool().returnConnection(connection);
-		    }
-		}
-	    }
+					// Track the connection health so that the pool can be
+					// purged at a later point
+					cpHealthTracker.trackConnectionError(connection.getParentConnectionPool(), lastException);
+				} else {
+					cpMonitor.incOperationFailure(null, e);
+				}
+			} catch (Throwable t) {
+				throw new RuntimeException(t);
+			} finally {
+				if (connection != null) {
+					if (connection.getLastException() != null
+						&& connection.getLastException() instanceof FatalConnectionException) {
+						Logger.warn("Received FatalConnectionException; closing connection "
+							+ connection.getContext().getAll() + " to host "
+							+ connection.getParentConnectionPool().getHost());
+						connection.getParentConnectionPool().closeConnection(connection);
+						// note - don't increment connection closed metric here;
+						// it's done in closeConnection
+					} else {
+						connection.getContext().reset();
+						connection.getParentConnectionPool().returnConnection(connection);
+					}
+				}
+			}
 
-	} while (retry.allowRetry());
+		} while (retry.allowRetry());
 
-	throw lastException;
+		throw lastException;
     }
 
     @Override
-	public <R> Collection<OperationResult<R>> executeWithRing(Operation<CL, R> op) throws DynoException {
+	public <R> Collection<OperationResult<R>> executeWithRing(CursorBasedResult<String> cursor, Operation<CL, R> op) throws DynoException {
 
 		// Start recording the operation
 		long startTime = System.currentTimeMillis();
 
 		Collection<Connection<CL>> connections = selectionStrategy
-				.getConnectionsToRing(cpConfiguration.getMaxTimeoutWhenExhausted(), TimeUnit.MILLISECONDS);
+				.getConnectionsToRing(cursor, cpConfiguration.getMaxTimeoutWhenExhausted(), TimeUnit.MILLISECONDS);
 
 		LinkedBlockingQueue<Connection<CL>> connQueue = new LinkedBlockingQueue<Connection<CL>>();
 		connQueue.addAll(connections);
@@ -472,115 +472,112 @@ public class ConnectionPoolImpl<CL> implements ConnectionPool<CL>, TopologyView 
     @Override
     public Future<Boolean> start() throws DynoException {
 
-	if (started.get()) {
-	    return getEmptyFutureTask(false);
-	}
-
-	HostSupplier hostSupplier = cpConfiguration.getHostSupplier();
-	if (hostSupplier == null) {
-	    throw new DynoException("Host supplier not configured!");
-	}
-
-	HostStatusTracker hostStatus = hostsUpdater.refreshHosts();
-	cpMonitor.setHostCount(hostStatus.getHostCount());
-	Collection<Host> hostsUp = hostStatus.getActiveHosts();
-
-	if (hostsUp == null || hostsUp.isEmpty()) {
-	    throw new NoAvailableHostsException("No available hosts when starting connection pool");
-	}
-
-	final ExecutorService threadPool = Executors.newFixedThreadPool(Math.max(10, hostsUp.size()));
-	final List<Future<Void>> futures = new ArrayList<Future<Void>>();
-
-	for (final Host host : hostsUp) {
-
-	    // Add host connection pool, but don't init the load balancer yet
-	    futures.add(threadPool.submit(new Callable<Void>() {
-
-		@Override
-		public Void call() throws Exception {
-		    addHost(host, false);
-		    return null;
+		if (started.get()) {
+			return getEmptyFutureTask(false);
 		}
-	    }));
-	}
 
-	try {
-	    for (Future<Void> future : futures) {
+		HostSupplier hostSupplier = cpConfiguration.getHostSupplier();
+		if (hostSupplier == null) {
+			throw new DynoException("Host supplier not configured!");
+		}
+
+		HostStatusTracker hostStatus = hostsUpdater.refreshHosts();
+		cpMonitor.setHostCount(hostStatus.getHostCount());
+
+		Collection<Host> hostsUp = hostStatus.getActiveHosts();
+		if (hostsUp == null || hostsUp.isEmpty()) {
+			throw new NoAvailableHostsException("No available hosts when starting connection pool");
+		}
+
+		final ExecutorService threadPool = Executors.newFixedThreadPool(Math.max(10, hostsUp.size()));
+		final List<Future<Void>> futures = new ArrayList<Future<Void>>();
+
+		for (final Host host : hostsUp) {
+
+			// Add host connection pool, but don't init the load balancer yet
+			futures.add(threadPool.submit(new Callable<Void>() {
+
+			@Override
+			public Void call() throws Exception {
+				addHost(host, false);
+				return null;
+			}
+			}));
+		}
+
 		try {
-		    future.get();
-		} catch (InterruptedException e) {
-		    // do nothing
-		} catch (ExecutionException e) {
-		    throw new RuntimeException(e);
-		}
-	    }
-	} finally {
-	    threadPool.shutdownNow();
-	}
-
-	boolean success = started.compareAndSet(false, true);
-	if (success) {
-	    idling.set(false);
-	    idleThreadPool.shutdownNow();
-	    selectionStrategy = initSelectionStrategy();
-	    cpHealthTracker.start();
-
-	    connPoolThreadPool.scheduleWithFixedDelay(new Runnable() {
-
-		@Override
-		public void run() {
-		    try {
-			HostStatusTracker hostStatus = hostsUpdater.refreshHosts();
-			cpMonitor.setHostCount(hostStatus.getHostCount());
-			Logger.debug(hostStatus.toString());
-			updateHosts(hostStatus.getActiveHosts(), hostStatus.getInactiveHosts());
-		    } catch (Throwable throwable) {
-			Logger.error("Failed to update hosts cache", throwable);
-		    }
+			for (Future<Void> future : futures) {
+				try {
+					future.get();
+				} catch (InterruptedException e) {
+					// do nothing
+				} catch (ExecutionException e) {
+					throw new RuntimeException(e);
+				}
+			}
+		} finally {
+			threadPool.shutdownNow();
 		}
 
-	    }, 15 * 1000, 30 * 1000, TimeUnit.MILLISECONDS);
+		boolean success = started.compareAndSet(false, true);
+		if (success) {
+			idling.set(false);
+			idleThreadPool.shutdownNow();
+			selectionStrategy = initSelectionStrategy();
+			cpHealthTracker.start();
 
-	    MonitorConsole.getInstance().registerConnectionPool(this);
+			connPoolThreadPool.scheduleWithFixedDelay(new Runnable() {
 
-	    registerMonitorConsoleMBean(MonitorConsole.getInstance());
+			@Override
+			public void run() {
+				try {
+					HostStatusTracker hostStatus = hostsUpdater.refreshHosts();
+					cpMonitor.setHostCount(hostStatus.getHostCount());
+					Logger.debug(hostStatus.toString());
+					updateHosts(hostStatus.getActiveHosts(), hostStatus.getInactiveHosts());
+				} catch (Throwable throwable) {
+					Logger.error("Failed to update hosts cache", throwable);
+				}
+			}
 
-	}
+				}, 15 * 1000, 10 * 1000, TimeUnit.MILLISECONDS);
 
-	return getEmptyFutureTask(true);
+			MonitorConsole.getInstance().registerConnectionPool(this);
+			registerMonitorConsoleMBean(MonitorConsole.getInstance());
+		}
+		return getEmptyFutureTask(true);
     }
 
     @Override
     public void idle() {
-	if (this.started.get()) {
-	    throw new IllegalStateException("Cannot move from started to idle once the pool has been started");
-	}
-
-	if (idling.compareAndSet(false, true)) {
-	    idleThreadPool.scheduleAtFixedRate(new Runnable() {
-		@Override
-		public void run() {
-		    if (!started.get()) {
-			try {
-			    HostStatusTracker hostStatus = hostsUpdater.refreshHosts();
-			    cpMonitor.setHostCount(hostStatus.getHostCount());
-			    Collection<Host> hostsUp = hostStatus.getActiveHosts();
-			    if (hostsUp.size() > 0) {
-				Logger.debug("Found hosts while IDLING; starting the connection pool");
-				start().get();
-			    }
-			} catch (NoAvailableHostsException nah) {
-			    Logger.debug("No hosts found, will continue IDLING");
-			} catch (DynoException de) {
-			    Logger.warn("Attempt to start connection pool FAILED", de);
-			} catch (Exception e) {
-			    Logger.warn("Attempt to start connection pool FAILED", e);
-			}
-		    }
+		if (this.started.get()) {
+			throw new IllegalStateException("Cannot move from started to idle once the pool has been started");
 		}
-	    }, 30, 60, TimeUnit.SECONDS);
-	}
+
+		if (idling.compareAndSet(false, true)) {
+			idleThreadPool.scheduleAtFixedRate(new Runnable() {
+				@Override
+				public void run() {
+					if (!started.get()) {
+						try {
+							HostStatusTracker hostStatus = hostsUpdater.refreshHosts();
+							cpMonitor.setHostCount(hostStatus.getHostCount());
+							Collection<Host> hostsUp = hostStatus.getActiveHosts();
+							if (hostsUp.size() > 0) {
+								Logger.debug("Found hosts while IDLING; starting the connection pool");
+								start().get();
+							}
+						} catch (NoAvailableHostsException nah) {
+							Logger.debug("No hosts found, will continue IDLING");
+						} catch (DynoException de) {
+							Logger.warn("Attempt to start connection pool FAILED", de);
+						} catch (Exception e) {
+							Logger.warn("Attempt to start connection pool FAILED", e);
+						}
+					}
+				}
+			}, 30, 60, TimeUnit.SECONDS);
+		}
     }
 
     @Override
@@ -605,27 +602,27 @@ public class ConnectionPoolImpl<CL> implements ConnectionPool<CL>, TopologyView 
     }
 
     private void deregisterMonitorConsoleMBean() {
-	final MBeanServer server = ManagementFactory.getPlatformMBeanServer();
-	try {
-	    ObjectName objectName = new ObjectName(MonitorConsole.OBJECT_NAME);
-	    if (server.isRegistered(objectName)) {
-		server.unregisterMBean(objectName);
-		Logger.info("deregistered mbean " + objectName);
-	    }
-	} catch (MalformedObjectNameException | MBeanRegistrationException | InstanceNotFoundException ex) {
-	    Logger.error("Unable to deregister MonitorConsole mbean ", ex);
-	}
+		final MBeanServer server = ManagementFactory.getPlatformMBeanServer();
+		try {
+			ObjectName objectName = new ObjectName(MonitorConsole.OBJECT_NAME);
+			if (server.isRegistered(objectName)) {
+				server.unregisterMBean(objectName);
+				Logger.info("deregistered mbean " + objectName);
+			}
+		} catch (MalformedObjectNameException | MBeanRegistrationException | InstanceNotFoundException ex) {
+			Logger.error("Unable to deregister MonitorConsole mbean ", ex);
+		}
 
     }
 
     private HostSelectionWithFallback<CL> initSelectionStrategy() {
 
-	if (cpConfiguration.getTokenSupplier() == null) {
-	    throw new RuntimeException("TokenMapSupplier not configured");
-	}
-	HostSelectionWithFallback<CL> selection = new HostSelectionWithFallback<CL>(cpConfiguration, cpMonitor);
-	selection.initWithHosts(cpMap);
-	return selection;
+		if (cpConfiguration.getTokenSupplier() == null) {
+			throw new RuntimeException("TokenMapSupplier not configured");
+		}
+		HostSelectionWithFallback<CL> selection = new HostSelectionWithFallback<CL>(cpConfiguration, cpMonitor);
+		selection.initWithHosts(cpMap);
+		return selection;
     }
 
     private Future<Boolean> getEmptyFutureTask(final Boolean condition) {

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/HostsUpdater.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/HostsUpdater.java
@@ -121,6 +121,8 @@ public class HostsUpdater {
 			}
 		}
 
+		// if a node is down, it might be absent in hostSupplier but has its presence in TokenMapSupplier.
+		// Add that host to the down list here.
 		for (Host h : allHostSetFromTokenMapSupplier.keySet()) {
 			hostsDownFromHostSupplier.add(new Host(h.getHostName(), h.getIpAddress(),
 					h.getPort(), h.getSecurePort(), h.getRack(),

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/HostsUpdater.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/HostsUpdater.java
@@ -51,24 +51,24 @@ public class HostsUpdater {
 			return null;
 		}
 		
-		List<Host> allHosts = hostSupplier.getHosts();
-		if (allHosts == null || allHosts.isEmpty()) {
+		List<Host> allHostsFromHostSupplier = hostSupplier.getHosts();
+		if (allHostsFromHostSupplier == null || allHostsFromHostSupplier.isEmpty()) {
 			throw new NoAvailableHostsException("No available hosts when starting HostsUpdater");
 		}
 
-		List<Host> hostsUp = new ArrayList<>();
-		List<Host> hostsDown = new ArrayList<>();
+		List<Host> hostsUpFromHostSupplier = new ArrayList<>();
+		List<Host> hostsDownFromHostSupplier = new ArrayList<>();
 
-		for (Host host : allHosts) {
+		for (Host host : allHostsFromHostSupplier) {
 			if (host.isUp()) {
-				hostsUp.add(host);
+				hostsUpFromHostSupplier.add(host);
 			} else {
-				hostsDown.add(host);
+				hostsDownFromHostSupplier.add(host);
 			}
 		}
 
 		// if nothing has changed, just return the earlier hosttracker.
-		if (!hostTracker.get().checkIfChanged(new HashSet<>(hostsUp), new HashSet<>(hostsDown))) {
+		if (!hostTracker.get().checkIfChanged(new HashSet<>(hostsUpFromHostSupplier), new HashSet<>(hostsDownFromHostSupplier))) {
 			return hostTracker.get();
 		}
 
@@ -77,8 +77,8 @@ public class HostsUpdater {
 		 * Hence get the hosts from HostSupplier and map them to TokenMapSupplier
 		 * and return them.
 		 */
-		Collections.sort(allHosts);
-		Set<Host> hostSet = new HashSet<>(allHosts);
+		Collections.sort(allHostsFromHostSupplier);
+		Set<Host> hostSet = new HashSet<>(allHostsFromHostSupplier);
 		// Create a list of host/Tokens
 		List<HostToken> hostTokens;
 		if (tokenMapSupplier != null) {
@@ -100,26 +100,35 @@ public class HostsUpdater {
 			allHostSetFromTokenMapSupplier.put(ht.getHost(), ht.getHost());
 		}
 
-		hostsUp.clear();
-		hostsDown.clear();
+		hostsUpFromHostSupplier.clear();
+		hostsDownFromHostSupplier.clear();
 
-		for (Host hostFromHostSupplier : allHosts) {
+		for (Host hostFromHostSupplier : allHostsFromHostSupplier) {
 			if (hostFromHostSupplier.isUp()) {
 				Host hostFromTokenMapSupplier = allHostSetFromTokenMapSupplier.get(hostFromHostSupplier);
 
-				hostsUp.add(new Host(hostFromHostSupplier.getHostName(), hostFromHostSupplier.getIpAddress(),
+				hostsUpFromHostSupplier.add(new Host(hostFromHostSupplier.getHostName(), hostFromHostSupplier.getIpAddress(),
 									 hostFromTokenMapSupplier.getPort(), hostFromTokenMapSupplier.getSecurePort(), hostFromTokenMapSupplier.getRack(),
 									 hostFromTokenMapSupplier.getDatacenter(), Host.Status.Up, hostFromTokenMapSupplier.getHashtag()));
+				allHostSetFromTokenMapSupplier.remove(hostFromTokenMapSupplier);
 			} else {
 				Host hostFromTokenMapSupplier = allHostSetFromTokenMapSupplier.get(hostFromHostSupplier);
 
-				hostsDown.add(new Host(hostFromHostSupplier.getHostName(), hostFromHostSupplier.getIpAddress(),
+				hostsDownFromHostSupplier.add(new Host(hostFromHostSupplier.getHostName(), hostFromHostSupplier.getIpAddress(),
 						hostFromTokenMapSupplier.getPort(), hostFromTokenMapSupplier.getSecurePort(), hostFromTokenMapSupplier.getRack(),
 						hostFromTokenMapSupplier.getDatacenter(), Host.Status.Down, hostFromTokenMapSupplier.getHashtag()));
+				allHostSetFromTokenMapSupplier.remove(hostFromTokenMapSupplier);
 			}
 		}
 
-		HostStatusTracker newTracker = hostTracker.get().computeNewHostStatus(hostsUp, hostsDown);
+		for (Host h : allHostSetFromTokenMapSupplier.keySet()) {
+			hostsDownFromHostSupplier.add(new Host(h.getHostName(), h.getIpAddress(),
+					h.getPort(), h.getSecurePort(), h.getRack(),
+					h.getDatacenter(), Host.Status.Down, h.getHashtag()));
+
+		}
+
+		HostStatusTracker newTracker = hostTracker.get().computeNewHostStatus(hostsUpFromHostSupplier, hostsDownFromHostSupplier);
 		hostTracker.set(newTracker);
 
 		return hostTracker.get();

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/lb/HostSelectionWithFallback.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/lb/HostSelectionWithFallback.java
@@ -267,7 +267,9 @@ public class HostSelectionWithFallback<CL> {
 					connections.add(getConnectionForTokenOnRackNoFallback(null, token, rack, duration, unit, new RunOnce()));
 				} else {
 					Connection<CL> c = getConnection(null, token, duration, unit, new RunOnce());
-					cursor.setRackForToken(token, c.getHost().getRack());
+					if (cursor != null) {
+						cursor.setRackForToken(token, c.getHost().getRack());
+					}
 					connections.add(c);
 				}
 			} catch (DynoConnectException e) {

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/lb/HostSelectionWithFallback.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/lb/HostSelectionWithFallback.java
@@ -244,7 +244,7 @@ public class HostSelectionWithFallback<CL> {
 		}
 	}
 
-	public Collection<Connection<CL>> getConnectionsToRing(CursorBasedResult<String> cursor, int duration, TimeUnit unit) throws NoAvailableHostsException, PoolExhaustedException {
+	public Collection<Connection<CL>> getConnectionsToRing(TokenRackMapper tokenRackMapper, int duration, TimeUnit unit) throws NoAvailableHostsException, PoolExhaustedException {
 		String targetRack = localRack;
 		if (targetRack == null) {
 			// get tokens for random rack
@@ -261,14 +261,14 @@ public class HostSelectionWithFallback<CL> {
 				// This is valid in case of an iterator based query like scan.
 				// Try to use that same rack if it is specified.
 				String rack = null;
-				if (cursor != null)
-					rack = cursor.getRackForToken(token);
+				if (tokenRackMapper != null)
+					rack = tokenRackMapper.getRackForToken(token);
 				if (rack != null) {
 					connections.add(getConnectionForTokenOnRackNoFallback(null, token, rack, duration, unit, new RunOnce()));
 				} else {
 					Connection<CL> c = getConnection(null, token, duration, unit, new RunOnce());
-					if (cursor != null) {
-						cursor.setRackForToken(token, c.getHost().getRack());
+					if (tokenRackMapper != null) {
+						tokenRackMapper.setRackForToken(token, c.getHost().getRack());
 					}
 					connections.add(c);
 				}

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/lb/HostSelectionWithFallbackTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/lb/HostSelectionWithFallbackTest.java
@@ -558,7 +558,7 @@ public class HostSelectionWithFallbackTest {
 
 	private Collection<String> runConnectionsToRingTest(HostSelectionWithFallback<Integer> selection) {
 
-		Collection<Connection<Integer>> connections = selection.getConnectionsToRing(10, TimeUnit.MILLISECONDS);
+		Collection<Connection<Integer>> connections = selection.getConnectionsToRing( null, 10, TimeUnit.MILLISECONDS);
 
 		return CollectionUtils.transform(connections, new Transform<Connection<Integer>, String>() {
 			@Override

--- a/dyno-demo/src/main/java/com/netflix/dyno/demo/redis/DynoJedisDemo.java
+++ b/dyno-demo/src/main/java/com/netflix/dyno/demo/redis/DynoJedisDemo.java
@@ -108,7 +108,8 @@ public class DynoJedisDemo {
 
 			@Override
 			public List<Host> getHosts() {
-				return hosts;
+				return getHostsFromDiscovery(clusterName);
+//				return hosts;
 			}
 		};
 
@@ -280,28 +281,38 @@ public class DynoJedisDemo {
 	public void runScanTest(boolean populateKeys) throws Exception {
 		logger.info("SCAN TEST -- begin");
 
-		final String keyPattern = System.getProperty("dyno.demo.scan.key.pattern", "DynoClientTest_key-*");
+		final String keyPattern = System.getProperty("dyno.demo.scan.key.pattern", "*");
 		final String keyPrefix = System.getProperty("dyno.demo.scan.key.prefix", "DynoClientTest_key-");
 
-		if (populateKeys) {
-			logger.info("Writing 500 keys to {} with prefix {}", this.clusterName, keyPrefix);
-			for (int i = 0; i < 500; i++) {
-				client.set(keyPrefix + i, "value-" + i);
-			}
-		}
+//		if (populateKeys) {
+//			logger.info("Writing 500000 keys to {} with prefix {}", this.clusterName, keyPrefix);
+//			for (int i = 0; i < 500000; i++) {
+//				client.set(keyPrefix + i, "value-" + i);
+//			}
+//		}
 
 		logger.info("Reading keys from {} with pattern {}", this.clusterName, keyPattern);
 		CursorBasedResult<String> cbi = null;
+		long start = System.currentTimeMillis();
+		int count = 0;
 		do {
-			cbi = client.dyno_scan(cbi, 10000, keyPattern);
+			cbi = client.dyno_scan(cbi, 5, keyPattern);
+
 
 			List<String> results = cbi.getStringResult();
+			count += results.size();
+			logger.info(">>>>>>>>>>>>>>>>>");
+			int i = 0;
 			for (String res : results) {
-				logger.info(res);
+				logger.info("{}) {}", i, res);
+				i++;
 			}
+			Thread.sleep(1000);
 		} while (!cbi.isComplete());
+		long end = System.currentTimeMillis();
 
-		logger.info("SCAN TEST -- done");
+
+		logger.info("SCAN TEST -- done {} results in {}ms", count, end - start);
 	}
 
 	public void runSScanTest(boolean populateKeys) throws Exception {
@@ -983,7 +994,7 @@ public class DynoJedisDemo {
 			}
 			case 5: {
 				final boolean writeKeys = Boolean.valueOf(props.getProperty("dyno.demo.scan.populateKeys"));
-				demo.runScanTest(writeKeys);
+				demo.runScanTest(true);
 				break;
 			}
 			case 6: {

--- a/dyno-demo/src/main/java/com/netflix/dyno/demo/redis/DynoJedisDemo.java
+++ b/dyno-demo/src/main/java/com/netflix/dyno/demo/redis/DynoJedisDemo.java
@@ -35,6 +35,7 @@ import javax.xml.parsers.SAXParserFactory;
 
 import com.google.common.collect.Lists;
 import com.netflix.dyno.connectionpool.*;
+import com.netflix.dyno.connectionpool.exception.PoolOfflineException;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
@@ -296,7 +297,14 @@ public class DynoJedisDemo {
 		long start = System.currentTimeMillis();
 		int count = 0;
 		do {
-			cbi = client.dyno_scan(cbi, 5, keyPattern);
+			try {
+
+				cbi = client.dyno_scan(cbi, 5, keyPattern);
+			} catch (PoolOfflineException ex) {
+				logger.info("Caught exception.... retrying scan");
+				cbi = null;
+				continue;
+			}
 
 
 			List<String> results = cbi.getStringResult();
@@ -308,7 +316,7 @@ public class DynoJedisDemo {
 				i++;
 			}
 			Thread.sleep(1000);
-		} while (!cbi.isComplete());
+		} while ((cbi == null) || !cbi.isComplete());
 		long end = System.currentTimeMillis();
 
 

--- a/dyno-demo/src/main/java/com/netflix/dyno/demo/redis/DynoJedisDemo.java
+++ b/dyno-demo/src/main/java/com/netflix/dyno/demo/redis/DynoJedisDemo.java
@@ -314,7 +314,6 @@ public class DynoJedisDemo {
 				logger.info("{}) {}", i, res);
 				i++;
 			}
-			Thread.sleep(1000);
 		} while ((cbi == null) || !cbi.isComplete());
 		long end = System.currentTimeMillis();
 
@@ -1001,7 +1000,7 @@ public class DynoJedisDemo {
 			}
 			case 5: {
 				final boolean writeKeys = Boolean.valueOf(props.getProperty("dyno.demo.scan.populateKeys"));
-				demo.runScanTest(true);
+				demo.runScanTest(writeKeys);
 				break;
 			}
 			case 6: {

--- a/dyno-demo/src/main/java/com/netflix/dyno/demo/redis/DynoJedisDemo.java
+++ b/dyno-demo/src/main/java/com/netflix/dyno/demo/redis/DynoJedisDemo.java
@@ -282,15 +282,15 @@ public class DynoJedisDemo {
 	public void runScanTest(boolean populateKeys) throws Exception {
 		logger.info("SCAN TEST -- begin");
 
-		final String keyPattern = System.getProperty("dyno.demo.scan.key.pattern", "*");
+		final String keyPattern = System.getProperty("dyno.demo.scan.key.pattern", "DynoClientTest_key-*");
 		final String keyPrefix = System.getProperty("dyno.demo.scan.key.prefix", "DynoClientTest_key-");
 
-//		if (populateKeys) {
-//			logger.info("Writing 500000 keys to {} with prefix {}", this.clusterName, keyPrefix);
-//			for (int i = 0; i < 500000; i++) {
-//				client.set(keyPrefix + i, "value-" + i);
-//			}
-//		}
+		if (populateKeys) {
+			logger.info("Writing 500 keys to {} with prefix {}", this.clusterName, keyPrefix);
+			for (int i = 0; i < 500; i++) {
+				client.set(keyPrefix + i, "value-" + i);
+			}
+		}
 
 		logger.info("Reading keys from {} with pattern {}", this.clusterName, keyPattern);
 		CursorBasedResult<String> cbi = null;
@@ -309,7 +309,6 @@ public class DynoJedisDemo {
 
 			List<String> results = cbi.getStringResult();
 			count += results.size();
-			logger.info(">>>>>>>>>>>>>>>>>");
 			int i = 0;
 			for (String res : results) {
 				logger.info("{}) {}", i, res);

--- a/dyno-demo/src/main/resources/demo.properties
+++ b/dyno-demo/src/main/resources/demo.properties
@@ -13,6 +13,7 @@ netflix.appinfo.validateInstanceId=false
 
 dyno.demo.retryPolicy=RetryNTimes:2
 dyno.demo.port=8102
+dyno.demo.scan.populateKeys=true
 dyno.demo.discovery.prod=discoveryreadonly.%s.dynprod.netflix.net:7001/v2/apps
 dyno.demo.discovery.test=discoveryreadonly.%s.dyntest.netflix.net:7001/v2/apps
 

--- a/dyno-jedis/src/main/java/com/netflix/dyno/jedis/CursorBasedResultImpl.java
+++ b/dyno-jedis/src/main/java/com/netflix/dyno/jedis/CursorBasedResultImpl.java
@@ -16,6 +16,7 @@
 package com.netflix.dyno.jedis;
 
 import com.netflix.dyno.connectionpool.CursorBasedResult;
+import com.netflix.dyno.connectionpool.TokenRackMapper;
 import redis.clients.jedis.ScanResult;
 
 import java.util.ArrayList;
@@ -37,17 +38,17 @@ import java.util.Map;
  *    } while (!cbi.isComplete());
  * </pre>
  */
-public class CursorBasedResultImpl<T> implements CursorBasedResult<T> {
+public class CursorBasedResultImpl<T> implements CursorBasedResult<T>, TokenRackMapper {
 
     private final Map<String, ScanResult<T>> result;
     private Map<Long, String> tokenRackMap;
 
-    public CursorBasedResultImpl(Map<String, ScanResult<T>> result) {
+    /* package private */ CursorBasedResultImpl(Map<String, ScanResult<T>> result) {
         this.result = result;
         this.tokenRackMap = new LinkedHashMap<>();
     }
 
-    public CursorBasedResultImpl(Map<String, ScanResult<T>> result, Map<Long, String> tokenRackMap) {
+    /* package private */ CursorBasedResultImpl(Map<String, ScanResult<T>> result, Map<Long, String> tokenRackMap) {
         this.result = result;
         this.tokenRackMap = tokenRackMap;
     }

--- a/dyno-jedis/src/main/java/com/netflix/dyno/jedis/CursorBasedResultImpl.java
+++ b/dyno-jedis/src/main/java/com/netflix/dyno/jedis/CursorBasedResultImpl.java
@@ -19,6 +19,7 @@ import com.netflix.dyno.connectionpool.CursorBasedResult;
 import redis.clients.jedis.ScanResult;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -39,9 +40,17 @@ import java.util.Map;
 public class CursorBasedResultImpl<T> implements CursorBasedResult<T> {
 
     private final Map<String, ScanResult<T>> result;
+    private Map<Long, String> tokenRackMap;
+    private final boolean noFailover = true;
 
     public CursorBasedResultImpl(Map<String, ScanResult<T>> result) {
         this.result = result;
+        this.tokenRackMap = new LinkedHashMap<>();
+    }
+
+    public CursorBasedResultImpl(Map<String, ScanResult<T>> result, Map<Long, String> tokenRackMap) {
+        this.result = result;
+        this.tokenRackMap = tokenRackMap;
     }
 
     @Override
@@ -83,4 +92,17 @@ public class CursorBasedResultImpl<T> implements CursorBasedResult<T> {
         return true;
     }
 
+    @Override
+    public String getRackForToken(Long token) {
+        return tokenRackMap.get(token);
+    }
+
+    public void setRackForToken(Long token, String rack) {
+        tokenRackMap.put(token, rack);
+    }
+
+    @Override
+    public Map<Long, String> getTokenRackMap() {
+        return this.tokenRackMap;
+    }
 }

--- a/dyno-jedis/src/main/java/com/netflix/dyno/jedis/CursorBasedResultImpl.java
+++ b/dyno-jedis/src/main/java/com/netflix/dyno/jedis/CursorBasedResultImpl.java
@@ -41,7 +41,6 @@ public class CursorBasedResultImpl<T> implements CursorBasedResult<T> {
 
     private final Map<String, ScanResult<T>> result;
     private Map<Long, String> tokenRackMap;
-    private final boolean noFailover = true;
 
     public CursorBasedResultImpl(Map<String, ScanResult<T>> result) {
         this.result = result;

--- a/dyno-jedis/src/main/java/com/netflix/dyno/jedis/DynoJedisClient.java
+++ b/dyno-jedis/src/main/java/com/netflix/dyno/jedis/DynoJedisClient.java
@@ -793,7 +793,7 @@ public class DynoJedisClient implements JedisCommands, BinaryJedisCommands, Mult
 
     private List<OperationResult<ScanResult<String>>> scatterGatherScan(final CursorBasedResult<String> cursor,
             final int count, final String... pattern) {
-        return new ArrayList<>(connPool.executeWithRing(new BaseKeyOperation<ScanResult<String>>("SCAN", OpName.SCAN) {
+        return new ArrayList<>(connPool.executeWithRing(cursor, new BaseKeyOperation<ScanResult<String>>("SCAN", OpName.SCAN) {
             @Override
             public ScanResult<String> execute(final Jedis client, final ConnectionContext state) throws DynoException {
                 if (pattern != null && pattern.length > 0) {
@@ -2660,7 +2660,7 @@ public class DynoJedisClient implements JedisCommands, BinaryJedisCommands, Mult
         Logger.warn("Executing d_keys for pattern: " + pattern);
 
         Collection<OperationResult<Set<String>>> results = connPool
-                .executeWithRing(new BaseKeyOperation<Set<String>>(pattern, OpName.KEYS) {
+                .executeWithRing(new CursorBasedResultImpl<String>(new LinkedHashMap<String, ScanResult<String>>()), new BaseKeyOperation<Set<String>>(pattern, OpName.KEYS) {
 
                     @Override
                     public Set<String> execute(Jedis client, ConnectionContext state) throws DynoException {
@@ -3790,14 +3790,17 @@ public class DynoJedisClient implements JedisCommands, BinaryJedisCommands, Mult
     }
 
     public CursorBasedResult<String> dyno_scan(CursorBasedResult<String> cursor, int count, String... pattern) {
+        if (cursor == null) {
+            // Create a temporary cursor context which will maintain a map of token to rack
+            cursor = new CursorBasedResultImpl<>(new LinkedHashMap<String, ScanResult<String>>());
+        }
         final Map<String, ScanResult<String>> results = new LinkedHashMap<>();
 
         List<OperationResult<ScanResult<String>>> opResults = scatterGatherScan(cursor, count, pattern);
         for (OperationResult<ScanResult<String>> opResult : opResults) {
             results.put(opResult.getNode().getHostAddress(), opResult.getResult());
         }
-
-        return new CursorBasedResultImpl<>(results);
+        return new CursorBasedResultImpl<>(results, cursor.getTokenRackMap());
     }
 
     @Override

--- a/dyno-jedis/src/test/java/com/netflix/dyno/jedis/UnitTestConnectionPool.java
+++ b/dyno-jedis/src/test/java/com/netflix/dyno/jedis/UnitTestConnectionPool.java
@@ -19,6 +19,7 @@ import com.netflix.dyno.connectionpool.*;
 import com.netflix.dyno.connectionpool.exception.DynoException;
 import com.netflix.dyno.connectionpool.impl.ConnectionContextImpl;
 import com.netflix.dyno.connectionpool.impl.OperationResultImpl;
+import com.netflix.dyno.connectionpool.TokenRackMapper;
 import org.mockito.Matchers;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -161,7 +162,7 @@ public class UnitTestConnectionPool implements ConnectionPool<Jedis> {
     }
 
     @Override
-    public <R> Collection<OperationResult<R>> executeWithRing(CursorBasedResult<String> cursor, Operation<Jedis, R> op) throws DynoException {
+    public <R> Collection<OperationResult<R>> executeWithRing(TokenRackMapper tokenRackMapper, Operation<Jedis, R> op) throws DynoException {
         return null;
     }
 

--- a/dyno-jedis/src/test/java/com/netflix/dyno/jedis/UnitTestConnectionPool.java
+++ b/dyno-jedis/src/test/java/com/netflix/dyno/jedis/UnitTestConnectionPool.java
@@ -161,7 +161,7 @@ public class UnitTestConnectionPool implements ConnectionPool<Jedis> {
     }
 
     @Override
-    public <R> Collection<OperationResult<R>> executeWithRing(Operation<Jedis, R> op) throws DynoException {
+    public <R> Collection<OperationResult<R>> executeWithRing(CursorBasedResult<String> cursor, Operation<Jedis, R> op) throws DynoException {
         return null;
     }
 

--- a/dyno-jedis/src/test/java/com/netflix/dyno/jedis/UnitTestConnectionPoolForCompression.java
+++ b/dyno-jedis/src/test/java/com/netflix/dyno/jedis/UnitTestConnectionPoolForCompression.java
@@ -155,7 +155,7 @@ public class UnitTestConnectionPoolForCompression implements ConnectionPool<Jedi
     }
 
     @Override
-    public <R> Collection<OperationResult<R>> executeWithRing(Operation<Jedis, R> op) throws DynoException {
+    public <R> Collection<OperationResult<R>> executeWithRing(CursorBasedResult<String> cursor, Operation<Jedis, R> op) throws DynoException {
         return null;
     }
 

--- a/dyno-jedis/src/test/java/com/netflix/dyno/jedis/UnitTestConnectionPoolForCompression.java
+++ b/dyno-jedis/src/test/java/com/netflix/dyno/jedis/UnitTestConnectionPoolForCompression.java
@@ -20,6 +20,7 @@ import com.netflix.dyno.connectionpool.exception.DynoException;
 import com.netflix.dyno.connectionpool.impl.ConnectionContextImpl;
 import com.netflix.dyno.connectionpool.impl.OperationResultImpl;
 import com.netflix.dyno.connectionpool.impl.utils.ZipUtils;
+import com.netflix.dyno.connectionpool.TokenRackMapper;
 import org.mockito.Matchers;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -155,7 +156,7 @@ public class UnitTestConnectionPoolForCompression implements ConnectionPool<Jedi
     }
 
     @Override
-    public <R> Collection<OperationResult<R>> executeWithRing(CursorBasedResult<String> cursor, Operation<Jedis, R> op) throws DynoException {
+    public <R> Collection<OperationResult<R>> executeWithRing(TokenRackMapper tokenRackMapper, Operation<Jedis, R> op) throws DynoException {
         return null;
     }
 


### PR DESCRIPTION
Dyno does a scatter gather of scan operation on the shards in a given rack. However this failed if one of the node in the AZ went down and scan never recovered. Also If a node in the current AZ was down, scan would never finish since it would keep on hoping between the other two racks all the time. This fix does the following:
- A tokenRackMapper interface is used to keep track of which token in pinned to which rack.
- The cursor that gets sent to the application (CursorBasedResultImpl) implements this interface
- The scatter-gather remembers which token is pinned to which rack in the cursor
- next time a scan is called (pagination), this TokenRackMapper is checked to see which rack the requests should be sent to.

This fix achieves the following behavior:
1) When a scan is first called, the scatter-gather will forward the requests to all the nodes in the local rack.  If the local rack is not defined, it will use a random rack as a local rack.
2) If a node is down in that rack, it will failover to a different replica in another rack for *that token only*. It remembers this in the TokenRackMapper. All subsequent calls to scan (pagination) with this cursor will use the same nodes that the previous operation used. That way, even if the node that was originally down comes back up, it will not be used.
3) While the scan iteration is going on, if one of the node goes now, the scan will throw a PoolOfflineOperation. 

This might not be good since if one is scanning the entire DB the results need to be thrown out. This is an inherent problem since the iterator returned by redis is very specific to a node and is not portable to another replica. 