### PR TITLE
Fix infinite recursive call in jedis' pipelines

### DIFF
--- a/dyno-jedis/src/main/java/com/netflix/dyno/jedis/DynoJedisPipeline.java
+++ b/dyno-jedis/src/main/java/com/netflix/dyno/jedis/DynoJedisPipeline.java
@@ -424,7 +424,7 @@ public class DynoJedisPipeline implements RedisPipeline, BinaryRedisPipeline, Au
 
 		Response<R> execute(final byte[] key, final OpName opName) {
 			checkKey(key);
-			return execute(key, opName);
+			return executeOperation(opName);
 		}
 
 		Response<R> execute(final String key, final OpName opName) {


### PR DESCRIPTION
Dyno will trigger an infinite recursive call for jedis pipelines with binary keys

```java
DynoJedisPipeline pipelined = dynoClient.pipelined();
pipelined.set("test".getBytes("UTF-8"), "value".getBytes("UTF-8")));
pipelined.sync();
```


this will throw a StackOverflowException
```bash
Caused by: java.lang.StackOverflowError
	at com.netflix.dyno.jedis.DynoJedisPipeline.verifyKey(DynoJedisPipeline.java:231)
	at com.netflix.dyno.jedis.DynoJedisPipeline.checkKey(DynoJedisPipeline.java:175)
	at com.netflix.dyno.jedis.DynoJedisPipeline.access$200(DynoJedisPipeline.java:52)
	at com.netflix.dyno.jedis.DynoJedisPipeline$PipelineOperation.execute(DynoJedisPipeline.java:426)
	at com.netflix.dyno.jedis.DynoJedisPipeline$PipelineOperation.execute(DynoJedisPipeline.java:427)
	at com.netflix.dyno.jedis.DynoJedisPipeline$PipelineOperation.execute(DynoJedisPipeline.java:427)
	at com.netflix.dyno.jedis.DynoJedisPipeline$PipelineOperation.execute(DynoJedisPipeline.java:427)
	at com.netflix.dyno.jedis.DynoJedisPipeline$PipelineOperation.execute(DynoJedisPipeline.java:427)
	...
```