### PR TITLE
Update topology with remote rack info when LOCAL_RACK and EC2_AVAILABILITY_ZONE are not specified

### DIFF
--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/lb/HostSelectionWithFallback.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/lb/HostSelectionWithFallback.java
@@ -360,7 +360,7 @@ public class HostSelectionWithFallback<CL> {
 		}
 
 		// Initialize Remote selectors
-		Set<String> remoteRacks = hPools.keySet().stream().map(h -> h.getRack()).filter(rack -> !rack.equals(localRack)).collect(Collectors.toSet());
+		Set<String> remoteRacks = hPools.keySet().stream().map(h -> h.getRack()).filter(rack -> rack != null && !rack.equals(localRack)).collect(Collectors.toSet());
 
 		for (String rack : remoteRacks) {
 			Map<HostToken, HostConnectionPool<CL>> dcPools = getHostPoolsForRack(tokenPoolMap, rack);

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/lb/HostSelectionWithFallback.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/lb/HostSelectionWithFallback.java
@@ -314,12 +314,7 @@ public class HostSelectionWithFallback<CL> {
 			return false;
 		}
 		Host host = hPool.getHost();
-
-		if (!host.isUp()) {
-			return false;
-		} else {
-			return hPool.isActive();
-		}
+		return host.isUp() && hPool.isActive();
 	}
 
 	private Map<HostToken, HostConnectionPool<CL>> getHostPoolsForRack(final Map<HostToken, HostConnectionPool<CL>> map, final String rack) {

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/lb/TokenAwareSelection.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/lb/TokenAwareSelection.java
@@ -15,15 +15,6 @@
  ******************************************************************************/
 package com.netflix.dyno.connectionpool.impl.lb;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-
-import com.netflix.dyno.connectionpool.exception.BadRequestException;
-import org.apache.commons.lang3.StringUtils;
-
 import com.netflix.dyno.connectionpool.BaseOperation;
 import com.netflix.dyno.connectionpool.HashPartitioner;
 import com.netflix.dyno.connectionpool.HostConnectionPool;
@@ -34,6 +25,13 @@ import com.netflix.dyno.connectionpool.impl.hash.BinarySearchTokenMapper;
 import com.netflix.dyno.connectionpool.impl.hash.Murmur1HashPartitioner;
 import com.netflix.dyno.connectionpool.impl.utils.CollectionUtils;
 import com.netflix.dyno.connectionpool.impl.utils.CollectionUtils.Transform;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Concrete implementation of the {@link HostSelectionStrategy} interface using
@@ -103,7 +101,7 @@ public class TokenAwareSelection<CL> implements HostSelectionStrategy<CL> {
                 throw new NoAvailableHostsException("Token not found for key " + key);
             }
 
-            hostPool = tokenPools.get(hToken.getToken());;
+            hostPool = tokenPools.get(hToken.getToken());
             if (hostPool == null) {
                 throw new NoAvailableHostsException(
                         "Could not find host connection pool for key: " + key + ", hash: " + tokenMapper.hash(key) + " Token:" + hToken.getToken());

--- a/dyno-demo/src/main/java/com/netflix/dyno/demo/redis/DynoDistributedCounterDemo.java
+++ b/dyno-demo/src/main/java/com/netflix/dyno/demo/redis/DynoDistributedCounterDemo.java
@@ -15,19 +15,21 @@
  ******************************************************************************/
 package com.netflix.dyno.demo.redis;
 
+import com.netflix.dyno.recipes.counter.DynoCounter;
+import com.netflix.dyno.recipes.counter.DynoJedisBatchCounter;
+import com.netflix.dyno.recipes.counter.DynoJedisCounter;
+import com.netflix.dyno.recipes.counter.DynoJedisPipelineCounter;
+
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Properties;
 import java.util.Random;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
-
-import com.netflix.dyno.recipes.counter.DynoCounter;
-import com.netflix.dyno.recipes.counter.DynoJedisBatchCounter;
-import com.netflix.dyno.recipes.counter.DynoJedisPipelineCounter;
-import com.netflix.dyno.recipes.counter.DynoJedisCounter;
 
 /**
  * Demo of {@link DynoCounter} implementations.
@@ -234,12 +236,17 @@ public class DynoDistributedCounterDemo extends DynoJedisDemo {
      *             <ol>dynomite_cluster_name</ol>
      *             <ol># of distributed counters (optional)</ol>
      */
-    public static void main(String[] args) {
+    public static void main(String[] args) throws IOException {
 
         final String clusterName = args[0];
 
         final DynoDistributedCounterDemo demo = new DynoDistributedCounterDemo(clusterName, "us-east-1e");
         int numCounters = (args.length == 2) ? Integer.valueOf(args[1]) : 1;
+        Properties props = new Properties();
+        props.load(DynoDistributedCounterDemo.class.getResourceAsStream("/demo.properties"));
+        for (String name : props.stringPropertyNames()) {
+            System.setProperty(name, props.getProperty(name));
+        }
 
         try {
             demo.initWithRemoteClusterFromEurekaUrl(args[0], 8102);

--- a/dyno-demo/src/main/java/com/netflix/dyno/demo/redis/DynoJedisDemo.java
+++ b/dyno-demo/src/main/java/com/netflix/dyno/demo/redis/DynoJedisDemo.java
@@ -17,18 +17,28 @@ package com.netflix.dyno.demo.redis;
 
 import com.google.common.collect.Lists;
 import com.google.gson.Gson;
-import com.netflix.dyno.connectionpool.*;
+import com.netflix.dyno.connectionpool.CursorBasedResult;
+import com.netflix.dyno.connectionpool.Host;
 import com.netflix.dyno.connectionpool.Host.Status;
+import com.netflix.dyno.connectionpool.HostSupplier;
+import com.netflix.dyno.connectionpool.OperationResult;
+import com.netflix.dyno.connectionpool.TokenMapSupplier;
 import com.netflix.dyno.connectionpool.exception.PoolOfflineException;
 import com.netflix.dyno.connectionpool.impl.ConnectionPoolConfigurationImpl;
 import com.netflix.dyno.connectionpool.impl.lb.HostToken;
 import com.netflix.dyno.contrib.ArchaiusConnectionPoolConfiguration;
-import com.netflix.dyno.jedis.DynoDualWriterClient;
 import com.netflix.dyno.jedis.DynoJedisClient;
 import com.netflix.dyno.jedis.DynoJedisPipeline;
 import com.netflix.dyno.recipes.json.DynoJedisJsonClient;
 import com.netflix.dyno.recipes.json.JsonPath;
-import org.apache.commons.cli.*;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.OptionGroup;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
@@ -42,10 +52,23 @@ import redis.clients.jedis.ScanResult;
 
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Random;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -269,7 +292,7 @@ public class DynoJedisDemo {
 
 	/**
 	 * This tests covers the use of binary keys
-	 * 
+	 *
 	 * @throws Exception
 	 */
 	public void runBinaryKeyTest() throws Exception {
@@ -278,7 +301,7 @@ public class DynoJedisDemo {
         byte[] videoInt =ByteBuffer.allocate(4).putInt(new Integer(100)).array();
         byte[] locInt =ByteBuffer.allocate(4).putInt(new Integer(200)).array();
         byte[] overallKey = new byte[videoInt.length + locInt.length];
-		
+
 		byte[] firstWindow = ByteBuffer.allocate(4).putFloat(new Float(1.25)).array();
 		byte[] secondWindow = ByteBuffer.allocate(4).putFloat(new Float(1.5)).array();
 		byte[] thirdWindow = ByteBuffer.allocate(4).putFloat(new Float(1.75)).array();
@@ -288,22 +311,22 @@ public class DynoJedisDemo {
 				+ fourthWindow.length];
 
         byte[] newKey = new byte[videoInt.length+locInt.length];
-		
+
 		// write
 		client.set(overallKey, overallVal);
 		System.out.println("Writing Key: " +  new String(overallKey, Charset.forName("UTF-8")));
-		
+
 		// read
 		OperationResult<byte[]> result = client.d_get(newKey);
 		System.out.println("Reading Key: " + new String(newKey, Charset.forName("UTF-8")) + ", Value: " + result.getResult().toString() + " " + result.getNode());
-		
+
 	}
 
 	/**
 	 * To run this test, the hashtag FP must be set on the Dynomite cluster. The
 	 * assumed hashtag for this test is {} hence each key is foo-{<String>}. To
 	 * validate that this test succeeds observe the cluster manually.
-	 * 
+	 *
 	 * @throws Exception
 	 */
 	public void runSimpleTestWithHashtag() throws Exception {
@@ -759,7 +782,7 @@ public class DynoJedisDemo {
 	/**
 	 * This demo runs a pipeline across ten different keys. The pipeline leverages
 	 * the hash value {bar} to determine the node where to send the data.
-	 * 
+	 *
 	 * @throws Exception
 	 */
 	public void runPipelineWithHashtag() throws Exception {
@@ -1193,7 +1216,7 @@ public class DynoJedisDemo {
 					"MUST set local for load balancing OR set the load balancing strategy to round robin");
 		}
 
-		String rack = props.getProperty("EC2_AVAILABILITY_ZONE", "us-east-1e");
+		String rack = props.getProperty("EC2_AVAILABILITY_ZONE", null);
 		String hostsFile = props.getProperty("dyno.demo.hostsFile");
 		String shadowHostsFile = props.getProperty("dyno.demo.shadowHostsFile");
 		int port = Integer.valueOf(props.getProperty("dyno.demo.port", "8102"));

--- a/dyno-demo/src/main/resources/demo.properties
+++ b/dyno-demo/src/main/resources/demo.properties
@@ -2,8 +2,11 @@
 ## Properties to initialize the demo app
 #
 LOCAL_DATACENTER=us-east-1
-LOCAL_RACK=us-east-1e
+#LOCAL_RACK=us-east-1e
 NETFLIX_STACK=dyno_demo
+#EC2_AVAILABILITY_ZONE=us-east-1
+
+dyno.demo.lbStrategy=TokenAware
 
 netflix.appinfo.name=dyno_demo
 netflix.environment=test
@@ -13,7 +16,6 @@ netflix.appinfo.validateInstanceId=false
 
 dyno.demo.retryPolicy=RetryNTimes:2
 dyno.demo.port=8102
-dyno.demo.scan.populateKeys=true
 dyno.demo.discovery.prod=discoveryreadonly.%s.dynprod.netflix.net:7001/v2/apps
 dyno.demo.discovery.test=discoveryreadonly.%s.dyntest.netflix.net:7001/v2/apps
 


### PR DESCRIPTION
When we do not set LOCAL_RACK and EC2_AVAILABILITY_ZONE we currently fall back to remote racks but do not update the topology to reflect the change.