### PR TITLE
Fix issues in Dyno pipelines

### DIFF
--- a/dyno-demo/src/main/java/com/netflix/dyno/demo/redis/DynoJedisDemo.java
+++ b/dyno-demo/src/main/java/com/netflix/dyno/demo/redis/DynoJedisDemo.java
@@ -20,7 +20,9 @@ import com.google.common.collect.Lists;
 import com.netflix.dyno.connectionpool.*;
 import com.netflix.dyno.connectionpool.Host.Status;
 import com.netflix.dyno.connectionpool.exception.PoolOfflineException;
+import com.netflix.dyno.connectionpool.impl.ConnectionPoolConfigurationImpl;
 import com.netflix.dyno.connectionpool.impl.lb.HostToken;
+import com.netflix.dyno.contrib.ArchaiusConnectionPoolConfiguration;
 import com.netflix.dyno.jedis.DynoDualWriterClient;
 import com.netflix.dyno.jedis.DynoJedisClient;
 import com.netflix.dyno.jedis.DynoJedisPipeline;
@@ -55,6 +57,7 @@ public class DynoJedisDemo {
 	public static final String randomValue = "dcfa7d0973834e5c9f480b65de19d684dcfa7d097383dcfa7d0973834e5c9f480b65de19d684dcfa7d097383dcfa7d0973834e5c9f480b65de19d684dcfa7d097383dcfa7d0973834e5c9f480b65de19d684dcfa7d097383";
 
 	protected DynoJedisClient client;
+	protected DynoJedisClient shadowClusterClient;
 
 	protected int numKeys;
 
@@ -160,6 +163,18 @@ public class DynoJedisDemo {
 				.withTokenMapSupplier(primaryTokenSupplier)
 				.withDualWriteTokenMapSupplier(shadowTokenSupplier)
 				.build();
+
+		ConnectionPoolConfigurationImpl shadowCPConfig =
+				new ArchaiusConnectionPoolConfiguration(shadowClusterName);
+
+		this.shadowClusterClient = new DynoJedisClient.Builder()
+				.withApplicationName("demo")
+				.withDynomiteClusterName("dyno-dev")
+				.withHostSupplier(primaryClusterHostSupplier)
+				.withTokenMapSupplier(primaryTokenSupplier)
+				.withCPConfig(shadowCPConfig)
+				.build();
+
 	}
 
 	public void init(HostSupplier hostSupplier, int port, TokenMapSupplier tokenSupplier) throws Exception {
@@ -189,6 +204,63 @@ public class DynoJedisDemo {
 		for (int i = 0; i < numKeys; i++) {
 			OperationResult<String> result = client.d_get("DynoClientTest-" + i);
 			System.out.println("Reading Key: " + i + ", Value: " + result.getResult() + " " + result.getNode());
+		}
+
+		// read from shadow cluster
+		if (shadowClusterClient != null) {
+			// read
+			for (int i = 0; i < numKeys; i++) {
+				OperationResult<String> result = shadowClusterClient.d_get("DynoClientTest-" + i);
+				System.out.println("Reading Key: " + i + ", Value: " + result.getResult() + " " + result.getNode());
+			}
+		}
+	}
+
+	public void runSimpleDualWriterPipelineTest() {
+		this.numKeys = 10;
+		System.out.println("Simple Dual Writer Pipeline test selected");
+
+		// write
+		DynoJedisPipeline pipeline = client.pipelined();
+		for (int i = 0; i < numKeys; i++) {
+			System.out.println("Writing key/value => DynoClientTest/" + i);
+			pipeline.hset("DynoClientTest", "DynoClientTest-" + i, "" + i);
+		}
+		pipeline.sync();
+
+		// new pipeline
+		pipeline = client.pipelined();
+		for (int i = 0; i < numKeys; i++) {
+			System.out.println("Writing key/value => DynoClientTest-1/" + i);
+			pipeline.hset("DynoClientTest-1", "DynoClientTest-" + i, "" + i);
+		}
+		pipeline.sync();
+
+		// read
+		System.out.println("Reading keys from dual writer pipeline client");
+		for (int i = 0; i < numKeys; i++) {
+			OperationResult<String> result = client.d_hget("DynoClientTest", "DynoClientTest-" + i);
+			System.out.println("Reading Key: DynoClientTest/" + i + ", Value: " + result.getResult() + " " + result.getNode());
+			result = client.d_hget("DynoClientTest-1", "DynoClientTest-" + i);
+			System.out.println("Reading Key: DynoClientTest-1/" + i + ", Value: " + result.getResult() + " " + result.getNode());
+		}
+
+		// read from shadow cluster
+		System.out.println("Reading keys from shadow Jedis client");
+		if (shadowClusterClient != null) {
+			// read
+			for (int i = 0; i < numKeys; i++) {
+				OperationResult<String> result = shadowClusterClient.d_hget("DynoClientTest", "DynoClientTest-" + i);
+				System.out.println("Reading Key: DynoClientTest/" + i + ", Value: " + result.getResult() + " " + result.getNode());
+				result = shadowClusterClient.d_hget("DynoClientTest-1", "DynoClientTest-" + i);
+				System.out.println("Reading Key: DynoClientTest-1/" + i + ", Value: " + result.getResult() + " " + result.getNode());
+			}
+		}
+
+		try {
+			pipeline.close();
+		} catch (Throwable t) {
+			t.printStackTrace();
 		}
 	}
 

--- a/dyno-jedis/src/main/java/com/netflix/dyno/jedis/DynoDualWriterPipeline.java
+++ b/dyno-jedis/src/main/java/com/netflix/dyno/jedis/DynoDualWriterPipeline.java
@@ -24,7 +24,7 @@ import java.util.concurrent.Future;
  */
 public class DynoDualWriterPipeline extends DynoJedisPipeline {
     private static final org.slf4j.Logger logger = LoggerFactory.getLogger(DynoDualWriterPipeline.class);
-    private static ExecutorService executor = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors());
+    private static ExecutorService executor = Executors.newSingleThreadExecutor();
     private final ConnectionPoolImpl<Jedis> connPool;
     private final DynoJedisPipeline shadowPipeline;
     private final DynoDualWriterClient.Dial dial;

--- a/dyno-jedis/src/main/java/com/netflix/dyno/jedis/DynoJedisPipeline.java
+++ b/dyno-jedis/src/main/java/com/netflix/dyno/jedis/DynoJedisPipeline.java
@@ -15,6 +15,7 @@
  */
 package com.netflix.dyno.jedis;
 
+import com.google.common.base.Strings;
 import com.netflix.dyno.connectionpool.*;
 import com.netflix.dyno.connectionpool.Connection;
 import com.netflix.dyno.connectionpool.exception.DynoException;
@@ -220,6 +221,9 @@ public class DynoJedisPipeline implements RedisPipeline, BinaryRedisPipeline, Au
 			 */
 			String hashValue = StringUtils.substringBetween(key, Character.toString(hashtag.charAt(0)),
 					Character.toString(hashtag.charAt(1)));
+			if (Strings.isNullOrEmpty(hashValue)) {
+				hashValue = key;
+			}
 			checkHashtag(key, hashValue);
 		}
 	}


### PR DESCRIPTION
-  Change Dyno dual writer pipeline to use single thread executor to
    run pipeline commands to avoid cases where some of the executor tasks may
    not run before the pipeline sync.

-  If dynomite cluster has hashkeys config set and if pipeline keys do not use
    hashtags, pipeline will end up using different connections for each
    pipeline command, which can result in unexpected outcomes and also result
    exhausting connections in connection pool. This is fixed by comparing
    the keys with the pipeline key when hashtags are not part of the key but
    dyno clusters have hashtags enabled.