### PR TITLE
Make circularList threadsafe (#234)

### DIFF
--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/lb/CircularListTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/lb/CircularListTest.java
@@ -323,6 +323,14 @@ public class CircularListTest {
 		checkValues(new ArrayList<Integer>(subMap.values()));
 	}
 
+	@Test
+	public void testCircularListGet() {
+		// integer overflow on read index should not result in exception
+		for (long i = 0; i < (long) Integer.MAX_VALUE + 10; i++) {
+			cList.getNextElement();
+		}
+	}
+
 	private class TestWorker {
 
 		private final ConcurrentHashMap<Integer, Integer> map = new ConcurrentHashMap<Integer, Integer>();


### PR DESCRIPTION
Turned add()/remove() to synchronized methods and modified the read index in CircularList a AtomicLong to avoid integer overflow.