### PR TITLE
Redis authentication support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,6 +87,7 @@ project(':dyno-jedis') {
         compile project(':dyno-core')
         compile project(':dyno-contrib')
         compile 'redis.clients:jedis:2.9.0'
+        testCompile 'com.netflix.spinnaker.embedded-redis:embedded-redis:0.8.0'
     }
 }
 

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/Host.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/Host.java
@@ -16,8 +16,10 @@
 package com.netflix.dyno.connectionpool;
 
 import java.net.InetSocketAddress;
+import java.util.Objects;
 
 import com.netflix.dyno.connectionpool.impl.utils.ConfigUtils;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Class encapsulating information about a host.
@@ -45,6 +47,7 @@ public class Host implements Comparable<Host> {
     private final String datacenter;
     private String hashtag;
     private Status status = Status.Down;
+    private final String password;
 
     public enum Status {
         Up, Down;
@@ -64,6 +67,10 @@ public class Host implements Comparable<Host> {
 
     public Host(String hostname, int port, String rack, Status status, String hashtag) {
         this(hostname, null, port, port, rack, ConfigUtils.getDataCenterFromRack(rack), status, hashtag);
+    }
+
+    public Host(String hostname, int port, String rack, Status status, String hashtag, String password) {
+        this(hostname, null, port, port, rack, ConfigUtils.getDataCenterFromRack(rack), status, hashtag, password);
     }
 
     public Host(String hostname, String ipAddress, int port, String rack) {
@@ -88,6 +95,10 @@ public class Host implements Comparable<Host> {
     }
 
     public Host(String name, String ipAddress, int port, int securePort, String rack, String datacenter, Status status, String hashtag) {
+        this(name, ipAddress, port, port, rack, datacenter, status, hashtag, null);
+    }
+
+    public Host(String name, String ipAddress, int port, int securePort, String rack, String datacenter, Status status, String hashtag, String password) {
         this.hostname = name;
         this.ipAddress = ipAddress;
         this.port = port;
@@ -96,6 +107,7 @@ public class Host implements Comparable<Host> {
         this.status = status;
         this.datacenter = datacenter;
         this.hashtag = hashtag;
+        this.password = StringUtils.isEmpty(password) ? null : password;
 
         // Used for the unit tests to prevent host name resolution
         if (port != -1) {
@@ -153,6 +165,10 @@ public class Host implements Comparable<Host> {
         return status == Status.Up;
     }
 
+    public String getPassword() {
+        return password;
+    }
+
     public InetSocketAddress getSocketAddress() {
         return socketAddress;
     }
@@ -205,7 +221,7 @@ public class Host implements Comparable<Host> {
     public String toString() {
 
         return "Host [hostname=" + hostname + ", ipAddress=" + ipAddress + ", port=" + port + ", rack: "
-                + rack + ", datacenter: " + datacenter + ", status: " + status.name() + ", hashtag=" + hashtag + "]";
-
+                + rack + ", datacenter: " + datacenter + ", status: " + status.name() + ", hashtag="
+                + hashtag +  ", password=" + (Objects.nonNull(password) ? "masked" : "null") + "]";
     }
 }

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/HostsUpdater.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/HostsUpdater.java
@@ -109,14 +109,16 @@ public class HostsUpdater {
 
 				hostsUpFromHostSupplier.add(new Host(hostFromHostSupplier.getHostName(), hostFromHostSupplier.getIpAddress(),
 									 hostFromTokenMapSupplier.getPort(), hostFromTokenMapSupplier.getSecurePort(), hostFromTokenMapSupplier.getRack(),
-									 hostFromTokenMapSupplier.getDatacenter(), Host.Status.Up, hostFromTokenMapSupplier.getHashtag()));
+									 hostFromTokenMapSupplier.getDatacenter(), Host.Status.Up, hostFromTokenMapSupplier.getHashtag(),
+									 hostFromTokenMapSupplier.getPassword()));
 				allHostSetFromTokenMapSupplier.remove(hostFromTokenMapSupplier);
 			} else {
 				Host hostFromTokenMapSupplier = allHostSetFromTokenMapSupplier.get(hostFromHostSupplier);
 
 				hostsDownFromHostSupplier.add(new Host(hostFromHostSupplier.getHostName(), hostFromHostSupplier.getIpAddress(),
 						hostFromTokenMapSupplier.getPort(), hostFromTokenMapSupplier.getSecurePort(), hostFromTokenMapSupplier.getRack(),
-						hostFromTokenMapSupplier.getDatacenter(), Host.Status.Down, hostFromTokenMapSupplier.getHashtag()));
+						hostFromTokenMapSupplier.getDatacenter(), Host.Status.Down, hostFromTokenMapSupplier.getHashtag(),
+						hostFromTokenMapSupplier.getPassword()));
 				allHostSetFromTokenMapSupplier.remove(hostFromTokenMapSupplier);
 			}
 		}

--- a/dyno-jedis/src/test/java/com/netflix/dyno/jedis/RedisAuthenticationIntegrationTest.java
+++ b/dyno-jedis/src/test/java/com/netflix/dyno/jedis/RedisAuthenticationIntegrationTest.java
@@ -1,0 +1,245 @@
+package com.netflix.dyno.jedis;
+
+import com.google.common.base.Throwables;
+import com.netflix.dyno.connectionpool.Connection;
+import com.netflix.dyno.connectionpool.ConnectionPoolConfiguration;
+import com.netflix.dyno.connectionpool.Host;
+import com.netflix.dyno.connectionpool.Host.Status;
+import com.netflix.dyno.connectionpool.HostConnectionPool;
+import com.netflix.dyno.connectionpool.HostSupplier;
+import com.netflix.dyno.connectionpool.TokenMapSupplier;
+import com.netflix.dyno.connectionpool.exception.DynoConnectException;
+import com.netflix.dyno.connectionpool.impl.ConnectionPoolConfigurationImpl;
+import com.netflix.dyno.connectionpool.impl.CountingConnectionPoolMonitor;
+import com.netflix.dyno.connectionpool.impl.HostConnectionPoolImpl;
+import com.netflix.dyno.connectionpool.impl.lb.HostToken;
+import com.netflix.dyno.contrib.DynoOPMonitor;
+import java.net.ConnectException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.exceptions.JedisDataException;
+import redis.embedded.RedisServer;
+import redis.embedded.RedisServerBuilder;
+
+public class RedisAuthenticationIntegrationTest {
+
+	private static final int REDIS_PORT = 8998;
+	private static final String REDIS_RACK = "rack-1c";
+	private static final String REDIS_DATACENTER = "rack-1";
+
+	private RedisServer redisServer;
+
+	@Before
+	public void setUp() throws Exception {
+		// skip tests on windows due to https://github.com/spinnaker/embedded-redis#redis-version
+		Assume.assumeFalse(System.getProperty("os.name").toLowerCase().startsWith("win"));
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		if (redisServer != null) {
+			redisServer.stop();
+		}
+	}
+
+	@Test
+	public void testDynoClient_noAuthSuccess() throws Exception {
+		redisServer = new RedisServer(REDIS_PORT);
+		redisServer.start();
+
+		Host noAuthHost = new Host("localhost", REDIS_PORT, REDIS_RACK, Host.Status.Up);
+		TokenMapSupplierImpl tokenMapSupplier = new TokenMapSupplierImpl(noAuthHost);
+		DynoJedisClient dynoClient = constructJedisClient(tokenMapSupplier,
+				() -> Collections.singletonList(noAuthHost));
+
+		String statusCodeReply = dynoClient.set("some-key", "some-value");
+		Assert.assertEquals("OK", statusCodeReply);
+
+		String value = dynoClient.get("some-key");
+		Assert.assertEquals("some-value", value);
+	}
+
+	@Test
+	public void testDynoClient_authSuccess() throws Exception {
+		redisServer = new RedisServerBuilder()
+				.port(REDIS_PORT)
+				.setting("requirepass password")
+				.build();
+		redisServer.start();
+
+		Host authHost = new Host("localhost", REDIS_PORT, REDIS_RACK, Status.Up, null, "password");
+
+		TokenMapSupplierImpl tokenMapSupplier = new TokenMapSupplierImpl(authHost);
+		DynoJedisClient dynoClient = constructJedisClient(tokenMapSupplier,
+				() -> Collections.singletonList(authHost));
+
+		String statusCodeReply = dynoClient.set("some-key", "some-value");
+		Assert.assertEquals("OK", statusCodeReply);
+
+		String value = dynoClient.get("some-key");
+		Assert.assertEquals("some-value", value);
+	}
+
+	@Test
+	public void testJedisConnFactory_noAuthSuccess() throws Exception {
+		redisServer = new RedisServer(REDIS_PORT);
+		redisServer.start();
+
+		Host noAuthHost = new Host("localhost", REDIS_PORT, REDIS_RACK, Host.Status.Up);
+
+		JedisConnectionFactory conFactory =
+				new JedisConnectionFactory(new DynoOPMonitor("some-application-name"), null);
+		ConnectionPoolConfiguration cpConfig = new ConnectionPoolConfigurationImpl("some-name");
+		CountingConnectionPoolMonitor poolMonitor = new CountingConnectionPoolMonitor();
+		HostConnectionPool<Jedis> hostConnectionPool =
+				new HostConnectionPoolImpl<>(noAuthHost, conFactory, cpConfig, poolMonitor);
+		Connection<Jedis> connection = conFactory
+				.createConnection(hostConnectionPool, null);
+
+		connection.execPing();
+	}
+
+	@Test
+	public void testJedisConnFactory_authSuccess() throws Exception {
+		redisServer = new RedisServerBuilder()
+				.port(REDIS_PORT)
+				.setting("requirepass password")
+				.build();
+		redisServer.start();
+
+		Host authHost = new Host("localhost", REDIS_PORT, REDIS_RACK, Status.Up, null, "password");
+
+		JedisConnectionFactory conFactory =
+				new JedisConnectionFactory(new DynoOPMonitor("some-application-name"), null);
+		ConnectionPoolConfiguration cpConfig = new ConnectionPoolConfigurationImpl("some-name");
+		CountingConnectionPoolMonitor poolMonitor = new CountingConnectionPoolMonitor();
+		HostConnectionPool<Jedis> hostConnectionPool =
+				new HostConnectionPoolImpl<>(authHost, conFactory, cpConfig, poolMonitor);
+		Connection<Jedis> connection = conFactory
+				.createConnection(hostConnectionPool, null);
+
+		connection.execPing();
+	}
+
+	@Test
+	public void testJedisConnFactory_connectionFailed() throws Exception {
+		Host noAuthHost = new Host("localhost", REDIS_PORT, REDIS_RACK, Host.Status.Up);
+
+		JedisConnectionFactory conFactory =
+				new JedisConnectionFactory(new DynoOPMonitor("some-application-name"), null);
+		ConnectionPoolConfiguration cpConfig = new ConnectionPoolConfigurationImpl("some-name");
+		CountingConnectionPoolMonitor poolMonitor = new CountingConnectionPoolMonitor();
+		HostConnectionPool<Jedis> hostConnectionPool =
+				new HostConnectionPoolImpl<>(noAuthHost, conFactory, cpConfig, poolMonitor);
+		Connection<Jedis> connection = conFactory
+				.createConnection(hostConnectionPool, null);
+
+		try {
+			connection.execPing();
+			Assert.fail("expected to throw");
+		} catch (DynoConnectException e) {
+			Assert.assertTrue("root cause should be connect exception",
+					Throwables.getRootCause(e) instanceof ConnectException);
+		}
+	}
+
+	@Test
+	public void testJedisConnFactory_authenticationRequired() throws Exception {
+		redisServer = new RedisServerBuilder()
+				.port(REDIS_PORT)
+				.setting("requirepass password")
+				.build();
+		redisServer.start();
+
+		Host noAuthHost = new Host("localhost", REDIS_PORT, REDIS_RACK, Host.Status.Up);
+
+		JedisConnectionFactory conFactory =
+				new JedisConnectionFactory(new DynoOPMonitor("some-application-name"), null);
+		ConnectionPoolConfiguration cpConfig = new ConnectionPoolConfigurationImpl("some-name");
+		CountingConnectionPoolMonitor poolMonitor = new CountingConnectionPoolMonitor();
+		HostConnectionPool<Jedis> hostConnectionPool =
+				new HostConnectionPoolImpl<>(noAuthHost, conFactory, cpConfig, poolMonitor);
+		Connection<Jedis> connection = conFactory
+				.createConnection(hostConnectionPool, null);
+
+		try {
+			connection.execPing();
+			Assert.fail("expected to throw");
+		} catch (JedisDataException e) {
+			Assert.assertEquals("NOAUTH Authentication required.", e.getMessage());
+		}
+	}
+
+	@Test
+	public void testJedisConnFactory_invalidPassword() throws Exception {
+		redisServer = new RedisServerBuilder()
+				.port(REDIS_PORT)
+				.setting("requirepass password")
+				.build();
+		redisServer.start();
+
+		Host authHost = new Host("localhost", REDIS_PORT, REDIS_RACK, Status.Up, null,
+				"invalid-password");
+
+		JedisConnectionFactory jedisConnectionFactory =
+				new JedisConnectionFactory(new DynoOPMonitor("some-application-name"), null);
+
+		ConnectionPoolConfiguration connectionPoolConfiguration = new ConnectionPoolConfigurationImpl(
+				"some-name");
+		HostConnectionPool<Jedis> hostConnectionPool = new HostConnectionPoolImpl<>(authHost,
+				jedisConnectionFactory, connectionPoolConfiguration, new CountingConnectionPoolMonitor());
+		Connection<Jedis> connection = jedisConnectionFactory
+				.createConnection(hostConnectionPool, null);
+
+		try {
+			connection.execPing();
+			Assert.fail("expected to throw");
+		} catch (JedisDataException e) {
+			Assert.assertEquals("ERR invalid password", e.getMessage());
+		}
+	}
+
+	private DynoJedisClient constructJedisClient(TokenMapSupplier tokenMapSupplier,
+			HostSupplier hostSupplier) {
+
+		final ConnectionPoolConfigurationImpl connectionPoolConfiguration =
+				new ConnectionPoolConfigurationImpl(REDIS_RACK);
+		connectionPoolConfiguration.withTokenSupplier(tokenMapSupplier);
+		connectionPoolConfiguration.setLocalRack(REDIS_RACK);
+		connectionPoolConfiguration.setLocalDataCenter(REDIS_DATACENTER);
+
+		return new DynoJedisClient.Builder()
+				.withApplicationName("some-application-name")
+				.withDynomiteClusterName(REDIS_RACK)
+				.withHostSupplier(hostSupplier)
+				.withCPConfig(connectionPoolConfiguration)
+				.build();
+	}
+
+	private static class TokenMapSupplierImpl implements TokenMapSupplier {
+
+		private final HostToken localHostToken;
+
+		private TokenMapSupplierImpl(Host host) {
+			this.localHostToken = new HostToken(100000L, host);
+		}
+
+		@Override
+		public List<HostToken> getTokens(Set<Host> activeHosts) {
+			return Collections.singletonList(localHostToken);
+		}
+
+		@Override
+		public HostToken getTokenForHost(Host host, Set<Host> activeHosts) {
+			return localHostToken;
+		}
+
+	}
+}

--- a/dyno-jedis/src/test/resources/log4j.properties
+++ b/dyno-jedis/src/test/resources/log4j.properties
@@ -1,0 +1,12 @@
+# logging conf solely for create_delete_tokens tool
+log4j.rootLogger=DEBUG,stdout
+
+# stdout
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%-5p %d [%t] %c: %m%n
+
+log4j.logger.org.apache.http.wire=FATAL
+log4j.logger.com.netflix.config=INFO
+log4j.logger.com.netflix.discovery=INFO
+log4j.logger.org.apache.http=INFO


### PR DESCRIPTION
Inspired by #187 

I'm interested in deploying Conductor to an environment that mandates Redis authentication.  I've followed a similar pattern as #187 for adding a `password` [field](https://github.com/Netflix/dyno/compare/master...davidwadden:redis-auth?expand=1#diff-8bf95e0cca7a2241e43ee9a278090157R50) to `Host.java` which then in turn is passed through the [`HostsUpdater.java`](https://github.com/Netflix/dyno/compare/master...davidwadden:redis-auth?expand=1#diff-623ee3b9f19280a0e5b584c1eba255d9) and set at the construction of the [`JedisConnectionFactory.java`](https://github.com/Netflix/dyno/compare/master...davidwadden:redis-auth?expand=1#diff-0acb68290b669a8b8e8ff2732284434a).

Interestings / questions:
- I only added a single [constructor overload](https://github.com/Netflix/dyno/compare/master...davidwadden:redis-auth?expand=1#diff-8bf95e0cca7a2241e43ee9a278090157R97) to `Host.java`.  Do you want any additional overloads that accept the `password`?.
- The [RedisAuthenticationIntegrationTest.java](https://github.com/Netflix/dyno/compare/master...davidwadden:redis-auth?expand=1#diff-8d372d34aa0e35a84da2b69b2d3d058e) that was added to cover Redis authentication introduces a `testCompile` dependency on [`embedded-redis`](https://github.com/Netflix/dyno/compare/master...davidwadden:redis-auth?expand=1#diff-c197962302397baf3a4cc36463dce5eaR90)
  - This dependency does not work on Windows, prefer not to have this test at all?
- `Host#toString` [masks](https://github.com/Netflix/dyno/compare/master...davidwadden:redis-auth?expand=1#diff-8bf95e0cca7a2241e43ee9a278090157R221) the contents of the `password` field.  Just a little non-standard
- Any additional test coverage I may have missed?

Also, noticed constructing a `Host` to be getting a bit complicated with the overloads.  Would you entertain another PR to introduce a `HostBuilder` to simplify this?
