### PR TITLE
Throw exception if the tokenMapSupplier and hostSupplier do not match

### DIFF
--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/HostsUpdater.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/HostsUpdater.java
@@ -106,6 +106,9 @@ public class HostsUpdater {
         for (Host hostFromHostSupplier : allHostsFromHostSupplier) {
             if (hostFromHostSupplier.isUp()) {
                 Host hostFromTokenMapSupplier = allHostSetFromTokenMapSupplier.get(hostFromHostSupplier);
+                if (hostFromTokenMapSupplier == null) {
+                    throw new DynoException("Could not find " + hostFromHostSupplier.getHostName() + " in token map supplier.");
+                }
 
                 hostsUpFromHostSupplier.add(new Host(hostFromHostSupplier.getHostName(), hostFromHostSupplier.getIpAddress(),
                         hostFromTokenMapSupplier.getPort(), hostFromTokenMapSupplier.getSecurePort(), hostFromTokenMapSupplier.getRack(),


### PR DESCRIPTION
We get a NPE when this manifests which leaves us with no information.
This patch throws a coherent exception which will help us debug further.

The root cause of this is still not found, but this patch should help us
find it in production.