### PR TITLE
Allow setting of dual-write FPs if any user config is provided

### DIFF
--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolConfigurationImpl.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolConfigurationImpl.java
@@ -404,6 +404,15 @@ public class ConnectionPoolConfigurationImpl implements ConnectionPoolConfigurat
         return this;
     }
 
+    public ConnectionPoolConfigurationImpl setDualWrite(boolean isDualWriteEnabled, String dualWriteClusterName,
+                                                        Integer dualWritePercentage) {
+        this.dualWriteClusterName = dualWriteClusterName;
+        this.dualWritePercentage = dualWritePercentage;
+        this.isDualWriteEnabled = isDualWriteEnabled;
+
+        return this;
+    }
+
     @Override
     public String getConnectionPoolConsistency() {
         return this.connectionPoolConsistency;

--- a/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolConfigurationImpl.java
+++ b/dyno-core/src/main/java/com/netflix/dyno/connectionpool/impl/ConnectionPoolConfigurationImpl.java
@@ -404,12 +404,18 @@ public class ConnectionPoolConfigurationImpl implements ConnectionPoolConfigurat
         return this;
     }
 
-    public ConnectionPoolConfigurationImpl setDualWrite(boolean isDualWriteEnabled, String dualWriteClusterName,
-                                                        Integer dualWritePercentage) {
-        this.dualWriteClusterName = dualWriteClusterName;
-        this.dualWritePercentage = dualWritePercentage;
+    public ConnectionPoolConfigurationImpl setDualWriteEnabled(boolean isDualWriteEnabled) {
         this.isDualWriteEnabled = isDualWriteEnabled;
+        return this;
+    }
 
+    public ConnectionPoolConfigurationImpl setDualWriteClusterName(String dualWriteClusterName) {
+        this.dualWriteClusterName = dualWriteClusterName;
+        return this;
+    }
+
+    public ConnectionPoolConfigurationImpl setDualWritePercentage(int dualWritePercentage) {
+        this.dualWritePercentage = dualWritePercentage;
         return this;
     }
 

--- a/dyno-jedis/src/main/java/com/netflix/dyno/jedis/DynoJedisClient.java
+++ b/dyno-jedis/src/main/java/com/netflix/dyno/jedis/DynoJedisClient.java
@@ -4791,8 +4791,13 @@ public class DynoJedisClient implements JedisCommands, BinaryJedisCommands, Mult
                 // TODO: Move to a clean generic userconfig + FP model.
                 if (!cpConfig.isDualWriteEnabled() && archaiusConfig.isDualWriteEnabled()) {
                     // If a user sets these configs explicitly, they take precedence over the FP values.
-                    cpConfig.setDualWrite(true, archaiusConfig.getDualWriteClusterName(),
-                            archaiusConfig.getDualWritePercentage());
+                    if (cpConfig.getDualWriteClusterName() == null) {
+                        cpConfig.setDualWriteClusterName(archaiusConfig.getDualWriteClusterName());
+                    }
+                    if (cpConfig.getDualWritePercentage() == 0) {
+                        cpConfig.setDualWritePercentage(archaiusConfig.getDualWritePercentage());
+                    }
+                    cpConfig.setDualWriteEnabled(true);
                 }
             }
             cpConfig.setConnectToDatastore(isDatastoreClient);


### PR DESCRIPTION
Currently, the DynoJedisClient does not look at any fast property
if any user configuration (ConnectionPoolConfigurationImpl) is
provided.

This patch allows us to pull in dual-write FP values if any cpConfig
is provided. However, if the same properties are set explicitly
by the user, they take precedence over the FP values.

The specific dual-write properties we look for:
dualwrite.enabled, dualwrite.percentage, dualwrite.cluster