### PR TITLE
Mget binary support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'nebula.netflixoss' version '3.6.4'
+    id 'nebula.netflixoss' version '5.0.0'
 }
 
 // Establish version and status

--- a/dyno-jedis/src/main/java/com/netflix/dyno/jedis/DynoJedisClient.java
+++ b/dyno-jedis/src/main/java/com/netflix/dyno/jedis/DynoJedisClient.java
@@ -129,7 +129,10 @@ public class DynoJedisClient implements JedisCommands, BinaryJedisCommands, Mult
         private final OpName op;
 
         private MultiKeyOperation(final List keys, final OpName o) {
-            Object firstKey = (keys != null) ? keys.get(0) : null;
+            //filter nulls
+            keys.removeIf(Objects::isNull);
+
+            Object firstKey = (keys != null && keys.size() > 0) ? keys.get(0) : null;
 
             if(firstKey != null) {
                 if (firstKey instanceof String) {//string key

--- a/dyno-jedis/src/main/java/com/netflix/dyno/jedis/DynoJedisClient.java
+++ b/dyno-jedis/src/main/java/com/netflix/dyno/jedis/DynoJedisClient.java
@@ -129,9 +129,6 @@ public class DynoJedisClient implements JedisCommands, BinaryJedisCommands, Mult
         private final OpName op;
 
         private MultiKeyOperation(final List keys, final OpName o) {
-            //filter nulls
-            //keys.removeAll(Collections.singletonList(null));
-
             Object firstKey = (keys != null && keys.size() > 0) ? keys.get(0) : null;
 
             if(firstKey != null) {

--- a/dyno-jedis/src/main/java/com/netflix/dyno/jedis/DynoJedisClient.java
+++ b/dyno-jedis/src/main/java/com/netflix/dyno/jedis/DynoJedisClient.java
@@ -130,7 +130,7 @@ public class DynoJedisClient implements JedisCommands, BinaryJedisCommands, Mult
 
         private MultiKeyOperation(final List keys, final OpName o) {
             //filter nulls
-            keys.removeIf(Objects::isNull);
+            keys.removeAll(Collections.singletonList(null));
 
             Object firstKey = (keys != null && keys.size() > 0) ? keys.get(0) : null;
 

--- a/dyno-jedis/src/main/java/com/netflix/dyno/jedis/DynoJedisClient.java
+++ b/dyno-jedis/src/main/java/com/netflix/dyno/jedis/DynoJedisClient.java
@@ -130,7 +130,7 @@ public class DynoJedisClient implements JedisCommands, BinaryJedisCommands, Mult
 
         private MultiKeyOperation(final List keys, final OpName o) {
             //filter nulls
-            keys.removeAll(Collections.singletonList(null));
+            //keys.removeAll(Collections.singletonList(null));
 
             Object firstKey = (keys != null && keys.size() > 0) ? keys.get(0) : null;
 


### PR DESCRIPTION
@ipapapa  and @shailesh33  I have implemented the mget with support for byte[] keys. Here are the summary of changes

- Implementing MultiKeyBinaryCommands interface and providing implementation for mget with byte[]
- Modified MultiKeyOperation to take binaryKey and assign it based on the first key in the List passed.
- The earlier assumption for String keys will not be null and now added null check
- CompressionValueMultiKeyOperation is modified to support changes from MultiKeyOperation
- I did a unit test with String mget and byte[] mget and the keys are span across multiple nodes. The result was correct.
- Now that we are implementing MultiKeyBinaryCommands this opens the door for byte[] implementation for other missing REDIS commands too and I will add them at later stage.

Please review the PR and let me know if anything needs to be added or modified.