### PR TITLE
refactor: Change GitHub Action version to address deprecation of v1/v2

### DIFF
--- a/.github/workflows/nebula-ci.yml
+++ b/.github/workflows/nebula-ci.yml
@@ -21,14 +21,14 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java }}
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         id: gradle-cache
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/gradle/dependency-locks/*.lockfile') }}
           restore-keys: |
             - ${{ runner.os }}-gradle-
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         id: gradle-wrapper-cache
         with:
           path: ~/.gradle/wrapper

--- a/.github/workflows/nebula-ci.yml
+++ b/.github/workflows/nebula-ci.yml
@@ -16,7 +16,10 @@ jobs:
         java: [ 8 ]
     name: CI with Java ${{ matrix.java }}
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
+      - run: |
+          git config --global user.name "Netflix OSS Maintainers"
+          git config --global user.email "netflixoss@netflix.com"
       - name: Setup jdk
         uses: actions/setup-java@v1
         with:

--- a/.github/workflows/nebula-publish.yml
+++ b/.github/workflows/nebula-publish.yml
@@ -17,14 +17,14 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         id: gradle-cache
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/gradle/dependency-locks/*.lockfile') }}
           restore-keys: |
             - ${{ runner.os }}-gradle-
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         id: gradle-wrapper-cache
         with:
           path: ~/.gradle/wrapper

--- a/.github/workflows/nebula-publish.yml
+++ b/.github/workflows/nebula-publish.yml
@@ -12,7 +12,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
+      - run: |
+          git config --global user.name "Netflix OSS Maintainers"
+          git config --global user.email "netflixoss@netflix.com"
       - name: Setup jdk 8
         uses: actions/setup-java@v1
         with:

--- a/.github/workflows/nebula-snapshot.yml
+++ b/.github/workflows/nebula-snapshot.yml
@@ -16,13 +16,13 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 8
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         id: gradle-cache
         with:
           path: |
             ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         id: gradle-wrapper-cache
         with:
           path: |

--- a/.github/workflows/nebula-snapshot.yml
+++ b/.github/workflows/nebula-snapshot.yml
@@ -9,9 +9,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - run: |
+          git config --global user.name "Netflix OSS Maintainers"
+          git config --global user.email "netflixoss@netflix.com"
       - name: Set up JDK
         uses: actions/setup-java@v1
         with:

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-    id 'nebula.netflixoss' version '9.1.0'
-    id "com.github.blindpirate.osgi" version "0.0.4"
+    id 'com.netflix.nebula.netflixoss' version '11.5.0'
+    id "com.github.blindpirate.osgi" version "0.0.7"
 }
 
 // Establish version and status
@@ -10,12 +10,16 @@ apply plugin: 'project-report'
 apply plugin: 'maven-publish'
 
 subprojects {
-    apply plugin: 'nebula.netflixoss'
-    apply plugin: 'java'
+    apply plugin: 'com.netflix.nebula.netflixoss'
+    apply plugin: 'java-library'
     apply plugin: 'idea'
     apply plugin: 'eclipse'
     apply plugin: 'jacoco'
-    sourceCompatibility = 1.8
+    java {
+        toolchain {
+            languageVersion = JavaLanguageVersion.of(8)
+        }
+    }
 
     repositories {
         mavenCentral()
@@ -36,15 +40,15 @@ subprojects {
     group = "com.netflix.${githubProjectName}"
 
     dependencies {
-        compile 'joda-time:joda-time:2.3'
-        compile 'org.slf4j:slf4j-api:1.7.6'
-        compile 'org.slf4j:slf4j-log4j12:1.7.21'
-        compile 'com.googlecode.json-simple:json-simple:1.1'
-        compile 'org.apache.httpcomponents:httpclient:4.2.1'
-        compile 'com.sun.jersey:jersey-core:1.11'
-        testCompile 'junit:junit:4.11'
-        testCompile 'org.mockito:mockito-all:1.9.5'
-        testCompile 'io.netty:netty-all:4.1.14.Final'
+        api 'joda-time:joda-time:2.3'
+        api 'org.slf4j:slf4j-api:1.7.6'
+        api 'org.slf4j:slf4j-log4j12:1.7.21'
+        api 'com.googlecode.json-simple:json-simple:1.1'
+        api 'org.apache.httpcomponents:httpclient:4.2.1'
+        api 'com.sun.jersey:jersey-core:1.11'
+        testImplementation 'junit:junit:4.11'
+        testImplementation 'org.mockito:mockito-all:1.9.5'
+        testImplementation 'io.netty:netty-all:4.1.14.Final'
     }
 
     project.tasks.withType(Javadoc) {
@@ -55,9 +59,9 @@ subprojects {
 
     jacocoTestReport {
         reports {
-            xml.enabled false
-            csv.enabled false
-            html.enabled true
+            xml.required = false
+            csv.required = false
+            html.required = true
         }
     }
 
@@ -69,9 +73,9 @@ project(':dyno-core') {
     apply plugin: 'project-report'
 
     dependencies {
-        compile 'org.apache.commons:commons-math:2.2'
-        compile 'org.apache.commons:commons-lang3:3.6'
-        compile 'commons-io:commons-io:2.4'
+        api 'org.apache.commons:commons-math:2.2'
+        api 'org.apache.commons:commons-lang3:3.6'
+        api 'commons-io:commons-io:2.4'
     }
 }
 
@@ -80,19 +84,19 @@ project(':dyno-contrib') {
     apply plugin: 'project-report'
 
     dependencies {
-        compile project(':dyno-core')
-        compile 'com.google.inject:guice:4.1.0'
-        compile 'com.netflix.archaius:archaius-core:0.7.6'
-        compile 'com.google.code.findbugs:jsr305:3.0.1'
-        compile 'com.netflix.servo:servo-core:0.12.17'
-        compile 'com.netflix.eureka:eureka-client:1.8.6'
-        compile 'commons-lang:commons-lang:2.6'
-        compile 'org.apache.commons:commons-lang3:3.5'
-        compile 'org.codehaus.jettison:jettison:1.3.7'
-        compile('com.ecwid.consul:consul-api:1.2.1') {
+        api project(':dyno-core')
+        api 'com.google.inject:guice:4.1.0'
+        api 'com.netflix.archaius:archaius-core:0.7.6'
+        api 'com.google.code.findbugs:jsr305:3.0.1'
+        api 'com.netflix.servo:servo-core:0.12.17'
+        api 'com.netflix.eureka:eureka-client:1.8.6'
+        api 'commons-lang:commons-lang:2.6'
+        api 'org.apache.commons:commons-lang3:3.5'
+        api 'org.codehaus.jettison:jettison:1.3.7'
+        api('com.ecwid.consul:consul-api:1.2.1') {
             exclude group: 'org.apache.httpcomponents'
         }
-        testCompile 'com.pszymczyk.consul:embedded-consul:0.3.3'
+        testImplementation 'com.pszymczyk.consul:embedded-consul:2.2.1'
     }
 }
 
@@ -101,8 +105,8 @@ project(':dyno-memcache') {
     apply plugin: 'project-report'
 
     dependencies {
-        compile project(':dyno-core')
-        compile project(':dyno-contrib')
+        api project(':dyno-core')
+        api project(':dyno-contrib')
     }
 }
 
@@ -112,11 +116,11 @@ project(':dyno-jedis') {
 
     dependencies {
         annotationProcessor 'org.projectlombok:lombok:1.18.4'
-        compile project(':dyno-core')
-        compile project(':dyno-contrib')
-        compile 'redis.clients:jedis:3.0.1'
+        api project(':dyno-core')
+        api project(':dyno-contrib')
+        api 'redis.clients:jedis:3.0.1'
         compileOnly 'org.projectlombok:lombok:1.18.4'
-        testCompile 'com.netflix.spinnaker.embedded-redis:embedded-redis:0.8.0'
+        testImplementation 'com.netflix.spinnaker.embedded-redis:embedded-redis:0.8.0'
     }
 }
 
@@ -125,7 +129,7 @@ project(':dyno-client') {
     apply plugin: 'project-report'
 
     dependencies {
-        compile project(':dyno-jedis')
+        api project(':dyno-jedis')
     }
 }
 
@@ -135,9 +139,9 @@ project(':dyno-redisson') {
     apply plugin: 'project-report'
 
     dependencies {
-        compile project(':dyno-core')
-        compile project(':dyno-contrib')
-        compile 'org.redisson:redisson:1.1.0'
+        api project(':dyno-core')
+        api project(':dyno-contrib')
+        api 'org.redisson:redisson:1.1.0'
     }
 }
 
@@ -146,12 +150,12 @@ project(':dyno-demo') {
     apply plugin: 'project-report'
 
     dependencies {
-        compile project(':dyno-core')
-        compile project(':dyno-contrib')
-        compile project(':dyno-memcache')
-        compile project(':dyno-jedis')
-        compile project(':dyno-recipes')
-        compile 'commons-cli:commons-cli:1.4'
+        api project(':dyno-core')
+        api project(':dyno-contrib')
+        api project(':dyno-memcache')
+        api project(':dyno-jedis')
+        api project(':dyno-recipes')
+        api 'commons-cli:commons-cli:1.4'
     }
 }
 
@@ -161,11 +165,11 @@ project(':dyno-recipes') {
 
     dependencies {
         annotationProcessor 'org.projectlombok:lombok:1.18.4'
-        compile project(':dyno-core')
-        compile project(':dyno-jedis')
-        compile 'com.google.code.gson:gson:2.8.5'
+        api project(':dyno-core')
+        api project(':dyno-jedis')
+        api 'com.google.code.gson:gson:2.8.5'
         compileOnly 'org.projectlombok:lombok:1.18.4'
-        testCompile 'com.netflix.spinnaker.embedded-redis:embedded-redis:0.8.0'
+        testImplementation 'com.netflix.spinnaker.embedded-redis:embedded-redis:0.8.0'
     }
 
     test {

--- a/dyno-contrib/src/test/java/com/netflix/dyno/contrib/ConsulHostsSupplierTest.java
+++ b/dyno-contrib/src/test/java/com/netflix/dyno/contrib/ConsulHostsSupplierTest.java
@@ -53,7 +53,9 @@ public class ConsulHostsSupplierTest {
 
     @After
     public void afterEach() throws Exception {
-        consulServer.close();
+        if(consulServer != null) {
+            consulServer.close();
+        }
     }
 
     @Test

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11-all.zip


### PR DESCRIPTION
Starting February 1st, 2025, Github is closing down v1-v2 of actions/cache (read more about it in this [changelog announcement](https://app.github.media/e/er?s=88570519&lid=6815&elqTrackId=08a5e2ee0de44b669cfee44c72a218f2&elq=553eec1a7c454e1f86dace7dd5ce9583&elqaid=4282&elqat=1&elqak=8AF5E7AAA12E3C7C230E5849DC6FF5707A505F45E589E4FD0E873A034D6DD7B23D08)) as well as all previous versions of the @actions/cache package in actions/toolkit. Attempting to use a version of the @actions/cache package or actions/cache after the announced deprecation date will result in a workflow failure. If you are pinned to a specific version or SHA of the cache action, your workflows will also fail after February 1st.

Use this link to re-run the recipe: https://app.moderne.io/recipes/org.openrewrite.github.ChangeActionVersion?organizationId=TmV0ZmxpeA%3D%3D#defaults=W3sidmFsdWUiOiJhY3Rpb25zL2NhY2hlIiwibmFtZSI6ImFjdGlvbiJ9LHsidmFsdWUiOiJ2NCIsIm5hbWUiOiJ2ZXJzaW9uIn1d