### PR TITLE
Make CircularList::getNextElement() thread safe

### DIFF
--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/lb/CircularList.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/lb/CircularList.java
@@ -50,7 +50,7 @@ public class CircularList<T> {
 	 * Get the next element in the list
 	 * @return T
 	 */ 
-	public T getNextElement() {
+	public synchronized T getNextElement() {
 		return ref.get().getNextElement();
 	}
 


### PR DESCRIPTION
We missed making this method synchronous in the previous patch.