### PR TITLE
Fix DynoJedisDemo for dual writes

### DIFF
--- a/dyno-demo/src/main/java/com/netflix/dyno/demo/redis/DynoJedisDemo.java
+++ b/dyno-demo/src/main/java/com/netflix/dyno/demo/redis/DynoJedisDemo.java
@@ -1229,14 +1229,15 @@ public class DynoJedisDemo {
                 demo = new DynoJedisDemo("dyno-localhost", rack);
                 demo.initWithLocalHost();
             } else {
-                demo = new DynoJedisDemo(cli.getOptionValue("p"), rack);
                 if (!cli.hasOption("s")) {
+                    demo = new DynoJedisDemo(cli.getOptionValue("p"), rack);
                     if (hostsFile != null) {
                         demo.initWithRemoteClusterFromFile(hostsFile, port);
                     } else {
                         demo.initWithRemoteClusterFromEurekaUrl(cli.getOptionValue("p"), port);
                     }
                 } else {
+                    demo = new DynoJedisDemo(cli.getOptionValue("p"), cli.getOptionValue("s"), rack);
                     if (hostsFile != null) {
                         demo.initDualClientWithRemoteClustersFromFile(hostsFile, shadowHostsFile, port);
                     } else {


### PR DESCRIPTION
The DynoJedisDemo did not call the appropriate constructor for
DynoJedisClient when configured to use a shadow cluster. This patch
fixes this.