### PR TITLE
Jedis binary API parity with string API

### DIFF
--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/CompressionOperation.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/CompressionOperation.java
@@ -23,4 +23,9 @@ public interface CompressionOperation<CL, R> extends Operation<CL, R> {
     String compressValue(String value, ConnectionContext ctx);
 
     String decompressValue(String value, ConnectionContext ctx);
+
+    byte[] compressValue(byte[] value, ConnectionContext ctx);
+
+    byte[] decompressValue(byte[] value, ConnectionContext ctx);
+
 }

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/Connection.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/Connection.java
@@ -55,6 +55,11 @@ public interface Connection<CL> {
     public void open() throws DynoException;
 
     /**
+     * Reset connection before adding back to pool.
+     */
+    public void reset();
+
+    /**
      * Can be used by clients to indicate connection exception.
      * This can be analyzed by connection pools later
      * e.g remove host from connection pool etc.

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/MultiKeyCompressionOperation.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/MultiKeyCompressionOperation.java
@@ -13,4 +13,9 @@ public interface MultiKeyCompressionOperation<CL, R> extends Operation<CL, R> {
     String[] compressMultiKeyValue(ConnectionContext ctx, String... value);
 
     String decompressValue(ConnectionContext ctx, String value);
+
+    byte[][] compressMultiKeyValue(ConnectionContext ctx, byte[]... value);
+
+    byte[] decompressValue(ConnectionContext ctx, byte[] value);
+
 }

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/HostConnectionPoolImpl.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/HostConnectionPoolImpl.java
@@ -346,6 +346,7 @@ public class HostConnectionPoolImpl<CL> implements HostConnectionPool<CL> {
                     return closeConnection(connection);
                 } else {
                     // Add the given connection back to the pool
+                    connection.reset();
                     availableConnections.add(connection);
                     return false;
                 }

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolImplTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolImplTest.java
@@ -114,6 +114,10 @@ public class ConnectionPoolImplTest {
         }
 
         @Override
+        public void reset() {
+        }
+
+        @Override
         public DynoConnectException getLastException() {
             return ex;
         }

--- a/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/HostConnectionPoolImplTest.java
+++ b/dyno-core/src/test/java/com/netflix/dyno/connectionpool/impl/HostConnectionPoolImplTest.java
@@ -85,6 +85,10 @@ public class HostConnectionPoolImplTest {
         }
 
         @Override
+        public void reset() {
+        }
+
+        @Override
         public DynoConnectException getLastException() {
             return ex;
         }

--- a/dyno-demo/src/main/java/com/netflix/dyno/demo/redis/CustomTokenSupplierExample.java
+++ b/dyno-demo/src/main/java/com/netflix/dyno/demo/redis/CustomTokenSupplierExample.java
@@ -93,8 +93,8 @@ public class CustomTokenSupplierExample {
         }
         // read
         for (int i = 0; i < 10; i++) {
-            OperationResult<String> result = client.d_get("" + i);
-            System.out.println("Key: " + i + ", Value: " + result.getResult() + " " + result.getNode());
+            String result = client.get("" + i);
+            System.out.println("Key: " + i + ", Value: " + result);
         }
     }
 

--- a/dyno-demo/src/main/java/com/netflix/dyno/demo/redis/DynoJedisDemo.java
+++ b/dyno-demo/src/main/java/com/netflix/dyno/demo/redis/DynoJedisDemo.java
@@ -248,16 +248,16 @@ public class DynoJedisDemo {
         }
         // read
         for (int i = 0; i < numKeys; i++) {
-            OperationResult<String> result = client.d_get("DynoClientTest-" + i);
-            System.out.println("Reading Key: " + i + ", Value: " + result.getResult() + " " + result.getNode());
+            String result = client.get("DynoClientTest-" + i);
+            System.out.println("Reading Key: " + i + ", Value: " + result);
         }
 
         // read from shadow cluster
         if (shadowClusterClient != null) {
             // read
             for (int i = 0; i < numKeys; i++) {
-                OperationResult<String> result = shadowClusterClient.d_get("DynoClientTest-" + i);
-                System.out.println("Reading Key: " + i + ", Value: " + result.getResult() + " " + result.getNode());
+                String result = shadowClusterClient.get("DynoClientTest-" + i);
+                System.out.println("Reading Key: " + i + ", Value: " + result);
             }
         }
     }
@@ -285,10 +285,10 @@ public class DynoJedisDemo {
         // read
         System.out.println("Reading keys from dual writer pipeline client");
         for (int i = 0; i < numKeys; i++) {
-            OperationResult<String> result = client.d_hget("DynoClientTest", "DynoClientTest-" + i);
-            System.out.println("Reading Key: DynoClientTest/" + i + ", Value: " + result.getResult() + " " + result.getNode());
-            result = client.d_hget("DynoClientTest-1", "DynoClientTest-" + i);
-            System.out.println("Reading Key: DynoClientTest-1/" + i + ", Value: " + result.getResult() + " " + result.getNode());
+            String result = client.hget("DynoClientTest", "DynoClientTest-" + i);
+            System.out.println("Reading Key: DynoClientTest/" + i + ", Value: " + result);
+            result = client.hget("DynoClientTest-1", "DynoClientTest-" + i);
+            System.out.println("Reading Key: DynoClientTest-1/" + i + ", Value: " + result);
         }
 
         // read from shadow cluster
@@ -296,10 +296,10 @@ public class DynoJedisDemo {
         if (shadowClusterClient != null) {
             // read
             for (int i = 0; i < numKeys; i++) {
-                OperationResult<String> result = shadowClusterClient.d_hget("DynoClientTest", "DynoClientTest-" + i);
-                System.out.println("Reading Key: DynoClientTest/" + i + ", Value: " + result.getResult() + " " + result.getNode());
-                result = shadowClusterClient.d_hget("DynoClientTest-1", "DynoClientTest-" + i);
-                System.out.println("Reading Key: DynoClientTest-1/" + i + ", Value: " + result.getResult() + " " + result.getNode());
+                String result = shadowClusterClient.hget("DynoClientTest", "DynoClientTest-" + i);
+                System.out.println("Reading Key: DynoClientTest/" + i + ", Value: " + result);
+                result = shadowClusterClient.hget("DynoClientTest-1", "DynoClientTest-" + i);
+                System.out.println("Reading Key: DynoClientTest-1/" + i + ", Value: " + result);
             }
         }
 
@@ -337,8 +337,8 @@ public class DynoJedisDemo {
         System.out.println("Writing Key: " + new String(overallKey, Charset.forName("UTF-8")));
 
         // read
-        OperationResult<byte[]> result = client.d_get(newKey);
-        System.out.println("Reading Key: " + new String(newKey, Charset.forName("UTF-8")) + ", Value: " + result.getResult().toString() + " " + result.getNode());
+        byte[] result = client.get(newKey);
+        System.out.println("Reading Key: " + new String(newKey, Charset.forName("UTF-8")) + ", Value: " + Arrays.toString(result));
 
     }
 
@@ -361,9 +361,9 @@ public class DynoJedisDemo {
         }
         // read
         for (int i = 0; i < numKeys; i++) {
-            OperationResult<String> result = client.d_get(i + "-{bar}");
+            String result = client.get(i + "-{bar}");
             System.out.println(
-                    "Reading Key: " + i + "-{bar}" + " , Value: " + result.getResult() + " " + result.getNode());
+                    "Reading Key: " + i + "-{bar}" + " , Value: " + result);
         }
     }
 

--- a/dyno-jedis/src/main/java/com/netflix/dyno/jedis/DynoDualWriterClient.java
+++ b/dyno-jedis/src/main/java/com/netflix/dyno/jedis/DynoDualWriterClient.java
@@ -15,17 +15,25 @@
  */
 package com.netflix.dyno.jedis;
 
+import com.netflix.dyno.connectionpool.CompressionOperation;
+import com.netflix.dyno.connectionpool.ConnectionContext;
 import com.netflix.dyno.connectionpool.ConnectionPool;
 import com.netflix.dyno.connectionpool.ConnectionPoolMonitor;
+import com.netflix.dyno.connectionpool.MultiKeyCompressionOperation;
 import com.netflix.dyno.connectionpool.OperationResult;
+import com.netflix.dyno.connectionpool.exception.DynoException;
 import com.netflix.dyno.connectionpool.impl.ConnectionPoolImpl;
 import com.netflix.dyno.contrib.DynoOPMonitor;
+import com.netflix.dyno.jedis.operation.BaseKeyOperation;
+import com.netflix.dyno.jedis.operation.MultiKeyOperation;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.ScanParams;
 import redis.clients.jedis.ScanResult;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -35,6 +43,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
 
 /**
  * Client that provides 'dual-write' functionality. This is useful when clients wish to move from one dynomite
@@ -43,6 +52,10 @@ import java.util.concurrent.atomic.AtomicReference;
  * @author jcacciatore
  */
 public class DynoDualWriterClient extends DynoJedisClient {
+
+
+    // FIXME: not all write commands are shadowed
+
 
     private static final Logger logger = LoggerFactory.getLogger(DynoDualWriterClient.class);
 
@@ -106,7 +119,7 @@ public class DynoDualWriterClient extends DynoJedisClient {
                 shadowClient.getConnPool(), dial);
     }
 
-    private <R> Future<OperationResult<R>> writeAsync(final String key, Callable<OperationResult<R>> func) {
+    private <R> Future<R> writeAsync(final String key, Callable<R> func) {
         if (sendShadowRequest(key)) {
             try {
                 return executor.submit(func);
@@ -124,7 +137,7 @@ public class DynoDualWriterClient extends DynoJedisClient {
     /**
      *  writeAsync() for binary commands
      */
-    private <R> Future<OperationResult<R>> writeAsync(final byte[] key, Callable<OperationResult<R>> func) {
+    private <R> Future<R> writeAsync(final byte[] key, Callable<R> func) {
         if (sendShadowRequest(key)) {
             try {
                 return executor.submit(func);
@@ -138,7 +151,6 @@ public class DynoDualWriterClient extends DynoJedisClient {
 
         return null;
     }
-
 
     /**
      * Returns true if the connection pool
@@ -205,611 +217,641 @@ public class DynoDualWriterClient extends DynoJedisClient {
 
     //----------------------------- JEDIS COMMANDS --------------------------------------
 
+
     @Override
     public Long append(final String key, final String value) {
-        return this.d_append(key, value).getResult();
+        writeAsync(key, () -> shadowClient.append(key, value));
+
+        return DynoDualWriterClient.super.append(key, value);
     }
 
     @Override
-    public OperationResult<Long> d_append(final String key, final String value) {
-        writeAsync(key, new Callable<OperationResult<Long>>() {
-            @Override
-            public OperationResult<Long> call() throws Exception {
-                return shadowClient.d_append(key, value);
-            }
-        });
+    public String hmset(final String key, final Map<String, String> hash) {
+        writeAsync(key, () -> shadowClient.hmset(key, hash));
 
-        return DynoDualWriterClient.super.d_append(key, value);
-
-    }
-
-    @Override
-    public OperationResult<String> d_hmset(final String key, final Map<String, String> hash) {
-        writeAsync(key, new Callable<OperationResult<String>>() {
-            @Override
-            public OperationResult<String> call() throws Exception {
-                return shadowClient.d_hmset(key, hash);
-            }
-        });
-
-        return DynoDualWriterClient.super.d_hmset(key, hash);
+        return DynoDualWriterClient.super.hmset(key, hash);
     }
 
     @Override
     public Long sadd(final String key, final String... members) {
-        return this.d_sadd(key, members).getResult();
-    }
+        writeAsync(key, () -> shadowClient.sadd(key, members));
 
-    @Override
-    public OperationResult<Long> d_sadd(final String key, final String... members) {
-        writeAsync(key, new Callable<OperationResult<Long>>() {
-            @Override
-            public OperationResult<Long> call() throws Exception {
-                return shadowClient.d_sadd(key, members);
-            }
-        });
-
-        return DynoDualWriterClient.super.d_sadd(key, members);
+        return DynoDualWriterClient.super.sadd(key, members);
 
     }
 
     @Override
     public Long hset(final String key, final String field, final String value) {
-        return this.d_hset(key, field, value).getResult();
-    }
+        writeAsync(key, () -> shadowClient.hset(key, field, value));
 
-    @Override
-    public OperationResult<Long> d_hset(final String key, final String field, final String value) {
-        writeAsync(key, new Callable<OperationResult<Long>>() {
-            @Override
-            public OperationResult<Long> call() throws Exception {
-                return shadowClient.d_hset(key, field, value);
-            }
-        });
-
-        return DynoDualWriterClient.super.d_hset(key, field, value);
+        return DynoDualWriterClient.super.hset(key, field, value);
     }
 
     @Override
     public String set(final String key, final String value) {
-        return this.d_set(key, value).getResult();
-    }
+        writeAsync(key, () -> shadowClient.set(key, value));
 
-    @Override
-    public OperationResult<String> d_set(final String key, final String value) {
-        writeAsync(key, new Callable<OperationResult<String>>() {
-            @Override
-            public OperationResult<String> call() throws Exception {
-                return shadowClient.d_set(key, value);
-            }
-        });
-
-        return DynoDualWriterClient.super.d_set(key, value);
+        return DynoDualWriterClient.super.set(key, value);
     }
 
     @Override
     public String setex(final String key, int seconds, String value) {
-        return this.d_setex(key, seconds, value).getResult();
-    }
+        writeAsync(key, () -> shadowClient.setex(key, seconds, value));
 
-    @Override
-    public OperationResult<String> d_setex(final String key, final Integer seconds, final String value) {
-        writeAsync(key, new Callable<OperationResult<String>>() {
-            @Override
-            public OperationResult<String> call() throws Exception {
-                return shadowClient.d_setex(key, seconds, value);
-            }
-        });
-
-        return DynoDualWriterClient.super.d_setex(key, seconds, value);
-
+        return DynoDualWriterClient.super.setex(key, seconds, value);
     }
 
     @Override
     public Long del(final String key) {
-        writeAsync(key, new Callable<OperationResult<Long>>() {
-            @Override
-            public OperationResult<Long> call() throws Exception {
-                return shadowClient.d_del(key);
-            }
-        });
+        writeAsync(key, () -> shadowClient.del(key));
 
         return DynoDualWriterClient.super.del(key);
     }
 
     @Override
     public Long expire(final String key, final int seconds) {
-        writeAsync(key, new Callable<OperationResult<Long>>() {
-            @Override
-            public OperationResult<Long> call() throws Exception {
-                return shadowClient.d_expire(key, seconds);
-            }
-        });
+        writeAsync(key, () -> shadowClient.expire(key, seconds));
 
         return DynoDualWriterClient.super.expire(key, seconds);
     }
 
     @Override
     public Long expireAt(final String key, final long unixTime) {
-        writeAsync(key, new Callable<OperationResult<Long>>() {
-            @Override
-            public OperationResult<Long> call() throws Exception {
-                return shadowClient.d_expireAt(key, unixTime);
-            }
-        });
+        writeAsync(key, () -> shadowClient.expireAt(key, unixTime));
 
         return DynoDualWriterClient.super.expireAt(key, unixTime);
     }
 
     @Override
     public String getSet(final String key, final String value) {
-        writeAsync(key, new Callable<OperationResult<String>>() {
-            @Override
-            public OperationResult<String> call() throws Exception {
-                return shadowClient.d_getSet(key, value);
-            }
-        });
+        writeAsync(key, () -> shadowClient.getSet(key, value));
 
         return DynoDualWriterClient.super.getSet(key, value);
     }
 
     @Override
     public Long hdel(final String key, final String... fields) {
-        writeAsync(key, new Callable<OperationResult<Long>>() {
-            @Override
-            public OperationResult<Long> call() throws Exception {
-                return shadowClient.d_hdel(key, fields);
-            }
-        });
+        writeAsync(key, () -> shadowClient.hdel(key, fields));
 
         return DynoDualWriterClient.super.hdel(key);
     }
 
     @Override
     public Long hincrBy(final String key, final String field, final long value) {
-        writeAsync(key, new Callable<OperationResult<Long>>() {
-            @Override
-            public OperationResult<Long> call() throws Exception {
-                return shadowClient.d_hincrBy(key, field, value);
-            }
-        });
+        writeAsync(key, () -> shadowClient.hincrBy(key, field, value));
 
         return DynoDualWriterClient.super.hincrBy(key, field, value);
     }
 
     @Override
     public Double hincrByFloat(final String key, final String field, final double value) {
-        writeAsync(key, new Callable<OperationResult<Double>>() {
-            @Override
-            public OperationResult<Double> call() throws Exception {
-                return shadowClient.d_hincrByFloat(key, field, value);
-            }
-        });
+        writeAsync(key, () -> shadowClient.hincrByFloat(key, field, value));
 
         return DynoDualWriterClient.super.hincrByFloat(key, field, value);
     }
 
     @Override
     public Long hsetnx(final String key, final String field, final String value) {
-        writeAsync(key, new Callable<OperationResult<Long>>() {
-            @Override
-            public OperationResult<Long> call() throws Exception {
-                return shadowClient.d_hsetnx(key, field, value);
-            }
-        });
+        writeAsync(key, () -> shadowClient.hsetnx(key, field, value));
 
         return DynoDualWriterClient.super.hsetnx(key, field, value);
     }
 
     @Override
     public Long incr(final String key) {
-        writeAsync(key, new Callable<OperationResult<Long>>() {
-            @Override
-            public OperationResult<Long> call() throws Exception {
-                return shadowClient.d_incr(key);
-            }
-        });
+        writeAsync(key, () -> shadowClient.incr(key));
 
         return DynoDualWriterClient.super.incr(key);
     }
 
     @Override
     public Long incrBy(final String key, final long delta) {
-        writeAsync(key, new Callable<OperationResult<Long>>() {
-            @Override
-            public OperationResult<Long> call() throws Exception {
-                return shadowClient.d_incrBy(key, delta);
-            }
-        });
+        writeAsync(key, () -> shadowClient.incrBy(key, delta));
 
         return DynoDualWriterClient.super.incrBy(key, delta);
     }
 
     @Override
     public Double incrByFloat(final String key, final double increment) {
-        writeAsync(key, new Callable<OperationResult<Double>>() {
-            @Override
-            public OperationResult<Double> call() throws Exception {
-                return shadowClient.d_incrByFloat(key, increment);
-            }
-        });
+        writeAsync(key, () -> shadowClient.incrByFloat(key, increment));
 
         return DynoDualWriterClient.super.incrByFloat(key, increment);
     }
 
     @Override
     public String lpop(final String key) {
-        writeAsync(key, new Callable<OperationResult<String>>() {
-            @Override
-            public OperationResult<String> call() throws Exception {
-                return shadowClient.d_lpop(key);
-            }
-        });
+        writeAsync(key, () -> shadowClient.lpop(key));
 
         return DynoDualWriterClient.super.lpop(key);
     }
 
     @Override
     public Long lpush(final String key, final String... values) {
-        writeAsync(key, new Callable<OperationResult<Long>>() {
-            @Override
-            public OperationResult<Long> call() throws Exception {
-                return shadowClient.d_lpush(key, values);
-            }
-        });
+        writeAsync(key, () -> shadowClient.lpush(key, values));
 
         return DynoDualWriterClient.super.lpush(key, values);
     }
 
     @Override
     public Long lrem(final String key, final long count, final String value) {
-        writeAsync(key, new Callable<OperationResult<Long>>() {
-            @Override
-            public OperationResult<Long> call() throws Exception {
-                return shadowClient.d_lrem(key, count, value);
-            }
-        });
+        writeAsync(key, () -> shadowClient.lrem(key, count, value));
 
         return DynoDualWriterClient.super.lrem(key, count, value);
     }
 
     @Override
     public String lset(final String key, final long count, final String value) {
-        writeAsync(key, new Callable<OperationResult<String>>() {
-            @Override
-            public OperationResult<String> call() throws Exception {
-                return shadowClient.d_lset(key, count, value);
-            }
-        });
+        writeAsync(key, () -> shadowClient.lset(key, count, value));
 
         return DynoDualWriterClient.super.lset(key, count, value);
     }
 
     @Override
     public String ltrim(final String key, final long start, final long end) {
-        writeAsync(key, new Callable<OperationResult<String>>() {
-            @Override
-            public OperationResult<String> call() throws Exception {
-                return shadowClient.d_ltrim(key, start, end);
-            }
-        });
+        writeAsync(key, () -> shadowClient.ltrim(key, start, end));
 
         return DynoDualWriterClient.super.ltrim(key, start, end);
     }
 
     @Override
     public Long persist(final String key) {
-        writeAsync(key, new Callable<OperationResult<Long>>() {
-            @Override
-            public OperationResult<Long> call() throws Exception {
-                return shadowClient.d_persist(key);
-            }
-        });
+        writeAsync(key, () -> shadowClient.persist(key));
 
         return DynoDualWriterClient.super.persist(key);
     }
 
     @Override
     public Long pexpireAt(final String key, final long millisecondsTimestamp) {
-        writeAsync(key, new Callable<OperationResult<Long>>() {
-            @Override
-            public OperationResult<Long> call() throws Exception {
-                return shadowClient.d_pexpireAt(key, millisecondsTimestamp);
-            }
-        });
+        writeAsync(key, () -> shadowClient.pexpireAt(key, millisecondsTimestamp));
 
         return DynoDualWriterClient.super.pexpireAt(key, millisecondsTimestamp);
     }
 
     @Override
     public Long pttl(final String key) {
-        writeAsync(key, new Callable<OperationResult<Long>>() {
-            @Override
-            public OperationResult<Long> call() throws Exception {
-                return shadowClient.d_pttl(key);
-            }
-        });
+        writeAsync(key, () -> shadowClient.pttl(key));
 
         return DynoDualWriterClient.super.pttl(key);
     }
 
     @Override
     public String rename(final String oldkey, final String newkey) {
-        writeAsync(oldkey, new Callable<OperationResult<String>>() {
-            @Override
-            public OperationResult<String> call() throws Exception {
-                return shadowClient.d_rename(oldkey, oldkey);
-            }
-        });
+        writeAsync(oldkey, () -> shadowClient.rename(oldkey, oldkey));
 
         return DynoDualWriterClient.super.rename(oldkey, oldkey);
     }
 
     @Override
     public String rpop(final String key) {
-        writeAsync(key, new Callable<OperationResult<String>>() {
-            @Override
-            public OperationResult<String> call() throws Exception {
-                return shadowClient.d_rpop(key);
-            }
-        });
+        writeAsync(key, () -> shadowClient.rpop(key));
 
         return DynoDualWriterClient.super.rpop(key);
     }
 
     @Override
     public Long scard(final String key) {
-        writeAsync(key, new Callable<OperationResult<Long>>() {
-            @Override
-            public OperationResult<Long> call() throws Exception {
-                return shadowClient.d_scard(key);
-            }
-        });
+        writeAsync(key, () -> shadowClient.scard(key));
 
         return DynoDualWriterClient.super.scard(key);
     }
 
     @Override
     public Boolean setbit(final String key, final long offset, final boolean value) {
-        writeAsync(key, new Callable<OperationResult<Boolean>>() {
-            @Override
-            public OperationResult<Boolean> call() throws Exception {
-                return shadowClient.d_setbit(key, offset, value);
-            }
-        });
+        writeAsync(key, () -> shadowClient.setbit(key, offset, value));
 
         return DynoDualWriterClient.super.setbit(key, offset, value);
     }
 
     @Override
     public Boolean setbit(final String key, final long offset, final String value) {
-        writeAsync(key, new Callable<OperationResult<Boolean>>() {
-            @Override
-            public OperationResult<Boolean> call() throws Exception {
-                return shadowClient.d_setbit(key, offset, value);
-            }
-        });
+        writeAsync(key, () -> shadowClient.setbit(key, offset, value));
 
         return DynoDualWriterClient.super.setbit(key, offset, value);
     }
 
     @Override
     public Long setnx(final String key, final String value) {
-        writeAsync(key, new Callable<OperationResult<Long>>() {
-            @Override
-            public OperationResult<Long> call() throws Exception {
-                return shadowClient.d_setnx(key, value);
-            }
-        });
+        writeAsync(key, () -> shadowClient.setnx(key, value));
 
         return DynoDualWriterClient.super.setnx(key, value);
     }
 
     @Override
     public Long setrange(final String key, final long offset, final String value) {
-        writeAsync(key, new Callable<OperationResult<Long>>() {
-            @Override
-            public OperationResult<Long> call() throws Exception {
-                return shadowClient.d_setrange(key, offset, value);
-            }
-        });
+        writeAsync(key, () -> shadowClient.setrange(key, offset, value));
 
         return DynoDualWriterClient.super.setrange(key, offset, value);
     }
 
     @Override
     public Set<String> smembers(final String key) {
-        writeAsync(key, new Callable<OperationResult<Set<String>>>() {
-            @Override
-            public OperationResult<Set<String>> call() throws Exception {
-                return shadowClient.d_smembers(key);
-            }
-        });
+        writeAsync(key, () -> shadowClient.smembers(key));
 
         return DynoDualWriterClient.super.smembers(key);
     }
 
     @Override
     public Long smove(final String srckey, final String dstkey, final String member) {
-        writeAsync(srckey, new Callable<OperationResult<Long>>() {
-            @Override
-            public OperationResult<Long> call() throws Exception {
-                return shadowClient.d_smove(srckey, dstkey, member);
-            }
-        });
+        writeAsync(srckey, () -> shadowClient.smove(srckey, dstkey, member));
 
         return DynoDualWriterClient.super.smove(srckey, dstkey, member);
     }
 
     @Override
     public List<String> sort(final String key) {
-        writeAsync(key, new Callable<OperationResult<List<String>>>() {
-            @Override
-            public OperationResult<List<String>> call() throws Exception {
-                return shadowClient.d_sort(key);
-            }
-        });
+        writeAsync(key, () -> shadowClient.sort(key));
 
         return DynoDualWriterClient.super.sort(key);
     }
 
     @Override
     public String spop(final String key) {
-        writeAsync(key, new Callable<OperationResult<String>>() {
-            @Override
-            public OperationResult<String> call() throws Exception {
-                return shadowClient.d_spop(key);
-            }
-        });
+        writeAsync(key, () -> shadowClient.spop(key));
 
         return DynoDualWriterClient.super.spop(key);
     }
 
     @Override
     public Long srem(final String key, final String... members) {
-        writeAsync(key, new Callable<OperationResult<Long>>() {
-            @Override
-            public OperationResult<Long> call() throws Exception {
-                return shadowClient.d_srem(key, members);
-            }
-        });
+        writeAsync(key, () -> shadowClient.srem(key, members));
 
         return DynoDualWriterClient.super.srem(key, members);
     }
 
     @Override
     public ScanResult<String> sscan(final String key, final String cursor) {
-        writeAsync(key, new Callable<OperationResult<ScanResult<String>>>() {
-            @Override
-            public OperationResult<ScanResult<String>> call() throws Exception {
-                return shadowClient.d_sscan(key, cursor);
-            }
-        });
+        writeAsync(key, () -> shadowClient.sscan(key, cursor));
 
         return DynoDualWriterClient.super.sscan(key, cursor);
     }
 
     @Override
     public ScanResult<String> sscan(final String key, final String cursor, final ScanParams params) {
-        writeAsync(key, new Callable<OperationResult<ScanResult<String>>>() {
-            @Override
-            public OperationResult<ScanResult<String>> call() throws Exception {
-                return shadowClient.d_sscan(key, cursor, params);
-            }
-        });
+        writeAsync(key, () -> shadowClient.sscan(key, cursor, params));
 
         return DynoDualWriterClient.super.sscan(key, cursor, params);
     }
 
     @Override
     public Long ttl(final String key) {
-        writeAsync(key, new Callable<OperationResult<Long>>() {
-            @Override
-            public OperationResult<Long> call() throws Exception {
-                return shadowClient.d_ttl(key);
-            }
-        });
+        writeAsync(key, () -> shadowClient.ttl(key));
 
         return DynoDualWriterClient.super.ttl(key);
     }
 
     @Override
     public Long zadd(final String key, final double score, final String member) {
-        writeAsync(key, new Callable<OperationResult<Long>>() {
-            @Override
-            public OperationResult<Long> call() throws Exception {
-                return shadowClient.d_zadd(key, score, member);
-            }
-        });
+        writeAsync(key, () -> shadowClient.zadd(key, score, member));
 
         return DynoDualWriterClient.super.zadd(key, score, member);
     }
 
     @Override
     public Long zadd(final String key, final Map<String, Double> scoreMembers) {
-        writeAsync(key, new Callable<OperationResult<Long>>() {
-            @Override
-            public OperationResult<Long> call() throws Exception {
-                return shadowClient.d_zadd(key, scoreMembers);
-            }
-        });
+        writeAsync(key, () -> shadowClient.zadd(key, scoreMembers));
 
         return DynoDualWriterClient.super.zadd(key, scoreMembers);
     }
 
     @Override
     public Double zincrby(final String key, final double score, final String member) {
-        writeAsync(key, new Callable<OperationResult<Double>>() {
-            @Override
-            public OperationResult<Double> call() throws Exception {
-                return shadowClient.d_zincrby(key, score, member);
-            }
-        });
+        writeAsync(key, () -> shadowClient.zincrby(key, score, member));
 
         return DynoDualWriterClient.super.zincrby(key, score, member);
     }
 
     @Override
     public Long zrem(final String key, final String... member) {
-        writeAsync(key, new Callable<OperationResult<Long>>() {
-            @Override
-            public OperationResult<Long> call() throws Exception {
-                return shadowClient.d_zrem(key, member);
-            }
-        });
+        writeAsync(key, () -> shadowClient.zrem(key, member));
 
         return DynoDualWriterClient.super.zrem(key, member);
     }
 
     @Override
     public List<String> blpop(final int timeout, final String key) {
-        writeAsync(key, new Callable<OperationResult<List<String>>>() {
-            @Override
-            public OperationResult<List<String>> call() throws Exception {
-                return shadowClient.d_blpop(timeout, key);
-            }
-        });
+        writeAsync(key, () -> shadowClient.blpop(timeout, key));
 
         return DynoDualWriterClient.super.blpop(timeout, key);
     }
 
     @Override
     public List<String> brpop(final int timeout, final String key) {
-        writeAsync(key, new Callable<OperationResult<List<String>>>() {
-            @Override
-            public OperationResult<List<String>> call() throws Exception {
-                return shadowClient.d_brpop(timeout, key);
-            }
-        });
+        writeAsync(key, () -> shadowClient.brpop(timeout, key));
 
         return DynoDualWriterClient.super.brpop(timeout, key);
     }
+
 
     /******************* Jedis Dual write for binary commands **************/
 
 
     @Override
+    public Long append(final byte[] key, final byte[] value) {
+        writeAsync(key, () -> shadowClient.append(key, value));
+
+        return DynoDualWriterClient.super.append(key, value);
+    }
+
+    @Override
+    public String hmset(final byte[] key, final Map<byte[], byte[]> hash) {
+        writeAsync(key, () -> shadowClient.hmset(key, hash));
+
+        return DynoDualWriterClient.super.hmset(key, hash);
+    }
+
+    @Override
+    public Long sadd(final byte[] key, final byte[]... members) {
+        writeAsync(key, () -> shadowClient.sadd(key, members));
+
+        return DynoDualWriterClient.super.sadd(key, members);
+
+    }
+
+    @Override
+    public Long hset(final byte[] key, final byte[] field, final byte[] value) {
+        writeAsync(key, () -> shadowClient.hset(key, field, value));
+
+        return DynoDualWriterClient.super.hset(key, field, value);
+    }
+
+    @Override
     public String set(final byte[] key, final byte[] value) {
-        writeAsync(key, new Callable<OperationResult<String>>() {
-            @Override
-            public OperationResult<String> call() throws Exception {
-                return shadowClient.d_set(key, value);
-            }
-        });
+        writeAsync(key, () -> shadowClient.set(key, value));
 
         return DynoDualWriterClient.super.set(key, value);
     }
 
     @Override
-    public String setex(final byte[] key, final int seconds, final byte[] value) {
-        writeAsync(key, new Callable<OperationResult<String>>() {
-            @Override
-            public OperationResult<String> call() throws Exception {
-                return shadowClient.d_setex(key, seconds, value);
-            }
-        });
+    public String setex(final byte[] key, int seconds, byte[] value) {
+        writeAsync(key, () -> shadowClient.setex(key, seconds, value));
 
         return DynoDualWriterClient.super.setex(key, seconds, value);
+    }
+
+    @Override
+    public Long del(final byte[] key) {
+        writeAsync(key, () -> shadowClient.del(key));
+
+        return DynoDualWriterClient.super.del(key);
+    }
+
+    @Override
+    public Long expire(final byte[] key, final int seconds) {
+        writeAsync(key, () -> shadowClient.expire(key, seconds));
+
+        return DynoDualWriterClient.super.expire(key, seconds);
+    }
+
+    @Override
+    public Long expireAt(final byte[] key, final long unixTime) {
+        writeAsync(key, () -> shadowClient.expireAt(key, unixTime));
+
+        return DynoDualWriterClient.super.expireAt(key, unixTime);
+    }
+
+    @Override
+    public byte[] getSet(final byte[] key, final byte[] value) {
+        writeAsync(key, () -> shadowClient.getSet(key, value));
+
+        return DynoDualWriterClient.super.getSet(key, value);
+    }
+
+    @Override
+    public Long hdel(final byte[] key, final byte[]... fields) {
+        writeAsync(key, () -> shadowClient.hdel(key, fields));
+
+        return DynoDualWriterClient.super.hdel(key);
+    }
+
+    @Override
+    public Long hincrBy(final byte[] key, final byte[] field, final long value) {
+        writeAsync(key, () -> shadowClient.hincrBy(key, field, value));
+
+        return DynoDualWriterClient.super.hincrBy(key, field, value);
+    }
+
+    @Override
+    public Double hincrByFloat(final byte[] key, final byte[] field, final double value) {
+        writeAsync(key, () -> shadowClient.hincrByFloat(key, field, value));
+
+        return DynoDualWriterClient.super.hincrByFloat(key, field, value);
+    }
+
+    @Override
+    public Long hsetnx(final byte[] key, final byte[] field, final byte[] value) {
+        writeAsync(key, () -> shadowClient.hsetnx(key, field, value));
+
+        return DynoDualWriterClient.super.hsetnx(key, field, value);
+    }
+
+    @Override
+    public Long incr(final byte[] key) {
+        writeAsync(key, () -> shadowClient.incr(key));
+
+        return DynoDualWriterClient.super.incr(key);
+    }
+
+    @Override
+    public Long incrBy(final byte[] key, final long delta) {
+        writeAsync(key, () -> shadowClient.incrBy(key, delta));
+
+        return DynoDualWriterClient.super.incrBy(key, delta);
+    }
+
+    @Override
+    public Double incrByFloat(final byte[] key, final double increment) {
+        writeAsync(key, () -> shadowClient.incrByFloat(key, increment));
+
+        return DynoDualWriterClient.super.incrByFloat(key, increment);
+    }
+
+    @Override
+    public byte[] lpop(final byte[] key) {
+        writeAsync(key, () -> shadowClient.lpop(key));
+
+        return DynoDualWriterClient.super.lpop(key);
+    }
+
+    @Override
+    public Long lpush(final byte[] key, final byte[]... values) {
+        writeAsync(key, () -> shadowClient.lpush(key, values));
+
+        return DynoDualWriterClient.super.lpush(key, values);
+    }
+
+    @Override
+    public Long lrem(final byte[] key, final long count, final byte[] value) {
+        writeAsync(key, () -> shadowClient.lrem(key, count, value));
+
+        return DynoDualWriterClient.super.lrem(key, count, value);
+    }
+
+    @Override
+    public String lset(final byte[] key, final long count, final byte[] value) {
+        writeAsync(key, () -> shadowClient.lset(key, count, value));
+
+        return DynoDualWriterClient.super.lset(key, count, value);
+    }
+
+    @Override
+    public String ltrim(final byte[] key, final long start, final long end) {
+        writeAsync(key, () -> shadowClient.ltrim(key, start, end));
+
+        return DynoDualWriterClient.super.ltrim(key, start, end);
+    }
+
+    @Override
+    public Long persist(final byte[] key) {
+        writeAsync(key, () -> shadowClient.persist(key));
+
+        return DynoDualWriterClient.super.persist(key);
+    }
+
+    @Override
+    public Long pexpireAt(final byte[] key, final long millisecondsTimestamp) {
+        writeAsync(key, () -> shadowClient.pexpireAt(key, millisecondsTimestamp));
+
+        return DynoDualWriterClient.super.pexpireAt(key, millisecondsTimestamp);
+    }
+
+    @Override
+    public Long pttl(final byte[] key) {
+        writeAsync(key, () -> shadowClient.pttl(key));
+
+        return DynoDualWriterClient.super.pttl(key);
+    }
+
+    @Override
+    public String rename(final byte[] oldkey, final byte[] newkey) {
+        writeAsync(oldkey, () -> shadowClient.rename(oldkey, oldkey));
+
+        return DynoDualWriterClient.super.rename(oldkey, oldkey);
+    }
+
+    @Override
+    public byte[] rpop(final byte[] key) {
+        writeAsync(key, () -> shadowClient.rpop(key));
+
+        return DynoDualWriterClient.super.rpop(key);
+    }
+
+    @Override
+    public Long scard(final byte[] key) {
+        writeAsync(key, () -> shadowClient.scard(key));
+
+        return DynoDualWriterClient.super.scard(key);
+    }
+
+    @Override
+    public Boolean setbit(final byte[] key, final long offset, final boolean value) {
+        writeAsync(key, () -> shadowClient.setbit(key, offset, value));
+
+        return DynoDualWriterClient.super.setbit(key, offset, value);
+    }
+
+    @Override
+    public Boolean setbit(final byte[] key, final long offset, final byte[] value) {
+        writeAsync(key, () -> shadowClient.setbit(key, offset, value));
+
+        return DynoDualWriterClient.super.setbit(key, offset, value);
+    }
+
+    @Override
+    public Long setnx(final byte[] key, final byte[] value) {
+        writeAsync(key, () -> shadowClient.setnx(key, value));
+
+        return DynoDualWriterClient.super.setnx(key, value);
+    }
+
+    @Override
+    public Long setrange(final byte[] key, final long offset, final byte[] value) {
+        writeAsync(key, () -> shadowClient.setrange(key, offset, value));
+
+        return DynoDualWriterClient.super.setrange(key, offset, value);
+    }
+
+    @Override
+    public Set<byte[]> smembers(final byte[] key) {
+        writeAsync(key, () -> shadowClient.smembers(key));
+
+        return DynoDualWriterClient.super.smembers(key);
+    }
+
+    @Override
+    public Long smove(final byte[] srckey, final byte[] dstkey, final byte[] member) {
+        writeAsync(srckey, () -> shadowClient.smove(srckey, dstkey, member));
+
+        return DynoDualWriterClient.super.smove(srckey, dstkey, member);
+    }
+
+    @Override
+    public List<byte[]> sort(final byte[] key) {
+        writeAsync(key, () -> shadowClient.sort(key));
+
+        return DynoDualWriterClient.super.sort(key);
+    }
+
+    @Override
+    public byte[] spop(final byte[] key) {
+        writeAsync(key, () -> shadowClient.spop(key));
+
+        return DynoDualWriterClient.super.spop(key);
+    }
+
+    @Override
+    public Long srem(final byte[] key, final byte[]... members) {
+        writeAsync(key, () -> shadowClient.srem(key, members));
+
+        return DynoDualWriterClient.super.srem(key, members);
+    }
+
+    @Override
+    public ScanResult<byte[]> sscan(final byte[] key, final byte[] cursor) {
+        writeAsync(key, () -> shadowClient.sscan(key, cursor));
+
+        return DynoDualWriterClient.super.sscan(key, cursor);
+    }
+
+    @Override
+    public ScanResult<byte[]> sscan(final byte[] key, final byte[] cursor, final ScanParams params) {
+        writeAsync(key, () -> shadowClient.sscan(key, cursor, params));
+
+        return DynoDualWriterClient.super.sscan(key, cursor, params);
+    }
+
+    @Override
+    public Long ttl(final byte[] key) {
+        writeAsync(key, () -> shadowClient.ttl(key));
+
+        return DynoDualWriterClient.super.ttl(key);
+    }
+
+    @Override
+    public Long zadd(final byte[] key, final double score, final byte[] member) {
+        writeAsync(key, () -> shadowClient.zadd(key, score, member));
+
+        return DynoDualWriterClient.super.zadd(key, score, member);
+    }
+
+    @Override
+    public Long zadd(final byte[] key, final Map<byte[], Double> scoreMembers) {
+        writeAsync(key, () -> shadowClient.zadd(key, scoreMembers));
+
+        return DynoDualWriterClient.super.zadd(key, scoreMembers);
+    }
+
+    @Override
+    public Double zincrby(final byte[] key, final double score, final byte[] member) {
+        writeAsync(key, () -> shadowClient.zincrby(key, score, member));
+
+        return DynoDualWriterClient.super.zincrby(key, score, member);
+    }
+
+    @Override
+    public Long zrem(final byte[] key, final byte[]... member) {
+        writeAsync(key, () -> shadowClient.zrem(key, member));
+
+        return DynoDualWriterClient.super.zrem(key, member);
     }
 
 }

--- a/dyno-jedis/src/main/java/com/netflix/dyno/jedis/DynoDualWriterPipeline.java
+++ b/dyno-jedis/src/main/java/com/netflix/dyno/jedis/DynoDualWriterPipeline.java
@@ -38,6 +38,11 @@ import java.util.concurrent.Future;
  * dynomite clusters.
  */
 public class DynoDualWriterPipeline extends DynoJedisPipeline {
+
+
+    // FIXME: not all write commands are shadowed
+
+
     private static final org.slf4j.Logger logger = LoggerFactory.getLogger(DynoDualWriterPipeline.class);
     private static ExecutorService executor = Executors.newSingleThreadExecutor();
     private final ConnectionPoolImpl<Jedis> connPool;

--- a/dyno-jedis/src/main/java/com/netflix/dyno/jedis/JedisConnectionFactory.java
+++ b/dyno-jedis/src/main/java/com/netflix/dyno/jedis/JedisConnectionFactory.java
@@ -181,6 +181,11 @@ public class JedisConnectionFactory implements ConnectionFactory<Jedis> {
         }
 
         @Override
+        public void reset() {
+            jedisClient.resetState();
+        }
+
+        @Override
         public DynoConnectException getLastException() {
             return lastDynoException;
         }

--- a/dyno-jedis/src/test/java/com/netflix/dyno/jedis/CompressionTest.java
+++ b/dyno-jedis/src/test/java/com/netflix/dyno/jedis/CompressionTest.java
@@ -137,7 +137,7 @@ public class CompressionTest {
         map.put(KEY_1KB, VALUE_1KB);
         map.put(KEY_3KB, VALUE_3KB);
 
-        client.d_hmset("compressionTestKey", map);
+        client.hmset("compressionTestKey", map);
 
         LastOperationMonitor monitor = (LastOperationMonitor) opMonitor;
         Assert.assertTrue(1 == monitor.getSuccessCount(OpName.HMSET.name(), true));

--- a/dyno-redisson/src/main/java/com/netflix/dyno/redisson/RedissonConnectionFactory.java
+++ b/dyno-redisson/src/main/java/com/netflix/dyno/redisson/RedissonConnectionFactory.java
@@ -125,6 +125,10 @@ public class RedissonConnectionFactory implements ConnectionFactory<RedisAsyncCo
         }
 
         @Override
+        public void reset() {
+        }
+
+        @Override
         public DynoConnectException getLastException() {
             return lastEx.get();
         }


### PR DESCRIPTION
This PR brings the Jedis binary API to parity with the string API. Also, I refactored the client implementations so it requires less boilerplate code to add unimplemented methods going forward. Some other changes in this PR include a fix to the demo and support for hashtags with binary keys. Also, I made a change to reset the Jedis instance before returning it to the pool. This fixes an issue we encountered during testing, and is consistent with how the JedisPool operates.

While implementing this I noticed that the dual write client does not shadow all write commands, and compression is not consistently implemented. I will open a ticket for those existing issues if one doesn't exist.