### PR TITLE
Dual writer in the DynoJedisDemo both point to primary cluster

### DIFF
--- a/dyno-demo/src/main/java/com/netflix/dyno/demo/redis/DynoJedisDemo.java
+++ b/dyno-demo/src/main/java/com/netflix/dyno/demo/redis/DynoJedisDemo.java
@@ -206,8 +206,8 @@ public class DynoJedisDemo {
         this.shadowClusterClient = new DynoJedisClient.Builder()
                 .withApplicationName("demo")
                 .withDynomiteClusterName("dyno-dev")
-                .withHostSupplier(primaryClusterHostSupplier)
-                .withTokenMapSupplier(primaryTokenSupplier)
+                .withHostSupplier(shadowClusterHostSupplier)
+                .withTokenMapSupplier(shadowTokenSupplier)
                 .withCPConfig(shadowCPConfig)
                 .build();
 


### PR DESCRIPTION
Turns out that the 'shadowClusterClient' in DynoJedisDemo was pointing
to the primary cluster because it was fed the wrong HostSupplier and
TokenMapSupplier.

This was never noticed since the shadowClusterClient would verify if all
the data was there in the source cluster instead of the shadow cluster,
hence making all the dual writer based runs false positives.