### PR TITLE
Fix flag to be used correctly for shadow cluster

### DIFF
--- a/dyno-demo/src/main/java/com/netflix/dyno/demo/redis/DynoJedisDemo.java
+++ b/dyno-demo/src/main/java/com/netflix/dyno/demo/redis/DynoJedisDemo.java
@@ -1209,7 +1209,7 @@ public class DynoJedisDemo {
 				demo.initWithLocalHost();
 			} else {
 				demo = new DynoJedisDemo(cli.getOptionValue("p"), rack);
-				if (cli.hasOption("s")) {
+				if (!cli.hasOption("s")) {
 					if (hostsFile != null) {
 						demo.initWithRemoteClusterFromFile(hostsFile, port);
 					} else {


### PR DESCRIPTION
We were looking at the shadow cluster to initialize a second connection pool when there was nothing specified. Fixing that.