### PR TITLE
Use IPAddresses from HostSupplier rather than from AbstractTokenMapSu…

### DIFF
--- a/dyno-recipes/src/test/java/com/netflix/dyno/recipes/lock/LocalRedisLockTest.java
+++ b/dyno-recipes/src/test/java/com/netflix/dyno/recipes/lock/LocalRedisLockTest.java
@@ -25,7 +25,15 @@ public class LocalRedisLockTest extends DynoLockClientTest {
         redisServer = new RedisServer(REDIS_PORT);
         redisServer.start();
         Assume.assumeFalse(System.getProperty("os.name").toLowerCase().startsWith("win"));
-        host = new HostBuilder().setHostname("localhost").setDatastorePort(REDIS_PORT).setPort(REDIS_PORT).setRack(REDIS_RACK).setStatus(Host.Status.Up).createHost();
+        host = new HostBuilder()
+                .setHostname("localhost")
+                .setIpAddress("127.0.0.1")
+                .setDatastorePort(REDIS_PORT)
+                .setPort(REDIS_PORT)
+                .setRack(REDIS_RACK)
+                .setStatus(Host.Status.Up)
+                .createHost();
+
         tokenMapSupplier = new TokenMapSupplierImpl(host);
         dynoLockClient = constructDynoLockClient();
     }


### PR DESCRIPTION
…pplier

We always used the IPs from the HostSupplier rather than the
AbstractTokenMapSupplier as an undocumented subtlety.

In the previous patch, this was changed as it seemed like a harmless
change.
https://github.com/Netflix/dyno/commit/7b253925f8bae6355a16164efe8469d7929f0591

Howver, the implication is that the client operates on Public IPs (which
the AbstractTokenMapSupplier supplies), as opposed to the Private IPs
(which the HostSupplier supplies), and in production, the Public IP
range are generally not accessible by clients.

Why does the AbstractTokenMapSupplier return public IPs?
This is because the AbstractTokenMapSupplier derives its values from
dynomite-manager which returns the topology seen by it and the server
processes, and they use Public IPs to communicate with each other.

TODO: Can we ensure that both the HostSupplier and AbstractTokenMapSupplier
agree on the same values?