### PR TITLE
Switch Travis CI from using Oracle JDK 8 to Open JDK 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-  - oraclejdk8
+  - openjdk8
 sudo: false
 install: ./installViaTravis.sh
 script: ./buildViaTravis.sh


### PR DESCRIPTION
Oracle has ended uspport for their JDK 8. Switching to Open JDK for
Travis builds.