### PR TITLE
Allow client to set per-connection level consistency

### DIFF
--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/ConnectionFactory.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/ConnectionFactory.java
@@ -39,4 +39,7 @@ public interface ConnectionFactory<CL> {
 
     Connection<CL> createConnectionWithDataStore(HostConnectionPool<CL> pool)
             throws DynoConnectException;
+
+    Connection<CL> createConnectionWithConsistencyLevel(HostConnectionPool<CL> pool, String consistency)
+            throws DynoConnectException;
 }

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/ConnectionPoolConfiguration.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/ConnectionPoolConfiguration.java
@@ -45,6 +45,12 @@ public interface ConnectionPoolConfiguration {
      */
     boolean isConnectToDatastore();
 
+    /**
+     * Returns 'true' if a connection-pool level consistency setting was provided.
+     * @return
+     */
+    boolean isConnectionPoolConsistencyProvided();
+
     boolean isFallbackEnabled();
 
     /**
@@ -235,6 +241,13 @@ public interface ConnectionPoolConfiguration {
      * @return
      */
     int getPoolReconnectWaitMillis();
+
+    /**
+     * Returns the user-provided connection pool level consistency setting if provided.
+     *
+     * @return
+     */
+    String getConnectionPoolConsistency();
 
     String getHashtag();
 

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolConfigurationImpl.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolConfigurationImpl.java
@@ -54,6 +54,7 @@ public class ConnectionPoolConfigurationImpl implements ConnectionPoolConfigurat
     private static final boolean DEFAULT_FALLBACK_POLICY = true;
     private static final boolean DEFAULT_CONNECT_TO_DATASTORE = false;
     private static final int DEFAULT_LOCK_VOTING_SIZE = -1;
+    private static final String UNSET_CONNECTION_POOL_CONSISTENCY = "UNSET_CONFIG";
 
     private HostSupplier hostSupplier;
     private TokenMapSupplier tokenSupplier;
@@ -87,6 +88,7 @@ public class ConnectionPoolConfigurationImpl implements ConnectionPoolConfigurat
     private int lockVotingSize = DEFAULT_LOCK_VOTING_SIZE;
     private boolean fallbackEnabled = DEFAULT_FALLBACK_POLICY;
     private boolean connectToDatastore = DEFAULT_CONNECT_TO_DATASTORE;
+    private String connectionPoolConsistency = UNSET_CONNECTION_POOL_CONSISTENCY;
 
 
     private RetryPolicyFactory retryFactory = new RetryPolicyFactory() {
@@ -144,6 +146,11 @@ public class ConnectionPoolConfigurationImpl implements ConnectionPoolConfigurat
     @Override
     public boolean isConnectToDatastore() {
         return connectToDatastore;
+    }
+
+    @Override
+    public boolean isConnectionPoolConsistencyProvided() {
+        return !(this.connectionPoolConsistency.compareTo(UNSET_CONNECTION_POOL_CONSISTENCY) == 0);
     }
 
     @Override
@@ -318,6 +325,10 @@ public class ConnectionPoolConfigurationImpl implements ConnectionPoolConfigurat
         this.connectToDatastore = connectToDatastore;
     }
 
+    public void setConnectionPoolConsistency(String consistency) {
+        this.connectionPoolConsistency = consistency;
+    }
+
     public ConnectionPoolConfigurationImpl setFallbackEnabled(boolean fallbackEnabled) {
         this.fallbackEnabled = fallbackEnabled;
         return this;
@@ -393,6 +404,10 @@ public class ConnectionPoolConfigurationImpl implements ConnectionPoolConfigurat
         return this;
     }
 
+    @Override
+    public String getConnectionPoolConsistency() {
+        return this.connectionPoolConsistency;
+    }
 
     public HostSupplier getHostSupplier() {
         return hostSupplier;

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/HostConnectionPoolImpl.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/HostConnectionPoolImpl.java
@@ -301,8 +301,15 @@ public class HostConnectionPoolImpl<CL> implements HostConnectionPool<CL> {
         public Connection<CL> createConnection() {
 
             try {
-                Connection<CL> connection = cpConfig.isConnectToDatastore() ? connFactory.createConnectionWithDataStore(pool) :
-                        connFactory.createConnection(pool);
+                Connection<CL> connection;
+                if (cpConfig.isConnectToDatastore()) {
+                    connection = connFactory.createConnectionWithDataStore(pool);
+                } else if (cpConfig.isConnectionPoolConsistencyProvided()) {
+                    connection = connFactory.createConnectionWithConsistencyLevel(pool, cpConfig.getConnectionPoolConsistency());
+                } else {
+                    connection = connFactory.createConnection(pool);
+                }
+
                 connection.open();
                 availableConnections.add(connection);
 

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolImplTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolImplTest.java
@@ -149,6 +149,12 @@ public class ConnectionPoolImplTest {
         public Connection<TestClient> createConnectionWithDataStore(HostConnectionPool<TestClient> pool) throws DynoConnectException {
             return null;
         }
+
+        @Override
+        public Connection<TestClient> createConnectionWithConsistencyLevel(HostConnectionPool<TestClient> pool, String consistency) throws DynoConnectException {
+            return null;
+        }
+
     };
 
     private Host host1 = new HostBuilder().setHostname("host1").setPort(8080).setRack("localRack").setStatus(Status.Up).createHost();
@@ -513,6 +519,12 @@ public class ConnectionPoolImplTest {
             public Connection<TestClient> createConnectionWithDataStore(HostConnectionPool<TestClient> pool) throws DynoConnectException {
                 return null;
             }
+
+            @Override
+            public Connection<TestClient> createConnectionWithConsistencyLevel(HostConnectionPool<TestClient> pool, String consistency) throws DynoConnectException {
+                return null;
+            }
+
         };
 
         final ConnectionPoolImpl<TestClient> pool = new ConnectionPoolImpl<TestClient>(badConnectionFactory, cpConfig, cpMonitor);
@@ -629,6 +641,12 @@ public class ConnectionPoolImplTest {
             public Connection<TestClient> createConnectionWithDataStore(HostConnectionPool<TestClient> pool) throws DynoConnectException {
                 return null;
             }
+
+            @Override
+            public Connection<TestClient> createConnectionWithConsistencyLevel(HostConnectionPool<TestClient> pool, String consistency) throws DynoConnectException {
+                return null;
+            }
+
         };
 
         final RetryNTimes retry = new RetryNTimes(3, false);

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/HostConnectionPoolImplTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/HostConnectionPoolImplTest.java
@@ -125,6 +125,12 @@ public class HostConnectionPoolImplTest {
         public Connection<TestClient> createConnectionWithDataStore(HostConnectionPool<TestClient> pool) throws DynoConnectException {
             return null;
         }
+
+        @Override
+        public Connection<TestClient> createConnectionWithConsistencyLevel(HostConnectionPool<TestClient> pool, String consistency) throws DynoConnectException {
+            return null;
+        }
+
     };
 
     private static ConnectionPoolConfigurationImpl config = new ConnectionPoolConfigurationImpl("TestClient");

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/SimpleAsyncConnectionPoolImplTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/SimpleAsyncConnectionPoolImplTest.java
@@ -62,6 +62,11 @@ public class SimpleAsyncConnectionPoolImplTest {
         public Connection<TestClient> createConnectionWithDataStore(HostConnectionPool<TestClient> pool) throws DynoConnectException {
             return null;
         }
+
+        @Override
+        public Connection<TestClient> createConnectionWithConsistencyLevel(HostConnectionPool<TestClient> pool, String consistency) throws DynoConnectException {
+            return null;
+        }
     };
 
     private static ConnectionPoolConfigurationImpl config = new ConnectionPoolConfigurationImpl("TestClient");

--- a/dyno-jedis/src/main/java/com/netflix/dyno/jedis/DynoConfigCommand.java
+++ b/dyno-jedis/src/main/java/com/netflix/dyno/jedis/DynoConfigCommand.java
@@ -1,0 +1,35 @@
+
+/*******************************************************************************
+ * Copyright 2018 Netflix
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+
+package com.netflix.dyno.jedis;
+
+import lombok.Getter;
+
+import redis.clients.jedis.commands.ProtocolCommand;
+import redis.clients.jedis.util.SafeEncoder;
+
+@Getter
+public enum DynoConfigCommand implements ProtocolCommand {
+    CONN_CONSISTENCY("DYNO_CONFIG:CONN_CONSISTENCY");
+
+    private final byte[] raw;
+
+    DynoConfigCommand(String opName) {
+        this.raw = SafeEncoder.encode(opName);
+    }
+}

--- a/dyno-redisson/src/main/java/com/netflix/dyno/redisson/RedissonConnectionFactory.java
+++ b/dyno-redisson/src/main/java/com/netflix/dyno/redisson/RedissonConnectionFactory.java
@@ -58,6 +58,11 @@ public class RedissonConnectionFactory implements ConnectionFactory<RedisAsyncCo
         throw new UnsupportedOperationException("");
     }
 
+    @Override
+    public Connection<RedisAsyncConnection<String, String>> createConnectionWithConsistencyLevel(HostConnectionPool<RedisAsyncConnection<String, String>> pool, String consistency) throws DynoConnectException {
+        throw new UnsupportedOperationException("");
+    }
+
     public static class RedissonConnection implements Connection<RedisAsyncConnection<String, String>> {
 
         private final HostConnectionPool<RedisAsyncConnection<String, String>> hostPool;


### PR DESCRIPTION
The Dynomite server side exposed an unsupported command called
"DYNO_CONFIG:CONN_CONSISTENCY <consistency_level>". This patch exposes
a new API on the DynoJedisClientBuilder that allows us to set
a consistency level per connection pool by invoking:

    withConnectionPoolConsistency( consistency )

If this API is invoked, on every connection to the Dynomite server, the
first command run will be the above mentioned one to set the consistency
level for that connection based on the user-provided arugument.

Testing: Used the DynoJedisDemo to try to get a key with quorum failures
and made sure it succeeds if withConnectionPoolConsistency("DC_ONE") is
set.

TODO: This was done in a hurry. Consider code-cleanup in the future.