### PR TITLE
Capture OK response after sending DYNO_CONFIG command

### DIFF
--- a/dyno-jedis/src/main/java/com/netflix/dyno/jedis/JedisConnectionFactory.java
+++ b/dyno-jedis/src/main/java/com/netflix/dyno/jedis/JedisConnectionFactory.java
@@ -176,6 +176,7 @@ public class JedisConnectionFactory implements ConnectionFactory<Jedis> {
             jedisClient.connect();
             if (isConsistencyLevelProvided()) {
                 jedisClient.getClient().sendCommand(DynoConfigCommand.CONN_CONSISTENCY, this.consistencyLevel);
+                jedisClient.getClient().getStatusCodeReply();
             }
         }
 


### PR DESCRIPTION
We forgot to capture the OK response from DYNO_CONFIG:CONN_CONSISTENCY
command after sending it, which meant that every command after that was
getting the response for the previous command since there was always an
unclaimed response on the wire.

This patch fixes it.