### PR TITLE
Reduce calls to TokenMapSupplier

### DIFF
--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/lb/AbstractTokenMapSupplier.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/lb/AbstractTokenMapSupplier.java
@@ -15,11 +15,7 @@
  */
 package com.netflix.dyno.connectionpool.impl.lb;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 import com.netflix.dyno.connectionpool.exception.TimeoutException;
 import com.netflix.dyno.connectionpool.impl.utils.ConfigUtils;
@@ -144,12 +140,18 @@ public abstract class AbstractTokenMapSupplier implements TokenMapSupplier {
         // to a dynomite server
         // hence trying them all
         Set<HostToken> allTokens = new HashSet<HostToken>();
+        Set<Host> remainingHosts = new TreeSet<>(activeHosts);
 
         for (Host host : activeHosts) {
             try {
                 List<HostToken> hostTokens = parseTokenListFromJson(getTopologyJsonPayload((host.getHostAddress())));
                 for (HostToken hToken : hostTokens) {
                     allTokens.add(hToken);
+                    remainingHosts.remove(hToken.getHost());
+                }
+                if (remainingHosts.size() == 0) {
+                    Logger.info("Received token information for " + allTokens.size() + " hosts. Not querying other hosts");
+                    break;
                 }
             } catch (Exception e) {
                 Logger.warn("Could not get json response for token topology [" + e.getMessage() + "]");

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/lb/AbstractTokenMapSupplier.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/lb/AbstractTokenMapSupplier.java
@@ -140,7 +140,7 @@ public abstract class AbstractTokenMapSupplier implements TokenMapSupplier {
         // to a dynomite server
         // hence trying them all
         Set<HostToken> allTokens = new HashSet<HostToken>();
-        Set<Host> remainingHosts = new TreeSet<>(activeHosts);
+        Set<Host> remainingHosts = new HashSet<>(activeHosts);
 
         for (Host host : activeHosts) {
             try {

--- a/dyno-demo/src/main/resources/log4j.xml
+++ b/dyno-demo/src/main/resources/log4j.xml
@@ -9,13 +9,13 @@
         </layout>
     </appender>
 
-    <root>
-        <priority value ="info" />
-        <appender-ref ref="console" />
-    </root>
+
 
     <logger name="com.netflix.dyno">
         <level value="debug"/>
     </logger>
-
+    <root>
+        <priority value ="info" />
+        <appender-ref ref="console" />
+    </root>
 </log4j:configuration>


### PR DESCRIPTION
At the startup, the client was talking to every node in the dynomite cluster to get token information.
This was done at 3 places. This lead to slow client startup and also too many calls to the underlying token database,
This is a simple optimization to skip talking to remaining hosts if the client received the information for all the hosts
specfied.