### PR TITLE
Disable demo properties that affect the client in production

### DIFF
--- a/dyno-demo/src/main/resources/demo.properties
+++ b/dyno-demo/src/main/resources/demo.properties
@@ -1,10 +1,12 @@
 ####
 ## Properties to initialize the demo app
 #
-LOCAL_DATACENTER=us-east-1
-LOCAL_RACK=us-east-1e
+
+# Uncomment properties as necessary.
+#LOCAL_DATACENTER=us-east-1
+#LOCAL_RACK=us-east-1d
 NETFLIX_STACK=dyno_demo
-EC2_AVAILABILITY_ZONE=us-east-1c
+#EC2_AVAILABILITY_ZONE=us-east-1c
 netflix.appinfo.name=dyno_demo
 netflix.environment=test
 netflix.appinfo.metadata.enableRoute53=false


### PR DESCRIPTION
Somehow, the demo properties get picked up by the client even though
it's not supposed to which causes incorrect behavior in the client.

The properties in question are LOCAL_RACK and LOCAL_DATACENTER which
return the values set in the demo.properties file in production, causing
ConfigUtils.getLocalZone() and ConfigUtils.getDataCenter() to return
potentially incorrect values.

TODO: Figure out why demo.properties gets picked up and disallow it from happening.